### PR TITLE
Feat: 메인페이지 배너 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,21 @@
     "@supabase/supabase-js": "^2.46.1",
     "next": "15.0.2",
     "react": "19.0.0-rc-02c0e824-20241028",
-    "react-dom": "19.0.0-rc-02c0e824-20241028"
+    "react-dom": "19.0.0-rc-02c0e824-20241028",
+    "react-icons": "^5.3.0"
   },
   "devDependencies": {
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@types/react-slick": "^0.23.13",
     "eslint": "^8",
     "eslint-config-next": "15.0.2",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.3.3",
+    "react-slick": "^0.30.2",
     "sass": "^1.80.6",
+    "slick-carousel": "^1.8.1",
     "supabase": "^1.215.0",
     "typescript": "^5"
   }

--- a/src/app/_component/Banner.tsx
+++ b/src/app/_component/Banner.tsx
@@ -23,9 +23,5 @@ export default async function Banner() {
     }
   ];
 
-  return (
-    <div>
-      <ImageSlider homeBanners={data} />
-    </div>
-  );
+  return <ImageSlider homeBanners={data} />;
 }

--- a/src/app/_component/Banner.tsx
+++ b/src/app/_component/Banner.tsx
@@ -1,0 +1,31 @@
+import ImageSlider from './ImageSlider';
+
+export default async function Banner() {
+  // TODO: supabase API 연결
+  const data = [
+    {
+      id: 1,
+      title: '서로서로 세워가는 교회',
+      description: '1. 예배로\n2. 믿음과 행함으로\n3. 전도로',
+      order: 1,
+      image_url:
+        'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/sign/home_banner/church-4911852_1920.jpg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJob21lX2Jhbm5lci9jaHVyY2gtNDkxMTg1Ml8xOTIwLmpwZyIsImlhdCI6MTczMDgyMzA0NiwiZXhwIjoxNzYyMzU5MDQ2fQ.m7XETfrk2JgqxLeM5uJ-UzISeMX3iNLDWOGng_4Ga-g&t=2024-11-05T16%3A10%3A46.164Z',
+      year: 2024
+    },
+    {
+      id: 2,
+      title: '차별금지법 반대 연합예배',
+      description: null,
+      order: 2,
+      image_url:
+        'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/sign/home_banner/anti.jpg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJob21lX2Jhbm5lci9hbnRpLmpwZyIsImlhdCI6MTczMDk5NjAzMSwiZXhwIjoxNzYyNTMyMDMxfQ.ytJtbJQETOAtt3VCgHjCbytGFAbGPksYRAb-nKSN2O8&t=2024-11-07T16%3A13%3A51.617Z',
+      year: 2024
+    }
+  ];
+
+  return (
+    <div>
+      <ImageSlider homeBanners={data} />
+    </div>
+  );
+}

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -4,6 +4,7 @@
   width: 100%;
   border-bottom: 0.1rem solid var(--dividing-line-color);
   background: var(--background);
+  z-index: 9999;
 }
 
 .header_wrap {

--- a/src/app/_component/ImageSlider.module.scss
+++ b/src/app/_component/ImageSlider.module.scss
@@ -1,0 +1,28 @@
+.image_slider {
+  :global(.slick-next::before) {
+    display: none;
+    opacity: 0;
+  }
+  :global(.slick-prev::before) {
+    display: none;
+    opacity: 0;
+  }
+
+  .slider_arrow {
+    z-index: 9000;
+  }
+}
+
+.banner {
+  position: relative;
+  width: 100%;
+  height: 30rem;
+  overflow: hidden;
+  cursor: pointer;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: fill;
+  }
+}

--- a/src/app/_component/ImageSlider.module.scss
+++ b/src/app/_component/ImageSlider.module.scss
@@ -10,6 +10,7 @@
 
   .slider_arrow {
     z-index: 9000;
+    transition: all 1s;
   }
 }
 
@@ -19,10 +20,12 @@
   height: 30rem;
   overflow: hidden;
   cursor: pointer;
+  outline: none;
 
   img {
     width: 100%;
     height: 100%;
-    object-fit: fill;
+    object-fit: cover;
+    object-position: center;
   }
 }

--- a/src/app/_component/ImageSlider.tsx
+++ b/src/app/_component/ImageSlider.tsx
@@ -2,7 +2,13 @@
 import Slider, { Settings } from 'react-slick';
 import styles from './ImageSlider.module.scss';
 import { Tables } from '@/shared/types/database.types';
-import { PiArrowCircleLeftThin, PiArrowCircleRightThin } from 'react-icons/pi';
+import {
+  PiArrowCircleLeftThin,
+  PiArrowCircleRightThin,
+  PiArrowCircleRightFill,
+  PiArrowCircleLeftFill
+} from 'react-icons/pi';
+import { useState } from 'react';
 
 type ImageSliderProp = {
   homeBanners: Tables<'home_banner'>[];
@@ -29,14 +35,11 @@ const ImageSlider = ({ homeBanners }: ImageSliderProp) => {
   };
 
   const multiConfig: Settings = {
-    dots: false,
     infinite: true,
-    arrows: true,
-    draggable: true,
     slidesToShow: 1,
     slidesToScroll: 1,
     autoplay: true,
-    speed: 500,
+    speed: 600,
     autoplaySpeed: 6000,
     fade: true,
     cssEase: 'ease-in-out',
@@ -69,6 +72,7 @@ const ImageSlider = ({ homeBanners }: ImageSliderProp) => {
 };
 
 const PrevArrow = (props: ArrowProps) => {
+  const [isHovered, setIsHovered] = useState(false);
   const { className, style, onClick, options } = props;
 
   return (
@@ -76,13 +80,17 @@ const PrevArrow = (props: ArrowProps) => {
       className={`${className} ${styles.slider_arrow}`}
       style={{ ...style, ...options, left: '3rem' }}
       onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
-      <PiArrowCircleLeftThin />
+      {isHovered && <PiArrowCircleLeftFill />}
+      {!isHovered && <PiArrowCircleLeftThin />}
     </div>
   );
 };
 
 const NextArrow = (props: ArrowProps) => {
+  const [isHovered, setIsHovered] = useState(false);
   const { className, style, onClick, options } = props;
 
   return (
@@ -90,8 +98,11 @@ const NextArrow = (props: ArrowProps) => {
       className={`${className} ${styles.slider_arrow}`}
       style={{ ...style, ...options, right: '3rem' }}
       onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
-      <PiArrowCircleRightThin />
+      {isHovered && <PiArrowCircleRightFill />}
+      {!isHovered && <PiArrowCircleRightThin />}
     </div>
   );
 };

--- a/src/app/_component/ImageSlider.tsx
+++ b/src/app/_component/ImageSlider.tsx
@@ -1,0 +1,99 @@
+'use client';
+import Slider, { Settings } from 'react-slick';
+import styles from './ImageSlider.module.scss';
+import { Tables } from '@/shared/types/database.types';
+import { PiArrowCircleLeftThin, PiArrowCircleRightThin } from 'react-icons/pi';
+
+type ImageSliderProp = {
+  homeBanners: Tables<'home_banner'>[];
+};
+
+type Options = {
+  [key: string]: string | undefined;
+};
+
+type ArrowProps = {
+  className?: string;
+  style?: React.CSSProperties;
+  onClick?: () => void;
+  options: Options;
+};
+
+const ImageSlider = ({ homeBanners }: ImageSliderProp) => {
+  // TODO: props로 전달
+  const options: Options = {
+    width: '3rem',
+    height: '3rem',
+    color: 'white',
+    fontSize: '3rem'
+  };
+
+  const multiConfig: Settings = {
+    dots: false,
+    infinite: true,
+    arrows: true,
+    draggable: true,
+    slidesToShow: 1,
+    slidesToScroll: 1,
+    autoplay: true,
+    speed: 500,
+    autoplaySpeed: 6000,
+    fade: true,
+    cssEase: 'ease-in-out',
+    nextArrow: <NextArrow options={options} />,
+    prevArrow: <PrevArrow options={options} />
+  };
+
+  const singleConfig = {
+    ...multiConfig,
+    draggable: false,
+    arrows: false
+  };
+
+  const selectedConfig = homeBanners.length > 1 ? multiConfig : singleConfig;
+
+  return (
+    <div className={styles.image_slider}>
+      <Slider {...selectedConfig}>
+        {homeBanners &&
+          homeBanners.map((banner) => (
+            <div key={banner.id} className={styles.banner}>
+              <img src={banner.image_url} alt={banner.title} />
+              {banner.title && <h2>{banner.title}</h2>}
+              {banner.description && <p>{banner.description}</p>}
+            </div>
+          ))}
+      </Slider>
+    </div>
+  );
+};
+
+const PrevArrow = (props: ArrowProps) => {
+  const { className, style, onClick, options } = props;
+
+  return (
+    <div
+      className={`${className} ${styles.slider_arrow}`}
+      style={{ ...style, ...options, left: '3rem' }}
+      onClick={onClick}
+    >
+      <PiArrowCircleLeftThin />
+    </div>
+  );
+};
+
+const NextArrow = (props: ArrowProps) => {
+  const { className, style, onClick, options } = props;
+
+  return (
+    <div
+      className={`${className} ${styles.slider_arrow}`}
+      style={{ ...style, ...options, right: '3rem' }}
+      onClick={onClick}
+    >
+      <PiArrowCircleRightThin />
+    </div>
+  );
+};
+
+export default ImageSlider;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,7 +67,6 @@ button {
 
 #main > div {
   margin: 0 auto;
-  padding: 1rem;
   max-width: 90rem;
   height: 100%;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import Footer from './_component/Footer';
 import localFont from 'next/font/local';
 import type { Metadata } from 'next';
 import './globals.css';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 
 export const metadata: Metadata = {
   title: '동남교회',

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import Banner from './_component/Banner';
+
 export default async function Home() {
-  return <div>Home</div>;
+  return <Banner />;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -486,6 +486,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-slick@^0.23.13":
+  version "0.23.13"
+  resolved "https://registry.yarnpkg.com/@types/react-slick/-/react-slick-0.23.13.tgz#037434e73a58063047b121e08565f7185d811f36"
+  integrity sha512-bNZfDhe/L8t5OQzIyhrRhBr/61pfBcWaYJoq6UDqFtv5LMwfg4NsVDD2J8N01JqdAdxLjOt66OZEp6PX+dGs/A==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18":
   version "18.3.12"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.12.tgz#99419f182ccd69151813b7ee24b792fe08774f60"
@@ -843,6 +850,11 @@ chownr@^3.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
   integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
+classnames@^2.2.5:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
+  integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
@@ -1025,6 +1037,11 @@ enhanced-resolve@^5.15.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquire.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw==
 
 es-abstract@^1.17.5, es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.1, es-abstract@^1.23.2, es-abstract@^1.23.3:
   version "1.23.3"
@@ -1934,6 +1951,13 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json2mq@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==
+  dependencies:
+    string-convert "^0.2.0"
+
 json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
@@ -1984,6 +2008,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -2314,10 +2343,26 @@ react-dom@19.0.0-rc-02c0e824-20241028:
   dependencies:
     scheduler "0.25.0-rc-02c0e824-20241028"
 
+react-icons@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-5.3.0.tgz#ccad07a30aebd40a89f8cfa7d82e466019203f1c"
+  integrity sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-slick@^0.30.2:
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/react-slick/-/react-slick-0.30.2.tgz#b28e992f9c519bb516a0af8d37e82cb59fee08ce"
+  integrity sha512-XvQJi7mRHuiU3b9irsqS9SGIgftIfdV5/tNcURTb5LdIokRA5kIIx3l4rlq2XYHfxcSntXapoRg/GxaVOM1yfg==
+  dependencies:
+    classnames "^2.2.5"
+    enquire.js "^2.1.6"
+    json2mq "^0.2.0"
+    lodash.debounce "^4.0.8"
+    resize-observer-polyfill "^1.5.0"
 
 react@19.0.0-rc-02c0e824-20241028:
   version "19.0.0-rc-02c0e824-20241028"
@@ -2356,6 +2401,11 @@ regexp.prototype.flags@^1.5.2:
     define-properties "^1.2.1"
     es-errors "^1.3.0"
     set-function-name "^2.0.2"
+
+resize-observer-polyfill@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -2541,6 +2591,11 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+slick-carousel@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/slick-carousel/-/slick-carousel-1.8.1.tgz#a4bfb29014887bb66ce528b90bd0cda262cc8f8d"
+  integrity sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==
+
 "source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
@@ -2550,6 +2605,11 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"


### PR DESCRIPTION
## 작업 내용
- 메인페이지의 배너 구현
- react-slick, slick-carousel (css), react-icons 라이브러리 설치
- 시각적 피드백을 위해 마우스 호버링 시 fill -> thin 아이콘으로 변경

## 작업 결과
![image](https://github.com/user-attachments/assets/ea795541-e6e6-4563-a7ab-0504b097cbbe)


## 앞으로 할 작업
- 임시 데이터 대신 supabase API 호출하여 데이터 전달
- 메인 페이지 구현