### PR TITLE
Feat: 헤더 반응형 적용

### DIFF
--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -1,52 +1,96 @@
+@import '../mixins';
+
 .header {
   position: fixed;
   top: 0;
-  width: 100%;
-  border-bottom: 0.1rem solid var(--dividing-line-color);
-  background: var(--background);
-  z-index: 9999;
+  right: 0;
+  left: 0;
+  background: white;
+  z-index: 99;
+
+  @include respond($mobile) {
+    width: 100%;
+  }
 }
 
 .header_wrap {
   padding: 1rem;
-  max-width: var(--max-width);
-  height: var(--header-height);
+  margin: 0 auto;
+  position: relative;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 4rem;
-  margin: 0 auto;
+  max-width: var(--max-width);
+  height: var(--header-height);
+  background-color: inherit;
+  box-shadow: rgba(0, 0, 0, 0.15) 1.95px 1.95px 2.6px;
+  z-index: 99;
+
+  @include respond($mobile) {
+    padding: 0;
+    flex-direction: column;
+    gap: 0;
+    height: auto;
+  }
 }
 
 .logo {
-  flex: 1;
+  flex: 0 0 auto;
+
+  @include respond($mobile) {
+    height: 50px; /* TODO: 변수화 */
+    line-height: 50px;
+
+    h1 {
+      font-size: 1.2rem;
+    }
+  }
 }
 
 .nav {
+  flex: 1;
+  width: 100%;
+  z-index: 99;
+
   ul {
     display: flex;
+    justify-content: center;
     gap: 1rem;
     font-size: 1.2rem;
     font-weight: 500;
 
+    @include respond($mobile) {
+      flex-direction: column;
+      gap: 0;
+    }
+
     li > a {
-      padding: 1rem 0.5rem;
-      transition: all var(--text-hover-delay);
+      display: inline-block;
+      padding: 0.5rem;
+      width: 100%;
+      transition: color var(--text-hover-delay);
 
       &:hover {
         color: var(--text-hover);
+      }
+
+      @include respond($mobile) {
+        text-align: center;
+        font-size: 0.8rem;
       }
     }
   }
 }
 
 .auth {
+  flex: 0 0 auto;
+
   ul {
     display: flex;
 
     li {
       position: relative;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem;
 
       &:not(:last-child)::after {
         content: '';
@@ -58,6 +102,35 @@
         background-color: #ccc;
         transform: translateY(-50%);
       }
+
+      @include respond($mobile) {
+        font-size: 0.8rem;
+      }
     }
   }
+}
+
+.toggle {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  display: none;
+
+  @include respond($mobile) {
+    display: inherit;
+
+    button {
+      display: inherit;
+    }
+  }
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 90;
 }

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -52,17 +52,21 @@
   width: 100%;
   z-index: 99;
 
+  @include respond($mobile) {
+    display: none;
+
+    & > ul {
+      flex-direction: column;
+      gap: 0 !important;
+    }
+  }
+
   ul {
     display: flex;
     justify-content: center;
     gap: 1rem;
     font-size: 1.2rem;
     font-weight: 500;
-
-    @include respond($mobile) {
-      flex-direction: column;
-      gap: 0;
-    }
 
     li > a {
       display: inline-block;
@@ -84,6 +88,10 @@
 
 .auth {
   flex: 0 0 auto;
+
+  @include respond($mobile) {
+    display: none;
+  }
 
   ul {
     display: flex;
@@ -133,4 +141,8 @@
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 90;
+}
+
+.visible {
+  display: block !important;
 }

--- a/src/app/_component/Header.tsx
+++ b/src/app/_component/Header.tsx
@@ -1,7 +1,36 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import styles from './Header.module.scss';
+import { GiHamburgerMenu } from 'react-icons/gi';
 
 export default function Header() {
+  const [isNavVisible, setNavVisible] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
+
+  const toggleNav = () => {
+    setNavVisible((prev) => !prev);
+  };
+
+  const handleClickOutside = (event: MouseEvent | PointerEvent) => {
+    if (navRef.current && !navRef.current.contains(event.target as Node)) {
+      setNavVisible(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isNavVisible) {
+      document.addEventListener('click', handleClickOutside);
+    } else {
+      document.removeEventListener('click', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  }, [isNavVisible]);
+
   return (
     <header className={styles.header}>
       <div className={styles.header_wrap}>
@@ -13,32 +42,42 @@ export default function Header() {
             </Link>
           </h1>
         </div>
-        <nav className={styles.nav}>
-          <ul>
-            <li>
-              <Link href="/about">교회소개</Link>
-            </li>
-            <li>
-              <Link href="/news">교회소식</Link>
-            </li>
-            <li>
-              <Link href="/fellowship">교제</Link>
-            </li>
-            <li>
-              <Link href="/gallery">동남앨범</Link>
-            </li>
-          </ul>
-        </nav>
-        <div className={styles.auth}>
-          <ul>
-            <li>
-              {/* TODO: 모달로 구현 */}
-              <Link href="/login">로그인</Link>
-            </li>
-            <li>회원가입</li>
-          </ul>
+        {isNavVisible && (
+          <>
+            <nav className={styles.nav} ref={navRef}>
+              <ul>
+                <li>
+                  <Link href="/about">교회소개</Link>
+                </li>
+                <li>
+                  <Link href="/news">교회소식</Link>
+                </li>
+                <li>
+                  <Link href="/fellowship">교제</Link>
+                </li>
+                <li>
+                  <Link href="/gallery">동남앨범</Link>
+                </li>
+              </ul>
+            </nav>
+            <div className={styles.auth}>
+              <ul>
+                <li>
+                  {/* TODO: 모달로 구현 */}
+                  <Link href="/login">로그인</Link>
+                </li>
+                <li>회원가입</li>
+              </ul>
+            </div>
+          </>
+        )}
+        <div className={styles.toggle}>
+          <button onClick={toggleNav} aria-label="Toggle Navigation">
+            <GiHamburgerMenu size="1rem" />
+          </button>
         </div>
       </div>
+      {isNavVisible && <div className={styles.overlay} />}
     </header>
   );
 }

--- a/src/app/_component/Header.tsx
+++ b/src/app/_component/Header.tsx
@@ -42,35 +42,31 @@ export default function Header() {
             </Link>
           </h1>
         </div>
-        {isNavVisible && (
-          <>
-            <nav className={styles.nav} ref={navRef}>
-              <ul>
-                <li>
-                  <Link href="/about">교회소개</Link>
-                </li>
-                <li>
-                  <Link href="/news">교회소식</Link>
-                </li>
-                <li>
-                  <Link href="/fellowship">교제</Link>
-                </li>
-                <li>
-                  <Link href="/gallery">동남앨범</Link>
-                </li>
-              </ul>
-            </nav>
-            <div className={styles.auth}>
-              <ul>
-                <li>
-                  {/* TODO: 모달로 구현 */}
-                  <Link href="/login">로그인</Link>
-                </li>
-                <li>회원가입</li>
-              </ul>
-            </div>
-          </>
-        )}
+        <nav className={`${styles.nav} ${isNavVisible ? styles.visible : ''}`} ref={navRef}>
+          <ul>
+            <li>
+              <Link href="/about">교회소개</Link>
+            </li>
+            <li>
+              <Link href="/news">교회소식</Link>
+            </li>
+            <li>
+              <Link href="/fellowship">교제</Link>
+            </li>
+            <li>
+              <Link href="/gallery">동남앨범</Link>
+            </li>
+          </ul>
+        </nav>
+        <div className={`${styles.auth} ${isNavVisible ? styles.visible : ''}`}>
+          <ul>
+            <li>
+              {/* TODO: 모달로 구현 */}
+              <Link href="/login">로그인</Link>
+            </li>
+            <li>회원가입</li>
+          </ul>
+        </div>
         <div className={styles.toggle}>
           <button onClick={toggleNav} aria-label="Toggle Navigation">
             <GiHamburgerMenu size="1rem" />

--- a/src/app/_mixins.scss
+++ b/src/app/_mixins.scss
@@ -1,0 +1,9 @@
+$mobile: 480px;
+$tablet: 640px;
+$desktop: 1024px;
+
+@mixin respond($size) {
+  @media screen and (max-width: $size) {
+    @content;
+  }
+}

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -1,0 +1,4 @@
+$mobile: 600;
+$tablet: 900;
+$small-desktop: 1200;
+$large-desktop: 1500;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -65,14 +65,34 @@ button {
   flex: 1;
 }
 
+@media screen and (max-width: 600px) {
+  #main {
+    padding-top: 50px;
+  }
+}
+
 #main > div {
   margin: 0 auto;
   max-width: 90rem;
-  height: 100%;
 }
 
 #footer {
   width: 100%;
   background: var(--footer-background);
   border-top: 0.1rem solid var(--dividing-line-color);
+}
+
+/* ===== Scrollbar CSS ===== */
+/* Firefox */
+* {
+  scrollbar-width: none;
+}
+
+/* Chrome, Edge, and Safari */
+*::-webkit-scrollbar {
+  width: 0px;
+}
+
+*::-webkit-scrollbar-track {
+  background: #ffffff;
 }


### PR DESCRIPTION
## 작업 내용
- 헤더 반응형 적용
  - 모바일 기기에서 햄버거 버튼을 누르면 네비게이션 표시
- sass의 mixin을 활용해 미디어 쿼리
- 조건부 컴포넌트 렌더링은 페이지 초기 렌더링 시 컴포넌트가 노출되지 않아 SEO 개선 필요
  - css를 활용해 클래스명에 스타일을 적용하는 방식으로 변경 

## 작업 결과
| PC | Mobile| Mobile|
|--|--|--|
|![image](https://github.com/user-attachments/assets/7a437a03-b99c-4236-a474-bc4348a6fc85)| ![image](https://github.com/user-attachments/assets/f36b591f-99f4-4305-ba8c-b70680092300)  | ![image](https://github.com/user-attachments/assets/1ed45c6e-5cd7-4d3b-ac10-20f772ce6c47) | 

## 앞으로 할 작업
- 배너 반응형 적용
- 각 URL에 매칭되는 페이지 생성
