### PR TITLE
Fix: 모바일 터치 이벤트로 발생하는 CSS 수정 및 @import 경고 해결

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  sassOptions: {
+    silenceDeprecations: ['legacy-js-api']
+  }
 };
 
 export default nextConfig;

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -74,8 +74,10 @@
       width: 100%;
       transition: color var(--text-hover-delay);
 
-      &:hover {
-        color: var(--text-hover);
+      @media (hover: hover) and (pointer: fine) {
+        &:hover {
+          color: var(--text-hover);
+        }
       }
 
       @include respond($mobile) {

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -1,4 +1,5 @@
-@import '../mixins';
+@use '../mixins' as *;
+@use '../variables';
 
 .header {
   position: fixed;
@@ -36,7 +37,6 @@
 
 .logo {
   flex: 0 0 auto;
-
   @include respond($mobile) {
     height: 50px; /* TODO: 변수화 */
     line-height: 50px;

--- a/src/app/_component/HomeSwiper.module.scss
+++ b/src/app/_component/HomeSwiper.module.scss
@@ -1,4 +1,5 @@
-@import '../mixins';
+@use '../mixins' as *;
+@use '../variables';
 
 .swiper {
   cursor: pointer;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -86,6 +86,7 @@ button {
 /* Firefox */
 * {
   scrollbar-width: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 /* Chrome, Edge, and Safari */


### PR DESCRIPTION
## 작업 내용

- sass `@import` 대신 `@use`로 변경
- 모바일 테스트 후 터치 이벤트로 발생하는 CSS 수정

| 모바일 터치 시 background | 모바일 네비게이션 터치 이후 hover CSS 유지 |
|--|--|
| ![image](https://github.com/user-attachments/assets/448d78e2-24ae-44bf-8e6a-8dab73efee1d) | ![image](https://github.com/user-attachments/assets/38bc61e0-9680-4c45-ab31-54c31fcd2359) | 
|  `* { -webkit-tap-highlight-color: transparent; }` |  `@media (hover: hover) and (pointer: fine) { ... }` <br/> PC에서만 hover CSS가 적용될 수 있도록 수정 |


## Sass @import 사용 경고
⚠️ Breaking Change: `@import` and global built-in functions

Dart Sass 1.80.0부터는 `@import`가 더 이상 권장되지 않는다. `@import` 대신 `@use` 사용할 것! 

### 이유
  1. 네임스페이스 충돌 방지: `@import`를 사용하면 모든 변수가 전역 네임스페이스에 추가되어, 다른 파일에서 동일한 이름의 변수나 믹스인이 있을 경우 충돌이 발생할 수 있음
  2. 컴파일 속도 개선: 동일한 파일이 여러 번 `@import`될 경우, Sass는 매번 해당 파일을 컴파일하므로 불필요한 성능 저하 초래
  3. 출처 추적 용이성: `@import`를 사용하면 특정 변수, 믹스인 또는 함수가 어디에서 왔는지 추적하기 어려움
  4. 모듈화 및 재사용성: `@use`와 `@forward`를 사용하면 코드의 모듈화를 촉진할 수 있으며, 필요한 부분만을 명확하게 가져와 사용 가능

```scss
Before
@import '../mixins';

After
@use '../mixins' as *;
@use '../variables';
```

## 앞으로 할 작업
- 메인 페이지 UI 작업
