### PR TITLE
Feat: 메인 페이지 환영 인사글, 퀵 메뉴 구현 (뷰포트에 기반한 반응형 웹 적용)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   /* config options here */
   sassOptions: {
+    additionalData: `@use "src/app/styles/_variables.scss" as *; @use "src/app/styles/_mixins.scss" as *;`,
     silenceDeprecations: ['legacy-js-api']
   }
 };

--- a/src/app/_component/BannerClient.tsx
+++ b/src/app/_component/BannerClient.tsx
@@ -8,8 +8,7 @@ import { Tables } from '@/shared/types/database.types';
 export default function BannerClient({ data }: BannerClientProps) {
   const options: SwiperOptions = {
     autoplay: {
-      delay: 6000,
-      disableOnInteraction: false
+      delay: 6000
     },
     effect: 'fade',
     loop: true,

--- a/src/app/_component/Footer.module.scss
+++ b/src/app/_component/Footer.module.scss
@@ -1,7 +1,7 @@
 .footer_wrap {
   margin: 0 auto;
   padding: 2rem 1rem;
-  max-width: var(--max-width);
+  max-width: $max-width;
 
   address {
     font-style: normal;

--- a/src/app/_component/Greeting.module.scss
+++ b/src/app/_component/Greeting.module.scss
@@ -4,7 +4,7 @@
 
   h3 {
     margin-bottom: 1.4rem;
-    font-size: 2.2rem;
+    font-size: 2.4rem;
 
     span {
       text-emphasis: '🩷';
@@ -22,20 +22,17 @@
     }
   }
 
-  // @include respond($breakpoint-md) {
-  //   padding: 1.4rem 1rem;
+  @include respond($breakpoint-md) {
+    h3 {
+      font-size: 1.6rem;
+    }
+    p {
+      font-size: 1.2rem;
+      line-height: 1.6;
 
-  //   h3 {
-  //     margin-bottom: 0.8rem;
-  //     font-size: 1.2rem;
-  //   }
-  //   p {
-  //     font-size: 1rem;
-  //     line-height: 1.4;
-
-  //     span {
-  //       font-size: 0.8rem;
-  //     }
-  //   }
-  // }
+      span {
+        font-size: 1rem;
+      }
+    }
+  }
 }

--- a/src/app/_component/Greeting.module.scss
+++ b/src/app/_component/Greeting.module.scss
@@ -4,7 +4,7 @@
 
   h3 {
     margin-bottom: 1.4rem;
-    font-size: 2rem;
+    font-size: 2.2rem;
 
     span {
       text-emphasis: '🩷';
@@ -12,7 +12,7 @@
   }
 
   p {
-    font-size: 1.4rem;
+    font-size: 1.5rem;
     font-weight: 400;
     line-height: 1.6;
     color: #777;
@@ -22,20 +22,20 @@
     }
   }
 
-  @include respond($mobile) {
-    padding: 1.4rem 1rem;
+  // @include respond($breakpoint-md) {
+  //   padding: 1.4rem 1rem;
 
-    h3 {
-      margin-bottom: 0.8rem;
-      font-size: 1.2rem;
-    }
-    p {
-      font-size: 1rem;
-      line-height: 1.4;
+  //   h3 {
+  //     margin-bottom: 0.8rem;
+  //     font-size: 1.2rem;
+  //   }
+  //   p {
+  //     font-size: 1rem;
+  //     line-height: 1.4;
 
-      span {
-        font-size: 0.8rem;
-      }
-    }
-  }
+  //     span {
+  //       font-size: 0.8rem;
+  //     }
+  //   }
+  // }
 }

--- a/src/app/_component/Greeting.module.scss
+++ b/src/app/_component/Greeting.module.scss
@@ -1,0 +1,43 @@
+@use '../mixins' as *;
+
+.greeting {
+  padding: 3rem 1rem;
+  text-align: center;
+
+  h3 {
+    margin-bottom: 1.4rem;
+    font-size: 2rem;
+
+    span {
+      text-emphasis: '🩷';
+    }
+  }
+
+  p {
+    font-size: 1.4rem;
+    font-weight: 400;
+    line-height: 1.6;
+    color: #777;
+
+    span {
+      font-size: 1.2rem;
+    }
+  }
+
+  @include respond($mobile) {
+    padding: 1.4rem 1rem;
+
+    h3 {
+      margin-bottom: 0.8rem;
+      font-size: 1.2rem;
+    }
+    p {
+      font-size: 1rem;
+      line-height: 1.4;
+
+      span {
+        font-size: 0.8rem;
+      }
+    }
+  }
+}

--- a/src/app/_component/Greeting.module.scss
+++ b/src/app/_component/Greeting.module.scss
@@ -1,5 +1,3 @@
-@use '../mixins' as *;
-
 .greeting {
   padding: 3rem 1rem;
   text-align: center;

--- a/src/app/_component/Greeting.tsx
+++ b/src/app/_component/Greeting.tsx
@@ -1,0 +1,16 @@
+import styles from './Greeting.module.scss';
+
+export default function Greeting() {
+  return (
+    <section className={styles.greeting}>
+      <h3>
+        하나님은 당신을 <span>사랑</span>하십니다.
+      </h3>
+      <p>
+        수고하고 무거운 짐진 자들아 <br />다 내게로 오라 내가 너희를 쉬게 하리라
+        <br />
+        <span>마태복음 11:28</span>
+      </p>
+    </section>
+  );
+}

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -5,10 +5,6 @@
   left: 0;
   background: white;
   z-index: 99;
-
-  @include respond($mobile) {
-    width: 100%;
-  }
 }
 
 .header_wrap {
@@ -18,13 +14,14 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 6rem;
   max-width: $max-width;
   height: $header-height;
   background-color: inherit;
-  box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 2px -2px rgba(0, 0, 0, 0.1);
   z-index: 99;
 
-  @include respond($mobile) {
+  @include respond($breakpoint-md) {
     padding: 0;
     flex-direction: column;
     gap: 0;
@@ -34,9 +31,14 @@
 
 .logo {
   flex: 0 0 auto;
-  @include respond($mobile) {
-    height: 50px; /* TODO: 변수화 */
-    line-height: 50px;
+
+  h1 {
+    font-size: 1.6rem;
+  }
+
+  @include respond($breakpoint-md) {
+    height: $mobile-header-height;
+    line-height: $mobile-header-height;
 
     h1 {
       font-size: 1.2rem;
@@ -45,12 +47,13 @@
 }
 
 .nav {
-  flex: 1;
-  width: 100%;
+  margin-left: auto;
   z-index: 99;
 
-  @include respond($mobile) {
+  @include respond($breakpoint-md) {
     display: none;
+    width: 100%;
+    margin-left: 0;
 
     & > ul {
       flex-direction: column;
@@ -77,7 +80,7 @@
         }
       }
 
-      @include respond($mobile) {
+      @include respond($breakpoint-md) {
         text-align: center;
         font-size: 0.8rem;
       }
@@ -88,7 +91,7 @@
 .auth {
   flex: 0 0 auto;
 
-  @include respond($mobile) {
+  @include respond($breakpoint-md) {
     display: none;
   }
 
@@ -110,7 +113,7 @@
         transform: translateY(-50%);
       }
 
-      @include respond($mobile) {
+      @include respond($breakpoint-md) {
         font-size: 0.8rem;
       }
     }
@@ -119,11 +122,11 @@
 
 .toggle {
   position: absolute;
-  top: calc($responsive-header-height / 2 - 0.5rem);
+  top: calc($mobile-header-height / 2 - 0.5rem);
   right: 1rem;
   display: none;
 
-  @include respond($mobile) {
+  @include respond($breakpoint-md) {
     display: inherit;
 
     button {

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -39,10 +39,6 @@
   @include respond($breakpoint-md) {
     height: $mobile-header-height;
     line-height: $mobile-header-height;
-
-    h1 {
-      font-size: 1.2rem;
-    }
   }
 }
 
@@ -55,7 +51,7 @@
     width: 100%;
     margin-left: 0;
 
-    & > ul {
+    ul {
       flex-direction: column;
       gap: 0 !important;
     }
@@ -82,13 +78,14 @@
 
       @include respond($breakpoint-md) {
         text-align: center;
-        font-size: 0.8rem;
+        font-size: 1.2rem;
       }
     }
   }
 }
 
 .auth {
+  margin-bottom: 0.6rem;
   flex: 0 0 auto;
 
   @include respond($breakpoint-md) {
@@ -101,6 +98,7 @@
     li {
       position: relative;
       padding: 0.5rem;
+      font-weight: 500;
 
       &:not(:last-child)::after {
         content: '';
@@ -114,17 +112,24 @@
       }
 
       @include respond($breakpoint-md) {
-        font-size: 0.8rem;
+        font-size: 1.2rem;
       }
     }
   }
 }
 
+$button-size: 1.2rem;
+
 .toggle {
   position: absolute;
-  top: calc($mobile-header-height / 2 - 0.5rem);
+  top: calc(($mobile-header-height - $button-size) / 2);
   right: 1rem;
   display: none;
+
+  svg {
+    width: $button-size;
+    height: $button-size;
+  }
 
   @include respond($breakpoint-md) {
     display: inherit;

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -85,10 +85,10 @@
 }
 
 .auth {
-  margin-bottom: 0.6rem;
   flex: 0 0 auto;
 
   @include respond($breakpoint-md) {
+    margin-bottom: 0.6rem;
     display: none;
   }
 

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -1,6 +1,3 @@
-@use '../mixins' as *;
-@use '../variables';
-
 .header {
   position: fixed;
   top: 0;
@@ -21,8 +18,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  max-width: var(--max-width);
-  height: var(--header-height);
+  max-width: $max-width;
+  height: $header-height;
   background-color: inherit;
   box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
   z-index: 99;
@@ -72,11 +69,11 @@
       display: inline-block;
       padding: 0.5rem;
       width: 100%;
-      transition: color var(--text-hover-delay);
+      transition: color $text-hover-delay;
 
       @media (hover: hover) and (pointer: fine) {
         &:hover {
-          color: var(--text-hover);
+          color: $text-hover;
         }
       }
 
@@ -122,7 +119,7 @@
 
 .toggle {
   position: absolute;
-  top: 1rem;
+  top: calc($responsive-header-height / 2 - 0.5rem);
   right: 1rem;
   display: none;
 

--- a/src/app/_component/Header.tsx
+++ b/src/app/_component/Header.tsx
@@ -75,7 +75,7 @@ export default function Header() {
         </div>
         <div className={styles.toggle}>
           <button onClick={toggleNav} aria-label="Toggle Navigation">
-            <GiHamburgerMenu size="1rem" />
+            <GiHamburgerMenu />
           </button>
         </div>
       </div>

--- a/src/app/_component/HomeSwiper.module.scss
+++ b/src/app/_component/HomeSwiper.module.scss
@@ -3,11 +3,11 @@
 
   img {
     width: 100%;
-    height: 400px;
+    height: 40rem;
     object-fit: cover;
 
-    @include respond($mobile) {
-      height: 250px;
+    @include respond($breakpoint-md) {
+      height: 25rem;
     }
   }
 

--- a/src/app/_component/HomeSwiper.module.scss
+++ b/src/app/_component/HomeSwiper.module.scss
@@ -1,6 +1,3 @@
-@use '../mixins' as *;
-@use '../variables';
-
 .swiper {
   cursor: pointer;
 
@@ -16,10 +13,10 @@
 
   :global(.swiper-pagination-bullet) {
     background-color: transparent !important;
-    border: 1.4px solid var(--primary-color);
+    border: 1.4px solid $primary-color;
   }
 
   :global(.swiper-pagination-bullet-active) {
-    background-color: var(--primary-color) !important;
+    background-color: $primary-color !important;
   }
 }

--- a/src/app/_component/LinkButtons.module.scss
+++ b/src/app/_component/LinkButtons.module.scss
@@ -1,0 +1,68 @@
+$button_size: 9rem;
+$button_tablet_size: 8rem;
+$button_mobile_size: 7.2rem;
+
+.quick_menu {
+  padding: 2rem 1rem;
+  display: grid;
+  grid-template-columns: repeat(6, $button_size);
+  grid-gap: 3rem;
+  justify-content: center;
+  place-items: center;
+
+  @include respond($breakpoint-xl) {
+    grid-template-columns: repeat(6, $button_tablet_size);
+    grid-gap: 2rem;
+  }
+
+  @include respond($breakpoint-md) {
+    grid-template-columns: repeat(3, $button_mobile_size);
+  }
+}
+
+.menu_item {
+  width: auto;
+  height: auto;
+  text-align: center;
+
+  a {
+    display: block;
+  }
+
+  div {
+    margin-bottom: 0.6rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: $button_size;
+    height: $button_size;
+    background-color: #fff5ec;
+    border-radius: 50%;
+
+    svg {
+      font-size: 3rem;
+      mix-blend-mode: hard-light;
+    }
+  }
+
+  span {
+    font-size: 1.4rem;
+  }
+
+  @include respond($breakpoint-xl) {
+    div {
+      width: $button_tablet_size;
+      height: $button_tablet_size;
+    }
+    span {
+      font-size: 1.2rem;
+    }
+  }
+
+  @include respond($breakpoint-md) {
+    div {
+      width: $button_mobile_size;
+      height: $button_mobile_size;
+    }
+  }
+}

--- a/src/app/_component/LinkButtons.module.scss
+++ b/src/app/_component/LinkButtons.module.scss
@@ -16,13 +16,12 @@ $button_mobile_size: 7.2rem;
   }
 
   @include respond($breakpoint-md) {
+    padding: 0;
     grid-template-columns: repeat(3, $button_mobile_size);
   }
 }
 
 .menu_item {
-  width: auto;
-  height: auto;
   text-align: center;
 
   a {
@@ -54,6 +53,7 @@ $button_mobile_size: 7.2rem;
       width: $button_tablet_size;
       height: $button_tablet_size;
     }
+
     span {
       font-size: 1.2rem;
     }
@@ -63,6 +63,10 @@ $button_mobile_size: 7.2rem;
     div {
       width: $button_mobile_size;
       height: $button_mobile_size;
+    }
+
+    span {
+      font-size: 1.1rem;
     }
   }
 }

--- a/src/app/_component/LinkButtons.tsx
+++ b/src/app/_component/LinkButtons.tsx
@@ -1,0 +1,37 @@
+import {
+  PiNewspaperClipping,
+  PiClockUser,
+  PiMapTrifold,
+  PiMapPinAreaLight,
+  PiWechatLogo
+} from 'react-icons/pi';
+import styles from './LinkButtons.module.scss';
+import Link from 'next/link';
+
+export default function LinkButtons() {
+  const quickList = [
+    { icon: PiMapTrifold, label: '주보', path: '/news/bulletin' },
+    { icon: PiClockUser, label: '예배안내', path: '/about' },
+    { icon: PiMapPinAreaLight, label: '오시는길', path: '/about' },
+    { icon: PiNewspaperClipping, label: '교회소식', path: '/news' },
+    { icon: PiWechatLogo, label: '나눔', path: '/fellowship' },
+    { icon: PiClockUser, label: '행정', path: '/' }
+  ];
+
+  return (
+    <section>
+      <ul className={styles.quick_menu}>
+        {quickList.map((item, index) => (
+          <li key={index} className={styles.menu_item}>
+            <Link href={item.path} key={index}>
+              <div>
+                <item.icon />
+              </div>
+              <span>{item.label}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/_variables.scss
+++ b/src/app/_variables.scss
@@ -1,4 +1,0 @@
-$mobile: 600;
-$tablet: 900;
-$small-desktop: 1200;
-$large-desktop: 1500;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,6 +66,10 @@ button {
 }
 
 @media screen and (max-width: 600px) {
+  body {
+    font-size: 14px;
+  }
+
   #main {
     padding-top: 50px;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import Header from './_component/Header';
 import Footer from './_component/Footer';
 import localFont from 'next/font/local';
 import type { Metadata } from 'next';
-import './globals.css';
+import '../app/styles/globals.scss';
 import 'swiper/css';
 import 'swiper/css/autoplay';
 import 'swiper/css/effect-fade';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
 import Banner from './_component/Banner';
+import Greeting from './_component/Greeting';
 
 export default async function Home() {
-  return <Banner />;
+  return (
+    <>
+      <Banner />
+      <Greeting />
+    </>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 import Banner from './_component/Banner';
 import Greeting from './_component/Greeting';
+import LinkButtons from './_component/LinkButtons';
 
 export default async function Home() {
   return (
     <>
       <Banner />
       <Greeting />
+      <LinkButtons />
     </>
   );
 }

--- a/src/app/styles/_mixins.scss
+++ b/src/app/styles/_mixins.scss
@@ -1,7 +1,3 @@
-$mobile: 480px;
-$tablet: 640px;
-$desktop: 1024px;
-
 @mixin respond($size) {
   @media screen and (max-width: $size) {
     @content;

--- a/src/app/styles/_mixins.scss
+++ b/src/app/styles/_mixins.scss
@@ -1,3 +1,11 @@
+@mixin respond-fonts($width, $font-size) {
+  @media screen and (min-width: $width) {
+    html {
+      font-size: $font-size;
+    }
+  }
+}
+
 @mixin respond($size) {
   @media screen and (max-width: $size) {
     @content;

--- a/src/app/styles/_variables.scss
+++ b/src/app/styles/_variables.scss
@@ -1,7 +1,4 @@
-$mobile: 480px;
-$tablet: 768px;
-$desktop: 1024px;
-
+/* Colors */
 $background: #ffffff;
 $foreground: #171717;
 
@@ -15,6 +12,15 @@ $text-hover: $primary-color;
 $text-hover-delay: 0.2s;
 
 /* Size */
-$max-width: 90rem;
+$max-width: 120rem;
 $header-height: 5rem;
-$responsive-header-height: 50px;
+$mobile-header-height: 4rem;
+
+/* Break Point */
+$breakpoint-xs: 361px; // Extra small devices (small phones)
+$breakpoint-sm: 481px; // Small devices (phones)
+$breakpoint-md: 601px; // Medium devices (tablets)
+$breakpoint-lg: 769px; // Large devices (small desktops)
+$breakpoint-xl: 1025px; // Extra large devices (desktops)
+$breakpoint-xxl: 1337px; // Extra extra large devices (large desktops)
+$breakpoint-xxxl: 1921px; // Extra extra extra large devices (large screens)

--- a/src/app/styles/_variables.scss
+++ b/src/app/styles/_variables.scss
@@ -1,0 +1,20 @@
+$mobile: 480px;
+$tablet: 768px;
+$desktop: 1024px;
+
+$background: #ffffff;
+$foreground: #171717;
+
+$primary-color: #f68b28;
+$secendary-color: #bf1e2dff;
+$dividing-line-color: #ddd;
+
+/* Text */
+$text-color: #171717;
+$text-hover: $primary-color;
+$text-hover-delay: 0.2s;
+
+/* Size */
+$max-width: 90rem;
+$header-height: 5rem;
+$responsive-header-height: 50px;

--- a/src/app/styles/globals.scss
+++ b/src/app/styles/globals.scss
@@ -1,31 +1,18 @@
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-
-  /* Colors */
-  --primary-color: #f68b28;
-  --secendary-color: #bf1e2dff;
-  --dividing-line-color: #ddd;
-
-  /* Text */
-  --text-color: #171717;
-  --text-hover: var(--primary-color);
-  --text-hover-delay: 0.2s;
-
-  /* Size */
-  --max-width: 90rem;
-  --header-height: 5rem;
-}
-
 html,
 body {
+  font-size: 16px;
   height: 100%;
   overflow-x: hidden;
+  -webkit-text-size-adjust: none;
+  -ms-text-size-adjust: none;
+  -moz-text-size-adjust: none;
+  -o-text-size-adjust: none;
 }
 
 body {
-  color: var(--text-color);
-  background: var(--background);
+  font-size: calc(1rem + 0.25vw);
+  color: $text-color;
+  background: $background;
   font-family: var(--font-notosans);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -61,12 +48,12 @@ button {
 }
 
 #main {
-  padding-top: var(--header-height);
+  padding-top: $header-height;
   flex: 1;
 }
 
 @media screen and (max-width: 600px) {
-  body {
+  html {
     font-size: 14px;
   }
 
@@ -75,29 +62,25 @@ button {
   }
 }
 
-#main > div {
+#main > div,
+#main > section {
   margin: 0 auto;
   max-width: 90rem;
 }
 
 #footer {
   width: 100%;
-  background: var(--footer-background);
-  border-top: 0.1rem solid var(--dividing-line-color);
+  border-top: 0.1rem solid $dividing-line-color;
 }
 
 /* ===== Scrollbar CSS ===== */
-/* Firefox */
 * {
   scrollbar-width: none;
   -webkit-tap-highlight-color: transparent;
 }
-
-/* Chrome, Edge, and Safari */
 *::-webkit-scrollbar {
   width: 0px;
 }
-
 *::-webkit-scrollbar-track {
   background: #ffffff;
 }

--- a/src/app/styles/globals.scss
+++ b/src/app/styles/globals.scss
@@ -1,21 +1,19 @@
-html,
+html {
+  font-size: 2.777778vw;
+}
+
 body {
-  font-size: 16px;
-  height: 100%;
+  background: $background;
+  font-family: var(--font-notosans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-size: calc(1rem + 0.25vw);
+  color: $text-color;
   overflow-x: hidden;
   -webkit-text-size-adjust: none;
   -ms-text-size-adjust: none;
   -moz-text-size-adjust: none;
   -o-text-size-adjust: none;
-}
-
-body {
-  font-size: calc(1rem + 0.25vw);
-  color: $text-color;
-  background: $background;
-  font-family: var(--font-notosans);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 * {
@@ -41,7 +39,6 @@ button {
 }
 
 #root {
-  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -52,20 +49,16 @@ button {
   flex: 1;
 }
 
-@media screen and (max-width: 600px) {
-  html {
-    font-size: 14px;
-  }
-
+@media screen and (max-width: $breakpoint-md) {
   #main {
-    padding-top: 50px;
+    padding-top: $mobile-header-height;
   }
 }
 
 #main > div,
 #main > section {
   margin: 0 auto;
-  max-width: 90rem;
+  max-width: $max-width;
 }
 
 #footer {
@@ -84,3 +77,21 @@ button {
 *::-webkit-scrollbar-track {
   background: #ffffff;
 }
+
+/*! ****************************************
+ * $breakpoint-xs: 360px 
+ * $breakpoint-sm: 480px 
+ * $breakpoint-md: 600px 
+ * $breakpoint-lg: 768px 
+ * $breakpoint-xl: 1024px
+ * $breakpoint-xxl: 1336px
+ * $breakpoint-xxxl: 1920px
+ * **************************************** */
+
+@include respond-fonts($breakpoint-xs, 2.778vw);
+@include respond-fonts($breakpoint-sm, 2.083vw);
+@include respond-fonts($breakpoint-md, 1.667vw);
+@include respond-fonts($breakpoint-lg, 1.302vw);
+@include respond-fonts($breakpoint-xl, 0.977vw);
+@include respond-fonts($breakpoint-xxl, 0.749vw);
+@include respond-fonts($breakpoint-xxxl, 0.521vw);


### PR DESCRIPTION
## 작업 내용

- 뷰포트에 기반한 폰트 크기를 변경하여 반응형 웹 구현
  - sass의 원활한 사용을 위해 mixin, 변수 전역 설정 (next.config.ts 수정)
  - `styles` 폴더를 생성하여 루트 sass 파일들을 이동하여 관리
  - 기존에 구현한 컴포넌트 스타일 수정
- 환영 인사글, 퀵 메뉴 구현 (반응형 적용)

## 작업 결과
|Mobile | Mobile - 메뉴 | PC |
|--|--|--|
| ![image](https://github.com/user-attachments/assets/c8b38e6e-a589-426b-adab-6ed724ec97ac) | ![image](https://github.com/user-attachments/assets/f13bcc3b-bd96-4506-831c-6f74cf14c242) <br /> * 실제로는 하단에도 오버레이 적용 (캡처 플러그인 사용) *| ![image](https://github.com/user-attachments/assets/d4919095-641c-48bf-8382-87dfc92b10a4) |  

| 반응형 웹 |
|--|
| ![_20241121_191424-ezgif com-video-to-gif-converter (2)](https://github.com/user-attachments/assets/26102055-1d55-46b6-a203-ae0fa63d5c0f)  | 

## 앞으로 할 작업
- 메인 페이지 갤러리 구현
  - 사진 여러장 슬라이더, 더미 이미지 사용
