### PR TITLE
Fix: 모바일 기기에서 홈 배너 슬라이더가 변경될 때 끊김 수정

### DIFF
--- a/src/app/_component/Banner.tsx
+++ b/src/app/_component/Banner.tsx
@@ -19,7 +19,7 @@ export default async function Banner() {
       description: null,
       order: 2,
       image_url:
-        'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/sign/home_banner/anti.jpg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJob21lX2Jhbm5lci9hbnRpLmpwZyIsImlhdCI6MTczMDk5NjAzMSwiZXhwIjoxNzYyNTMyMDMxfQ.ytJtbJQETOAtt3VCgHjCbytGFAbGPksYRAb-nKSN2O8&t=2024-11-07T16%3A13%3A51.617Z',
+        'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/sign/home_banner/church.jpg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1cmwiOiJob21lX2Jhbm5lci9jaHVyY2guanBnIiwiaWF0IjoxNzMyNjEwNjIwLCJleHAiOjE3NjQxNDY2MjB9.IJ5PfVONthOoKrtyt9Mbr6DodzWCyeb7Ej_OiqLxAkg&t=2024-11-26T08%3A43%3A40.327Z',
       year: 2024
     }
   ];

--- a/src/app/_component/BannerClient.tsx
+++ b/src/app/_component/BannerClient.tsx
@@ -11,6 +11,7 @@ export default function BannerClient({ data }: BannerClientProps) {
       delay: 5000,
       disableOnInteraction: false
     },
+    autoHeight: true,
     effect: 'fade',
     fadeEffect: {
       crossFade: true

--- a/src/app/_component/BannerClient.tsx
+++ b/src/app/_component/BannerClient.tsx
@@ -13,7 +13,6 @@ export default function BannerClient({ data }: BannerClientProps) {
     },
     effect: 'fade',
     loop: true,
-    loopAdditionalSlides: 1,
     observer: true,
     observeParents: true,
     modules: [Autoplay, EffectFade, Pagination],

--- a/src/app/_component/BannerClient.tsx
+++ b/src/app/_component/BannerClient.tsx
@@ -13,7 +13,8 @@ export default function BannerClient({ data }: BannerClientProps) {
     effect: 'fade',
     loop: true,
     modules: [Autoplay, EffectFade, Pagination],
-    pagination: { clickable: true }
+    pagination: { clickable: true },
+    passiveListeners: false
   };
 
   return <HomeSwiper bannerData={data} options={options} />;

--- a/src/app/_component/BannerClient.tsx
+++ b/src/app/_component/BannerClient.tsx
@@ -1,22 +1,28 @@
 'use client';
 
 import HomeSwiper from './HomeSwiper';
-import { Autoplay, EffectFade, Pagination } from 'swiper/modules';
+import { Autoplay, EffectFade, Pagination, Parallax } from 'swiper/modules';
 import { SwiperOptions } from 'swiper/types';
 import { Tables } from '@/shared/types/database.types';
 
 export default function BannerClient({ data }: BannerClientProps) {
   const options: SwiperOptions = {
     autoplay: {
-      delay: 6000,
+      delay: 5000,
       disableOnInteraction: false
     },
     effect: 'fade',
+    fadeEffect: {
+      crossFade: true
+    },
     loop: true,
-    observer: true,
-    observeParents: true,
-    modules: [Autoplay, EffectFade, Pagination],
-    pagination: { clickable: true }
+    modules: [Autoplay, Pagination, Parallax, EffectFade],
+    pagination: {
+      clickable: true
+    },
+    parallax: true,
+    slidesPerView: 1,
+    speed: 1500
   };
 
   return <HomeSwiper bannerData={data} options={options} />;

--- a/src/app/_component/BannerClient.tsx
+++ b/src/app/_component/BannerClient.tsx
@@ -8,13 +8,16 @@ import { Tables } from '@/shared/types/database.types';
 export default function BannerClient({ data }: BannerClientProps) {
   const options: SwiperOptions = {
     autoplay: {
-      delay: 6000
+      delay: 6000,
+      disableOnInteraction: false
     },
     effect: 'fade',
     loop: true,
+    loopAdditionalSlides: 1,
+    observer: true,
+    observeParents: true,
     modules: [Autoplay, EffectFade, Pagination],
-    pagination: { clickable: true },
-    passiveListeners: false
+    pagination: { clickable: true }
   };
 
   return <HomeSwiper bannerData={data} options={options} />;

--- a/src/app/_component/HomeGalleryClient.tsx
+++ b/src/app/_component/HomeGalleryClient.tsx
@@ -11,9 +11,10 @@ export default function HomeGalleryClient({ data }: HomeGalleryClientProps) {
       delay: 1,
       disableOnInteraction: false
     },
+    autoHeight: true,
     freeMode: true,
     loop: true,
-    loopAdditionalSlides: 1,
+    loopAdditionalSlides: 3,
     speed: 8e3,
     slidesPerView: 'auto',
     observer: true,

--- a/src/app/_component/HomeGalleryClient.tsx
+++ b/src/app/_component/HomeGalleryClient.tsx
@@ -18,7 +18,8 @@ export default function HomeGalleryClient({ data }: HomeGalleryClientProps) {
     observer: true,
     observeParents: true,
     touchEventsTarget: 'container',
-    modules: [Autoplay, FreeMode]
+    modules: [Autoplay, FreeMode],
+    passiveListeners: false
   };
 
   return <HomeGalleryCarousel options={options} data={data} />;

--- a/src/app/_component/HomeGalleryClient.tsx
+++ b/src/app/_component/HomeGalleryClient.tsx
@@ -13,13 +13,12 @@ export default function HomeGalleryClient({ data }: HomeGalleryClientProps) {
     },
     freeMode: true,
     loop: true,
+    loopAdditionalSlides: 1,
     speed: 8e3,
     slidesPerView: 'auto',
     observer: true,
     observeParents: true,
-    touchEventsTarget: 'container',
-    modules: [Autoplay, FreeMode],
-    passiveListeners: false
+    modules: [Autoplay, FreeMode]
   };
 
   return <HomeGalleryCarousel options={options} data={data} />;

--- a/src/app/_component/HomeSwiper.tsx
+++ b/src/app/_component/HomeSwiper.tsx
@@ -15,7 +15,9 @@ export default function HomeSwiper({ bannerData, options }: SwiperProps) {
     <Swiper {...options} className={styles.swiper}>
       {bannerData.map((banner) => (
         <SwiperSlide key={banner.id}>
-          <img src={banner.image_url} alt={banner.title} />
+          <div className="swiper-slide-transform">
+            <img src={banner.image_url} alt={banner.title} />
+          </div>
         </SwiperSlide>
       ))}
     </Swiper>

--- a/src/app/_component/LinkButtons.module.scss
+++ b/src/app/_component/LinkButtons.module.scss
@@ -3,7 +3,7 @@ $button_tablet_size: 8rem;
 $button_mobile_size: 7.2rem;
 
 .quick_menu {
-  padding: 2rem 1rem 3rem 1rem;
+  padding: 0 1rem 3rem 1rem;
   display: grid;
   grid-template-columns: repeat(6, $button_size);
   grid-gap: 3rem;

--- a/src/app/gallery/[id]/page.tsx
+++ b/src/app/gallery/[id]/page.tsx
@@ -1,0 +1,3 @@
+export default function GalleryDetail() {
+  return <div>GalleryDetail</div>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import 'swiper/scss/autoplay';
 import 'swiper/scss/free-mode';
 import 'swiper/scss/effect-fade';
 import 'swiper/scss/pagination';
+import 'swiper/scss/parallax';
 
 export const metadata: Metadata = {
   title: '동남교회',

--- a/src/app/news/bulletin/page.tsx
+++ b/src/app/news/bulletin/page.tsx
@@ -1,0 +1,3 @@
+export default function Bulletin() {
+  return <div>Bulletin</div>;
+}


### PR DESCRIPTION
## 작업 내용
- `⚠️ Added non-passive event listener to a scroll-blocking 'touchstart' event. Consider marking event handler as 'passive' to make the page more responsive`
- 프로덕션 환경에서 배너 슬라이더가 변경될 때 스크롤이 되지 않거나 홈 갤러리 캐러셀이 동작하지 않는 등 끊김 발생
  - 원인: supabase에 저장된 파일의 크기가 14.62MB로 파일 용량이 너무 큼
  - 해결책: 파일 용량이 작은 URL로 대체

<img src="https://github.com/user-attachments/assets/a0892f3f-3850-4163-b51e-4f08a1ceae3b" width="100%"> 
