### PR TITLE
Feat: 모바일 기기 사이드바 Navigation Drawer

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.5.1",
     "@supabase/supabase-js": "^2.46.1",
+    "lodash-es": "^4.17.21",
     "next": "15.0.2",
     "react": "19.0.0-rc-02c0e824-20241028",
     "react-dom": "19.0.0-rc-02c0e824-20241028",
@@ -20,6 +21,7 @@
     "swiper": "^11.1.14"
   },
   "devDependencies": {
+    "@types/lodash-es": "^4.17.12",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,8 +1,9 @@
 import { createServerSideClient } from '@/shared/supabase/server';
+import { UserProps } from '@/shared/types/types';
 
-export const getCurrnetUser = async () => {
+export const getCurrnetUser = async (): Promise<UserProps> => {
   const supabase = await createServerSideClient();
   const user = await supabase.auth.getUser();
 
-  return user.data.user;
+  return user.data.user as UserProps;
 };

--- a/src/app/_component/Drawer.module.scss
+++ b/src/app/_component/Drawer.module.scss
@@ -1,0 +1,102 @@
+$drawer-width: 28rem;
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: -$drawer_width;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  width: $drawer_width;
+  height: 100%;
+  background-color: white;
+  z-index: 100;
+  transition: right 325ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+
+  .top {
+    padding: 2rem 1rem 0 1rem;
+    width: 100%;
+    text-align: right;
+
+    button {
+      display: inline-block;
+
+      svg {
+        width: 2rem;
+        height: 2rem;
+      }
+    }
+  }
+
+  .profile {
+    padding: 1rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .login_btn {
+      padding: 1rem 1.6rem;
+      display: block;
+      width: 100%;
+      background-color: $primary-color;
+      border-radius: 0.8rem;
+      color: white;
+      text-align: center;
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+
+    a {
+      display: inline-flex;
+      svg {
+        fill: rgb(194, 194, 194);
+      }
+    }
+  }
+
+  .nav {
+    padding: 1rem;
+    border-top: 1px solid #eee;
+
+    .nav_list {
+      font-size: 1.2rem;
+
+      & > li > a {
+        display: flex;
+        align-items: center;
+      }
+
+      svg {
+        margin-right: 1rem;
+        width: 1.8rem;
+        height: 1.8rem;
+        opacity: 0.6;
+      }
+    }
+
+    .subnav_list {
+      padding-left: 0.9rem;
+      font-size: 1rem;
+      opacity: 0.8;
+
+      li {
+        padding-left: 1.8rem;
+        border-left: 2px solid #eee;
+      }
+    }
+
+    li > a {
+      padding: 0.5rem 0;
+      display: block;
+    }
+  }
+
+  .bottom {
+    padding: 1rem;
+  }
+}
+
+.animate {
+  right: 0;
+  box-shadow: 0 2px 2px -2px rgba(0, 0, 0, 0.1);
+}

--- a/src/app/_component/Drawer.tsx
+++ b/src/app/_component/Drawer.tsx
@@ -1,0 +1,79 @@
+import Link from 'next/link';
+import { IoMdClose, IoIosArrowForward } from 'react-icons/io';
+import UserProfile from './user/UserProfile';
+import IconContainer from './common/IconContainer';
+import { signOut } from '@/apis/auth';
+import { sitemap } from '@/shared/constants/sitemap';
+import { UserProps } from '@/shared/types/types';
+import styles from './Drawer.module.scss';
+
+type DrawerProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  user: UserProps;
+};
+
+export default function Drawer({ isOpen, onClose, user }: DrawerProps) {
+  const { avatar_url = '', user_name = '', name = '' } = user?.user_metadata ?? {};
+
+  return (
+    <aside className={`${styles.drawer} ${isOpen ? styles.animate : styles.hidden}`}>
+      <div className={styles.top}>
+        <button onClick={onClose}>
+          <IoMdClose />
+        </button>
+      </div>
+      <div className={styles.profile}>
+        {user && (
+          <>
+            <UserProfile
+              avatarUrl={avatar_url}
+              imageSize="4rem"
+              username={user_name}
+              name={name}
+              showInfo
+            />
+            <Link href={`/mypage/${user.id}`}>
+              <IoIosArrowForward size="2rem" />
+            </Link>
+          </>
+        )}
+        {!user && (
+          <Link href="/login" className={styles.login_btn}>
+            로그인
+          </Link>
+        )}
+      </div>
+      <nav className={styles.nav}>
+        <ul className={styles.nav_list}>
+          {sitemap
+            .filter((item) => item.show)
+            .map((item) => (
+              <li key={item.path}>
+                <Link href={item.path}>
+                  <IconContainer>
+                    <item.icon />
+                  </IconContainer>
+                  <span>{item.label}</span>
+                </Link>
+                {item.subPath && item.subPath?.length > 0 && (
+                  <ul className={styles.subnav_list}>
+                    {item.subPath.map((subItem) => (
+                      <li key={subItem.path}>
+                        <Link href={subItem.path}>{subItem.label}</Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+        </ul>
+      </nav>
+      {user && (
+        <div className={styles.bottom}>
+          <button onClick={signOut}>로그아웃</button>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/app/_component/Header.module.scss
+++ b/src/app/_component/Header.module.scss
@@ -19,7 +19,6 @@
   height: $header-height;
   background-color: inherit;
   box-shadow: 0 2px 2px -2px rgba(0, 0, 0, 0.1);
-  z-index: 99;
 
   @include respond($breakpoint-md) {
     padding: 0;

--- a/src/app/_component/Header.tsx
+++ b/src/app/_component/Header.tsx
@@ -5,36 +5,21 @@ import Link from 'next/link';
 import styles from './Header.module.scss';
 import { GiHamburgerMenu } from 'react-icons/gi';
 import { usePathname } from 'next/navigation';
-import { User } from '@supabase/supabase-js';
 import { sitemap } from '@/shared/constants/sitemap';
 import UserProfile from './user/UserProfile';
 import ModalOverlay from './common/ModalOverlay';
 import useModal from '../hooks/useModal';
 import UserProfileModal from './user/UserProfileModal';
+import useIsMobile from '../hooks/useIsMobile';
+import Drawer from './Drawer';
+import { UserProps } from '@/shared/types/types';
 
 type HeaderProps = {
-  user?: User | UserWithCustomMetadata | null;
-};
-
-type UserWithCustomMetadata = Omit<User, 'user_metadata'> & {
-  user_metadata: UserMetadata;
-};
-
-export type UserMetadata = {
-  avatar_url: string;
-  email: string;
-  email_verified: boolean;
-  full_name: string;
-  iss: string;
-  name: string;
-  phone_verified: boolean;
-  preferred_username: string;
-  provider_id: string;
-  sub: string;
-  user_name: string;
+  user: UserProps;
 };
 
 export default function Header({ user }: HeaderProps) {
+  const isMobile = useIsMobile();
   const { isVisible: isNavVisible, ref, handleToggle, setVisible } = useModal();
   const {
     isVisible: isProfileVisible,
@@ -52,7 +37,7 @@ export default function Header({ user }: HeaderProps) {
 
   return (
     <header className={styles.header}>
-      <div className={styles.header_wrap} ref={ref}>
+      <div className={styles.header_wrap}>
         <div className={styles.logo}>
           <h1>
             <Link href="/">
@@ -62,17 +47,20 @@ export default function Header({ user }: HeaderProps) {
           </h1>
         </div>
         <nav className={`${styles.nav} ${isNavVisible ? styles.visible : ''}`}>
-          <ul>
-            {sitemap
-              .filter((item) => item.show)
-              .map((item, index) => (
-                <li key={index}>
-                  <Link href={item.path}>{item.label}</Link>
-                </li>
-              ))}
-          </ul>
+          {!isMobile && (
+            <ul>
+              {sitemap
+                .filter((item) => item.show)
+                .map((item, index) => (
+                  <li key={index}>
+                    <Link href={item.path}>{item.label}</Link>
+                  </li>
+                ))}
+            </ul>
+          )}
         </nav>
-        <div className={`${styles.auth} ${isNavVisible ? styles.visible : ''}`}>
+        {/* <div className={`${styles.auth} ${isNavVisible ? styles.visible : ''}`}> */}
+        <div className={`${styles.auth}`}>
           {/* TODO: 모달로 구현 */}
           {!isLoggedIn && <Link href="/login">로그인</Link>}
           {isLoggedIn && (
@@ -93,10 +81,11 @@ export default function Header({ user }: HeaderProps) {
             </div>
           )}
         </div>
-        <div className={styles.toggle}>
+        <div className={styles.toggle} ref={ref}>
           <button onClick={handleToggle} aria-label="Toggle Navigation">
             <GiHamburgerMenu />
           </button>
+          {isMobile && <Drawer isOpen={isNavVisible} onClose={handleToggle} user={user} />}
         </div>
       </div>
       <ModalOverlay isVisible={isNavVisible} />

--- a/src/app/_component/common/IconContainer.tsx
+++ b/src/app/_component/common/IconContainer.tsx
@@ -1,0 +1,7 @@
+type IconContainerProps = {
+  children: React.ReactNode;
+};
+
+export default function IconContainer({ children }: IconContainerProps) {
+  return <i style={{ display: 'inline-flex' }}>{children}</i>;
+}

--- a/src/app/_component/user/UserProfile.module.scss
+++ b/src/app/_component/user/UserProfile.module.scss
@@ -1,6 +1,5 @@
 .profile {
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
 
   .profile_image {
@@ -13,7 +12,6 @@
 
   .info {
     margin-left: 1rem;
-    font-size: 1.1rem;
     line-height: 1.2;
 
     span {

--- a/src/app/_component/user/UserProfile.tsx
+++ b/src/app/_component/user/UserProfile.tsx
@@ -4,6 +4,7 @@ type UserProfileProps = {
   avatarUrl: string;
   name?: string;
   username?: string;
+  fontSize?: string;
   imageSize?: string;
   showInfo?: boolean;
   handleClick?: (event: React.MouseEvent<HTMLDivElement | HTMLButtonElement, MouseEvent>) => void;
@@ -14,6 +15,7 @@ export default function UserProfile({
   name,
   username,
   imageSize = '3.6rem',
+  fontSize = '1.2rem',
   showInfo = false,
   handleClick
 }: UserProfileProps) {
@@ -23,7 +25,7 @@ export default function UserProfile({
         <img src={avatarUrl} alt={`${name}님의 프로필 이미지`} />
       </div>
       {showInfo && (
-        <div className={styles.info}>
+        <div className={styles.info} style={{ fontSize }}>
           <span>@{username}</span>
           <span className={styles.name}>{name}</span>
         </div>

--- a/src/app/_component/user/UserProfileModal.module.scss
+++ b/src/app/_component/user/UserProfileModal.module.scss
@@ -23,10 +23,6 @@ $modal_padding: 1rem;
 
     .header {
       width: 100%;
-
-      & > div {
-        justify-content: flex-start;
-      }
     }
 
     .divide {

--- a/src/app/hooks/useIsMobile.tsx
+++ b/src/app/hooks/useIsMobile.tsx
@@ -1,0 +1,24 @@
+import { useLayoutEffect, useState } from 'react';
+import { debounce } from 'lodash-es';
+
+export default function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  const MOBILE_MAX_WIDTH = 601;
+
+  useLayoutEffect(() => {
+    const updateSize = () => {
+      setIsMobile(window.innerWidth < MOBILE_MAX_WIDTH);
+    };
+
+    updateSize();
+
+    const debouncedUpdateSize = debounce(updateSize, 250);
+    window.addEventListener('resize', debouncedUpdateSize);
+
+    return () => {
+      window.removeEventListener('resize', debouncedUpdateSize);
+    };
+  }, []);
+
+  return isMobile;
+}

--- a/src/app/styles/globals.scss
+++ b/src/app/styles/globals.scss
@@ -71,7 +71,7 @@ button {
   right: 0;
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.5);
-  z-index: 90;
+  z-index: 99;
 }
 
 /* ===== Scrollbar CSS ===== */

--- a/src/shared/constants/sitemap.ts
+++ b/src/shared/constants/sitemap.ts
@@ -1,7 +1,17 @@
+import {
+  PiChurch,
+  PiNewspaperClipping,
+  PiWechatLogo,
+  PiImages,
+  PiSignIn,
+  PiUserCircle
+} from 'react-icons/pi';
+
 export const sitemap = [
   {
     path: '/about',
     label: '교회소개',
+    icon: PiChurch,
     subPath: [
       { path: '/about/#serving_people', label: '섬기는 이' },
       { path: '/about/#worship_info', label: '예배안내' },
@@ -12,14 +22,15 @@ export const sitemap = [
   {
     path: '/news',
     label: '교회소식',
+    icon: PiNewspaperClipping,
     subPath: [
       { path: '/news/announcement', label: '공지사항' },
       { path: '/news/bulletin', label: '주보' }
     ],
     show: true
   },
-  { path: '/fellowship', label: '교제', show: true },
-  { path: '/gallery', label: '동남앨범', show: true },
-  { path: '/login', label: '로그인', show: false },
-  { path: '/mypage', label: '마이페이지', show: false }
+  { path: '/fellowship', label: '교제', icon: PiWechatLogo, show: true },
+  { path: '/gallery', label: '동남앨범', icon: PiImages, show: true },
+  { path: '/login', label: '로그인', icon: PiSignIn, show: false },
+  { path: '/mypage', label: '마이페이지', icon: PiUserCircle, show: false }
 ];

--- a/src/shared/types/types.ts
+++ b/src/shared/types/types.ts
@@ -1,0 +1,21 @@
+import { User } from '@supabase/supabase-js';
+
+export type UserProps = UserWithCustomMetadata | null;
+
+export type UserWithCustomMetadata = Omit<User, 'user_metadata'> & {
+  user_metadata: UserMetadata;
+};
+
+export type UserMetadata = {
+  avatar_url: string;
+  email: string;
+  email_verified: boolean;
+  full_name: string;
+  iss: string;
+  name: string;
+  phone_verified: boolean;
+  preferred_username: string;
+  provider_id: string;
+  sub: string;
+  user_name: string;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,6 +462,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash-es@^4.17.12":
+  version "4.17.12"
+  resolved "https://registry.yarnpkg.com/@types/lodash-es/-/lodash-es-4.17.12.tgz#65f6d1e5f80539aa7cfbfc962de5def0cf4f341b"
+  integrity sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.13.tgz#786e2d67cfd95e32862143abe7463a7f90c300eb"
+  integrity sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==
+
 "@types/node@*":
   version "22.9.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
@@ -2012,6 +2024,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.merge@^4.6.2:
   version "4.6.2"


### PR DESCRIPTION
## 작업 내용
- useIsMobile 모바일 감지 커스텀 훅 로직 수정
  - 성능 개선을 위해 `lodash-es` 라이브러리 설치 후 debounce 함수 사용
- 모바일 기기에서의 사이드바 Navigation Drawer 구현
  - 사이드바 외부 클릭 시 모달 닫히기
  - 로그인 여부에 따른 UI 변경
  - 사이드바의 네비게이션을 통해 페이지 이동

## 작업 결과

| 로그인 | 로그아웃 | 메뉴 이동 |
|--|--|--|
| ![스크린 캡처_20241212_160026-min](https://github.com/user-attachments/assets/48fe4bf5-f11a-40bf-b4e7-805f3eeccc28) | ![스크린 캡처_20241212_160136-min](https://github.com/user-attachments/assets/426322bf-177f-43d9-ad41-f105c4f7d4f8) |  ![스크린 캡처_20241212_160226-min](https://github.com/user-attachments/assets/e0fdb87b-b0d9-4a46-a396-6604a23e27f7)| 


## 앞으로 할 작업
- 교회소식 공지사항 게시판 구현
