### PR TITLE
Feat: 주보 수정 페이지 - Storage, Table 수정

### DIFF
--- a/src/actions/bulletin/bulletin.action.ts
+++ b/src/actions/bulletin/bulletin.action.ts
@@ -1,9 +1,9 @@
 'use server';
 
 import { redirect, RedirectType } from 'next/navigation';
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import { createServerSideClient } from '@/shared/supabase/server';
-import { uploadFileAction } from '../file.action';
+import { updateFileAction, uploadFileAction } from '../file.action';
 import { getUrlsFromApiResponse } from '@/shared/util/file';
 import type { ImageFileData } from '@/shared/types/types';
 
@@ -51,4 +51,63 @@ export const createBulletinAction = async (
   revalidatePath('/news');
   revalidatePath('/news/bulletin');
   redirect('/news/bulletin', RedirectType.push);
+};
+
+export const updateBulletinAction = async (
+  selectedFiles: ImageFileData[],
+  state: { status: boolean; payload?: FormData; error?: string } | null | undefined,
+  formData: FormData
+) => {
+  const bulletinId = formData.get('bulletin_id')?.toString();
+  const title = formData.get('title')?.toString().trim();
+  const isDisabled = formData.get('is_disabled');
+  let imagefileUrls = [] as string[];
+  const updatedObject = {} as UpdateObject;
+
+  if (isDisabled) {
+    return {
+      status: false,
+      error: '변경된 내역이 없습니다.'
+    };
+  }
+
+  if (selectedFiles.length > 0) {
+    const uploadPromises = selectedFiles.map((file) => updateFileAction(file));
+    const uploadResults = await Promise.all(uploadPromises);
+    imagefileUrls = getUrlsFromApiResponse(uploadResults);
+
+    updatedObject.image_url = imagefileUrls;
+  }
+
+  if (title) {
+    updatedObject.title = title;
+  }
+
+  try {
+    const supabase = await createServerSideClient({});
+    const { error } = await supabase
+      .from('bulletin')
+      .update({ ...updatedObject })
+      .eq('id', Number(bulletinId))
+      .select();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  } catch (error) {
+    console.error(error);
+    return {
+      status: false,
+      error: `주보 생성에 실패했습니다: ${error}`
+    };
+  }
+
+  revalidateTag('bulletin');
+  revalidatePath('/news/bulletin');
+  redirect(`/news/bulletin/${bulletinId}`, RedirectType.push);
+};
+
+type UpdateObject = {
+  title?: string;
+  image_url?: string[];
 };

--- a/src/actions/file.action.ts
+++ b/src/actions/file.action.ts
@@ -35,3 +35,35 @@ export const uploadFileAction = async (file: ImageFileData) => {
     };
   }
 };
+
+export const updateFileAction = async (file: ImageFileData) => {
+  const filename = extractNumbersFromString(file.filename);
+  const fileimage = file.fileimage as string;
+  const base64 = fileimage.split('base64,')[1];
+  const buffer = decode(base64);
+
+  try {
+    const supabase = await createServerSideClient({});
+    const { data, error } = await supabase.storage.from('bulletin').update(filename, buffer, {
+      contentType: file.filetype,
+      cacheControl: '3600'
+    });
+
+    if (error) {
+      console.error(error);
+    }
+
+    return {
+      status: true,
+      data: {
+        url: `${process.env.NEXT_PUBLIC_SUPABASE_URL}/storage/v1/object/public/${data?.fullPath}`
+      },
+      error: ''
+    };
+  } catch (error) {
+    return {
+      status: false,
+      error: `파일 업로드에 실패했습니다: ${error}`
+    };
+  }
+};

--- a/src/apis/bulletin.ts
+++ b/src/apis/bulletin.ts
@@ -4,7 +4,10 @@ import { BulletinType } from '@/shared/types/types';
 import { convertYearToTimestamptz } from '@/shared/util/time';
 
 export const getLatestBulletin = async () => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'last-bulletin' });
+  const supabase = await createServerSideClient({
+    cache: 'force-cache',
+    tag: ['last-bulletin', 'bulletin']
+  });
   const { data: bulletin } = await supabase
     .from('bulletin')
     .select('*')
@@ -14,8 +17,11 @@ export const getLatestBulletin = async () => {
   return { latestBulletin: bulletin ? bulletin[0] : null };
 };
 
-export const getBulletinsById = async (id: string) => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: `bulletin-${id}` });
+export const getBulletinsById = async (id: string): Promise<BulletinWithUserName | null> => {
+  const supabase = await createServerSideClient({
+    cache: 'force-cache',
+    tag: [`bulletin-${id}`, 'bulletin']
+  });
   const { data: bulletin } = await supabase
     .from('bulletin')
     .select(`*, profiles ( user_name )`)
@@ -26,7 +32,7 @@ export const getBulletinsById = async (id: string) => {
 };
 
 export const getBulletin = async () => {
-  const supabase = await createServerSideClient({ cache: 'force-cache' });
+  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
   const {
     data: bulletins,
     count,
@@ -42,8 +48,8 @@ export const getBulletin = async () => {
   return { bulletins, count };
 };
 
-export const getBulletinByYearAndPage = async (page = '1', year = '2024') => {
-  const supabase = await createServerSideClient({ cache: 'force-cache' });
+export const getBulletinByYearAndPage = async (page = '1', year = '2025') => {
+  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
   const startDateTime = convertYearToTimestamptz(year);
   const endDateTime = convertYearToTimestamptz(Number(year) + 1);
 
@@ -67,7 +73,7 @@ export const getBulletinByYearAndPage = async (page = '1', year = '2024') => {
 };
 
 export const getBulletinByYear = async (year = '2024') => {
-  const supabase = await createServerSideClient({ cache: 'force-cache' });
+  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
   const startDateTime = convertYearToTimestamptz(year);
   const endDateTime = convertYearToTimestamptz(Number(year) + 1);
 
@@ -89,7 +95,7 @@ export const getBulletinByYear = async (year = '2024') => {
 };
 
 export const getBulletinByPage = async (page = '1') => {
-  const supabase = await createServerSideClient({ cache: 'force-cache' });
+  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
   const from = (Number(page) - 1) * ITEM_PER_PAGE;
   const to = from + ITEM_PER_PAGE - 1;
 
@@ -156,4 +162,4 @@ type BulletinRuternType = Promise<{
   count: number | null;
 }>;
 
-type BulletinWithUserName = BulletinType & { profiles: { user_name: string } };
+export type BulletinWithUserName = BulletinType & { profiles: { user_name: string } };

--- a/src/app/(with-navbar)/news/bulletin/[id]/page.tsx
+++ b/src/app/(with-navbar)/news/bulletin/[id]/page.tsx
@@ -38,6 +38,8 @@ export default async function BulletinDetail({ params }: { params: Promise<{ id:
         userId={user_id}
         thumbnail={image_url[0]}
         id={id.toString()}
+        updateLink={`/news/bulletin/${id}/update`}
+        onDelete={() => null}
       />
       <BoardBody>
         {image_url.map((url) => (

--- a/src/app/(with-navbar)/news/bulletin/[id]/update/page.tsx
+++ b/src/app/(with-navbar)/news/bulletin/[id]/update/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useActionState, useEffect, useState } from 'react';
+import { useProfile } from '@/context/SessionContextProvider';
+import MainContainer from '@/app/_component/layout/common/MainContainer';
+import FileUpload from '../../_component/create/FileUpload';
+import FilePreview from '../../_component/create/FilePreview';
+import { supabase } from '@/shared/supabase/client';
+import { updateBulletinAction } from '@/actions/bulletin/bulletin.action';
+import { convertFileToImageData, convertUrlToImageData } from '@/shared/util/file';
+import { BulletinWithUserName } from '@/apis/bulletin';
+import type { ImageFileData } from '@/shared/types/types';
+import styles from '../../create/page.module.scss';
+
+export default function UpdateBulletin() {
+  const { id: bulletinId } = useParams<{ id: string }>();
+  const user = useProfile();
+
+  const [bulletin, setBulletin] = useState<BulletinWithUserName | null>(null);
+  const [title, setTitle] = useState('');
+  const [uploadedFiles, setUploadedFiles] = useState<ImageFileData[]>([]);
+  const [selectedFiles, setSelectedFiles] = useState<ImageFileData[]>([]);
+  const [actionState, formAction, isPending] = useActionState(
+    updateBulletinAction.bind(null, selectedFiles),
+    null
+  );
+  const isDisabled = bulletin?.title === title && selectedFiles.length === 0;
+
+  const handleInputChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files === null) return;
+
+    const files = Array.from(e.target.files);
+    const imageFiles = files.filter((file) => file.type.startsWith('image/'));
+
+    if (imageFiles.length < files.length) {
+      window.alert('이미지 파일만 첨부해주세요.');
+    }
+
+    const imagePromises = Array.from(imageFiles).map(convertFileToImageData);
+    const imageData = await Promise.all(imagePromises);
+
+    setSelectedFiles((prev) => [...prev, ...imageData]);
+  };
+
+  const handleDeleteSelectedFile = (id: number) => {
+    if (window.confirm('정말로 삭제하시겠습니까?')) {
+      const result = selectedFiles.filter((data) => data.id !== id);
+      setSelectedFiles(result);
+    }
+  };
+
+  useEffect(() => {
+    const fetchBulletin = async (id: string) => {
+      const { data } = await supabase
+        .from('bulletin')
+        .select(`*, profiles ( user_name )`)
+        .eq('id', id)
+        .single();
+
+      if (!data) {
+        setUploadedFiles([]);
+        setBulletin(null);
+        return;
+      }
+
+      const imageFiles = data?.image_url.map(convertUrlToImageData);
+      const imageData = await Promise.all(imageFiles);
+      setUploadedFiles(imageData);
+      setBulletin(data as unknown as BulletinWithUserName | null);
+      setTitle(data.title);
+    };
+
+    fetchBulletin(bulletinId);
+  }, [bulletinId]);
+
+  useEffect(() => {
+    if (actionState?.error) {
+      window.alert(actionState?.error);
+    }
+  }, [actionState?.error]);
+
+  if (!user) return null;
+
+  return (
+    <MainContainer title="주보 수정하기">
+      <form action={formAction} className={styles.form}>
+        <div className={styles.group}>
+          <label htmlFor="title">제목</label>
+          <input
+            type="text"
+            name="title"
+            placeholder="제목을 입력해주세요 (2025년 1월 5일 첫째 주)"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+        </div>
+        <div className={styles.group}>
+          <label htmlFor="image_url">주보 이미지 업로드</label>
+          <FileUpload onChange={handleInputChange} />
+        </div>
+        <div className={styles.image_preview}>
+          <label>미리보기 (수정 전)</label>
+          <FilePreview files={uploadedFiles} />
+        </div>
+        {selectedFiles.length > 0 && (
+          <div className={styles.image_preview}>
+            <label>미리보기 (수정 후)</label>
+            <FilePreview files={selectedFiles} onDelete={handleDeleteSelectedFile} />
+          </div>
+        )}
+        <input name="bulletin_id" value={bulletinId} hidden readOnly />
+        <input name="is_disabled" type="checkbox" checked={isDisabled} hidden readOnly />
+        <div className={styles.submit}>
+          <button disabled={isPending} className={styles.submit_btn}>
+            수정하기
+          </button>
+        </div>
+      </form>
+    </MainContainer>
+  );
+}

--- a/src/app/(with-navbar)/news/bulletin/_component/BulletinYearFilter.tsx
+++ b/src/app/(with-navbar)/news/bulletin/_component/BulletinYearFilter.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import styles from './BulletinYearFilter.module.scss';
 
-const START_YEAR = 2024;
+const START_YEAR = 2025;
 const currentYear = new Date().getFullYear();
 
 type BulletinYearFilterProps = {

--- a/src/app/(with-navbar)/news/bulletin/_component/create/FilePreview.tsx
+++ b/src/app/(with-navbar)/news/bulletin/_component/create/FilePreview.tsx
@@ -3,7 +3,7 @@ import styles from './FilePreview.module.scss';
 
 type FilePreviewProps = {
   files: ImageFileData[];
-  onDelete: (id: number) => void;
+  onDelete?: (id: number) => void;
 };
 
 export default function FilePreview({ files, onDelete }: FilePreviewProps) {
@@ -25,9 +25,11 @@ export default function FilePreview({ files, onDelete }: FilePreviewProps) {
                 <span>크기 : {filesize}</span>
                 <span>수정한 날짜 : {datetime}</span>
               </p>
-              <button type="button" onClick={() => onDelete(id)}>
-                삭제
-              </button>
+              {onDelete && (
+                <button type="button" onClick={() => onDelete(id)}>
+                  삭제
+                </button>
+              )}
             </div>
           </div>
         );

--- a/src/app/(with-navbar)/news/bulletin/create/page.module.scss
+++ b/src/app/(with-navbar)/news/bulletin/create/page.module.scss
@@ -26,3 +26,23 @@
     font-size: 1.4rem;
   }
 }
+
+.image_preview {
+  label {
+    margin-bottom: 0.6rem;
+    display: inline-block;
+    font-size: 1.6rem;
+    font-weight: 600;
+  }
+}
+
+.submit {
+  text-align: right;
+
+  .submit_btn {
+    padding: 0.8rem 1rem;
+    width: 10rem;
+    border: 1px solid black;
+    border-radius: 0.4rem;
+  }
+}

--- a/src/app/(with-navbar)/news/bulletin/create/page.tsx
+++ b/src/app/(with-navbar)/news/bulletin/create/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useActionState, useState } from 'react';
+import { useActionState, useEffect, useState } from 'react';
 import { createBulletinAction } from '@/actions/bulletin/bulletin.action';
 import { useProfile } from '@/context/SessionContextProvider';
 import MainContainer from '@/app/_component/layout/common/MainContainer';
@@ -41,11 +41,13 @@ export default function Page() {
     }
   };
 
-  if (!user) return null;
+  useEffect(() => {
+    if (actionState?.error) {
+      window.alert(actionState?.error);
+    }
+  }, [actionState?.error]);
 
-  if (actionState?.error) {
-    window.alert(actionState?.error);
-  }
+  if (!user) return null;
 
   return (
     <MainContainer title="주보 추가하기">

--- a/src/app/_component/auth/UserIdMatcher.tsx
+++ b/src/app/_component/auth/UserIdMatcher.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useProfile } from '@/context/SessionContextProvider';
+
+export default function UserIdMatcher({
+  userId,
+  children
+}: {
+  userId: string;
+  children: React.ReactNode;
+}) {
+  const profile = useProfile();
+
+  if (!profile || profile.id !== userId) return null;
+
+  return <>{children}</>;
+}

--- a/src/app/_component/board/BoardFooter.module.scss
+++ b/src/app/_component/board/BoardFooter.module.scss
@@ -15,7 +15,6 @@
   dd {
     display: flex;
     align-items: center;
-    text-decoration: underline;
     font-size: 1.2rem;
     word-break: break-all;
 
@@ -23,6 +22,10 @@
       margin-right: 0.6rem;
       width: 1.5rem;
       height: 1.5rem;
+    }
+
+    a:hover {
+      @include link-hover-style;
     }
   }
 

--- a/src/app/_component/board/BoardHeader.tsx
+++ b/src/app/_component/board/BoardHeader.tsx
@@ -1,14 +1,18 @@
-import { formattedDate } from '@/shared/util/date';
+import Link from 'next/link';
 import { FiTrash, FiEdit } from 'react-icons/fi';
-import styles from './BoardHeader.module.scss';
 import KakaoShareBtn from '../common/KakaoShare';
+import UserIdMatcher from '../auth/UserIdMatcher';
+import { formattedDate } from '@/shared/util/date';
+import styles from './BoardHeader.module.scss';
 
 export default async function BoardHeader({
   title,
   userName,
   createdAt,
   userId,
-  thumbnail
+  thumbnail,
+  updateLink = '/'
+  // onDelete
 }: BoardHeaderProps) {
   return (
     <div className={styles.header}>
@@ -30,12 +34,16 @@ export default async function BoardHeader({
           <ul>
             {userId && (
               <>
-                <li>
-                  <FiTrash />
-                </li>
-                <li>
-                  <FiEdit />
-                </li>
+                <UserIdMatcher userId={userId}>
+                  <li>
+                    <FiTrash />
+                  </li>
+                  <li>
+                    <Link href={updateLink}>
+                      <FiEdit />
+                    </Link>
+                  </li>
+                </UserIdMatcher>
               </>
             )}
             <li>
@@ -60,4 +68,6 @@ type BoardHeaderProps = {
   createdAt: string;
   userId: string;
   thumbnail: string;
+  updateLink: string;
+  onDelete: () => void;
 };

--- a/src/app/styles/_mixins.scss
+++ b/src/app/styles/_mixins.scss
@@ -24,3 +24,8 @@
   white-space: nowrap;
   word-wrap: normal;
 }
+
+@mixin link-hover-style {
+  text-decoration: underline;
+  color: #1f5da9;
+}

--- a/src/shared/supabase/server.ts
+++ b/src/shared/supabase/server.ts
@@ -17,7 +17,7 @@ export const createServerSideClient = async ({
   tag
 }: {
   cache?: RequestCache;
-  tag?: string;
+  tag?: string | string[];
 }) => {
   const cookieStore = await cookies();
 
@@ -28,7 +28,7 @@ export const createServerSideClient = async ({
       global: {
         fetch: createFetch({
           next: {
-            tags: [tag || 'supabase']
+            tags: [...(tag || 'supabase')]
           },
           cache
         })

--- a/src/shared/util/file.ts
+++ b/src/shared/util/file.ts
@@ -45,9 +45,14 @@ export function convertFileToImageData(file: File): Promise<ImageFileData> {
   });
 }
 
-export const convertUrltoImageData = async (url: string) => {
+export const convertUrlToImageData = async (url: string) => {
   const res = await fetch(url);
   const data = await res.blob();
-  const file = new File([data], getFilenameFromUrl(url), { type: data.type });
+  const lastModified = res.headers.get('last-modified')!;
+  const file = new File([data], getFilenameFromUrl(url), {
+    type: data.type,
+    lastModified: new Date(lastModified).getTime()
+  });
+
   return convertFileToImageData(file);
 };

--- a/src/shared/util/file.ts
+++ b/src/shared/util/file.ts
@@ -44,3 +44,10 @@ export function convertFileToImageData(file: File): Promise<ImageFileData> {
     reader.readAsDataURL(file);
   });
 }
+
+export const convertUrltoImageData = async (url: string) => {
+  const res = await fetch(url);
+  const data = await res.blob();
+  const file = new File([data], getFilenameFromUrl(url), { type: data.type });
+  return convertFileToImageData(file);
+};


### PR DESCRIPTION
## 작업 내용
- 현재 사용자와 글쓴이의 user_id를 비교하여 수정/삭제 활성화 여부 적용
- 이미지 URL에서 이미지 데이터로 변경할 때 이미지의 마지막으로 수정된 시간 설정 (기존에는 현재 시간으로 출력)
  - header의 last-modified 속성 활용
- 주보 생성 업로드 실패시 오류 메시지가 반복되어 출력되어 이를 sideeffect를 처리하는 useEffect에서 처리
```tsx
// BEFORE
if (actionState?.error) {
  window.alert(actionState?.error);
}

// AFTER
useEffect(() => {
  if (actionState?.error) {
    window.alert(actionState?.error);
  }
}, [actionState?.error]);
```
- 캐시 무효화를 위한 tag 추가
  - 여러 tag를 지정할 수 있도록 tag의 타입 변경 `string` -> `string | string[]`
- 주보 수정 폼을 제출했을 때 서버 액션 로직 구현
  - Storage 업데이트, Table 업데이트
## 작업 결과
![스크린 캡처_20250310_042952](https://github.com/user-attachments/assets/80fbda55-f96c-4250-9a73-f08d54517e15)


## 앞으로 할 작업
- 캐시 무효화 미적용 개선
- 이미지가 Storage에 업로드 되어 수정되었음에도 이전 이미지가 보여짐 (개발 환경에서 강력 새로고침하면 이미지가 업데이트 됨)
