### PR TITLE
Chore: 주보 업데이트 서버 액션의 server client의 cacheControl 값을 0으로 설정

### DIFF
--- a/src/actions/file.action.ts
+++ b/src/actions/file.action.ts
@@ -13,8 +13,7 @@ export const uploadFileAction = async (file: ImageFileData) => {
   try {
     const supabase = await createServerSideClient({});
     const { data, error } = await supabase.storage.from('bulletin').upload(filename, buffer, {
-      contentType: file.filetype,
-      cacheControl: '3600'
+      contentType: file.filetype
     });
 
     if (error) {
@@ -46,7 +45,7 @@ export const updateFileAction = async (file: ImageFileData) => {
     const supabase = await createServerSideClient({});
     const { data, error } = await supabase.storage.from('bulletin').update(filename, buffer, {
       contentType: file.filetype,
-      cacheControl: '3600'
+      cacheControl: '0'
     });
 
     if (error) {


### PR DESCRIPTION
## 작업 내용

- 문제: 주보 이미지 Storage 업데이트 이후에도 이미지가 기존의 이미지로 출력되는 현상
- 이유: 이미지 CDN 
- 해결: cacheControl 값을 0으로 설정

[참고](https://www.restack.io/docs/supabase-knowledge-supabase-cache-control)