### PR TITLE
Style: 텍스트 간격 및 기본 폰트 크기, 레이아웃 간격 수정

### DIFF
--- a/src/app/_component/home/AboutOurChurch.module.scss
+++ b/src/app/_component/home/AboutOurChurch.module.scss
@@ -20,8 +20,8 @@
 
   .frame {
     display: inline-flex;
+    align-items: center;
     position: relative;
-    background-color: $color-white;
     overflow: hidden;
   }
 
@@ -57,7 +57,7 @@
   }
 
   h2 {
-    margin-bottom: $spacing-md;
+    margin-bottom: $spacing-lg;
   }
 
   .about_content {
@@ -67,6 +67,7 @@
 
     p {
       letter-spacing: -0.05rem;
+      line-height: $line-height-wide;
 
       @include respond-up($breakpoint-md) {
         font-size: $font-size-medium;

--- a/src/app/_component/home/AboutOurChurch.tsx
+++ b/src/app/_component/home/AboutOurChurch.tsx
@@ -18,7 +18,7 @@ export default async function AboutOurChurch() {
           </div>
           <div className={styles.about_info}>
             <span>바른 신학, 바른 교회, 바른 생활</span>
-            <h2>우리 교회를 소개합니다</h2>
+            <h2>동남교회를 소개합니다</h2>
             <div className={styles.about_content}>
               <p>
                 동남교회는 대한예수교장로회(합신) 교단 소속으로, 오직 성경만을 유일한 규칙으로 삼는
@@ -27,11 +27,11 @@ export default async function AboutOurChurch() {
               </p>
               <p>
                 바른 신학의 토대 위에서 바른 교회, 바른 생활의 정신을 실천합니다. 그리스도께서
-                모범을 보이신 것처럼, 모든 성도가 겸손한 섬김의 자세로 서로를 존중하며 사랑 안에서
+                모범을 보이신 것처럼 모든 성도가 겸손한 섬김의 자세로 서로를 존중하며 사랑 안에서
                 굳건히 연합하는 공동체를 지향합니다.
               </p>
             </div>
-            <Link href="/about">자세히 알아보기</Link>
+            <Link href="/about">교회소개 살펴보기</Link>
           </div>
         </div>
       </LayoutContainer>

--- a/src/app/_component/home/Banner.module.scss
+++ b/src/app/_component/home/Banner.module.scss
@@ -8,7 +8,7 @@ $banner-image-url: 'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/p
   background-image: var(--banner-gradient), url($banner-image-url);
   background-position:
     0 0,
-    40% top;
+    45% top;
   background-size: auto, cover;
   background-repeat: repeat, no-repeat;
   z-index: 1;
@@ -16,7 +16,7 @@ $banner-image-url: 'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/p
   .content {
     display: flex;
     flex-direction: column;
-    gap: $spacing-xs;
+    gap: $spacing-sm;
   }
 
   h1 {
@@ -31,7 +31,7 @@ $banner-image-url: 'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/p
   }
 
   .learn_more {
-    padding: $spacing-xs $spacing-xl;
+    padding: $spacing-sm $spacing-xl;
     margin-top: $spacing-xs;
     display: inline-block;
     width: fit-content;
@@ -47,12 +47,12 @@ $banner-image-url: 'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/p
     }
   }
 
-  @include respond-up($breakpoint-lg) {
+  @include respond-up($breakpoint-md) {
     --banner-gradient: #{$desktop-gradient};
     padding: $spacing-layout 0;
     background-position:
       0 0,
-      0 10%;
+      50% 10%;
   }
 }
 

--- a/src/app/_component/home/Banner.tsx
+++ b/src/app/_component/home/Banner.tsx
@@ -19,7 +19,7 @@ export default async function Banner() {
               마음의 짐을 내려놓고 참된 안식을 누리세요.
             </p>
             <Link href="/about" className={styles.learn_more}>
-              자세히 보기
+              처음 오셨나요?
             </Link>
           </div>
         </LayoutContainer>

--- a/src/app/_component/home/ChurchVision.module.scss
+++ b/src/app/_component/home/ChurchVision.module.scss
@@ -38,16 +38,15 @@
     flex-direction: column;
     align-items: center;
     gap: $spacing-xs;
-    max-width: 90%;
     border-radius: $border-radius-lg;
 
     h3 {
       font-size: $font-size-h5-mobile;
     }
 
-    @include respond-up($breakpoint-md) {
+    @include respond-up($breakpoint-sm) {
       padding: $spacing-xl $spacing-xs;
-      max-width: 58%;
+      max-width: 75%;
 
       h3 {
         font-size: $font-size-h5;

--- a/src/app/_component/layout/header/index.module.scss
+++ b/src/app/_component/layout/header/index.module.scss
@@ -8,7 +8,6 @@
 }
 
 .header_wrap {
-  padding: $spacing-lg 0;
   position: relative;
   display: flex;
   justify-content: space-between;

--- a/src/app/styles/globals.scss
+++ b/src/app/styles/globals.scss
@@ -9,7 +9,6 @@ body {
   font-family: $font-family-base;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  font-size: $font-size-body;
   letter-spacing: $letter-spacing-base;
   line-height: $line-height-base;
   color: $color-text-default;
@@ -46,22 +45,13 @@ p,
 ul,
 ol,
 blockquote {
-  font-size: $font-size-default;
+  font-size: $font-size-medium;
   word-break: keep-all;
-}
-
-@include respond($breakpoint-md) {
-  p,
-  ul,
-  ol,
-  blockquote {
-    font-size: $font-size-medium;
-  }
 }
 
 a {
   text-decoration: none;
-  font-size: $font-size-medium;
+  font-size: $font-size-small;
 }
 
 ul,
@@ -72,7 +62,7 @@ li {
 button {
   border: none;
   background: none;
-  font-size: $font-size-medium;
+  font-size: $font-size-small;
   cursor: pointer;
 }
 
@@ -105,7 +95,7 @@ button {
 .hidden-on-mobile {
   display: none;
 
-  @include respond-up($breakpoint-md) {
+  @include respond-up($breakpoint-sm) {
     display: inline-block;
   }
 }

--- a/src/app/styles/tokens/_layout.scss
+++ b/src/app/styles/tokens/_layout.scss
@@ -1,5 +1,5 @@
 $max-width: 100rem;
-$header-height: 5rem;
+$header-height: 6rem;
 
 // Button
 $button-height-sm: 2.25rem;

--- a/src/app/styles/tokens/_typography.scss
+++ b/src/app/styles/tokens/_typography.scss
@@ -20,12 +20,11 @@ $letter-spacing-tight: -0.1rem;
 $letter-spacing-base: -0.05rem;
 
 // Base Text Size
-$font-size-body: calc(1rem + 0.25vw);
-$font-size-default: 1.6rem;
-$font-size-medium: 1.4rem;
 $font-size-large: 1.8rem;
-$font-size-small: 1.2rem;
-$font-size-caption: 1rem;
+$font-size-default: 1.6rem;
+$font-size-medium: 1.5rem;
+$font-size-small: 1.4rem;
+$font-size-caption: 1.3rem;
 
 // Heading Sizes
 $font-size-h1: 4.2rem;


### PR DESCRIPTION
## 🚀 개요 (Summary)

> 모바일 환경에서 텍스트 가독성 저하 문제를 해결하기 위해 기본 폰트 크기와 줄 간격을 상향 조정하고 레이아웃 여백 수정

## 📌 주요 구현 및 문제 해결 내용

### 텍스트 간격 및 기본 폰트 크기, 레이아웃 간격 수정

**문제 상황**
- 배포된 페이지를 모바일 기기에서 확인했을 때 본문 텍스트가 작아 보기 어려움
- 텍스트의 줄 간격이 좁아 미적으로도 답답한 디자인

**원인:**

- 기존 기본 폰트 크기인 1.4rem가 모바일 뷰포트에서 최종적으로 약 12.4px로 렌더링
- default 행간격이 아니라 넓은 행간격 미지정

**해결 방안**

- 더 나은 사용자 경험을 위해 기본 폰트 크기를 1.4rem에서 1.5rem로 상향 조정 (12.4px -> 13.3px)
- line-height를 1.8로 명시적으로 설정하여 가독성 개선

## Screenshots
| Before Mobile (320px) | After Mobile (320px)
|--|--|
|  <img width="321" height="952" alt="image" src="https://github.com/user-attachments/assets/08f96dfd-b6b4-494b-abcc-aa95747aa1b5" /> | <img width="318" height="1088" alt="image" src="https://github.com/user-attachments/assets/2e5eb8ee-df5e-4626-a68f-7f99216bee33" /> |

| Before PC (1440px) | After PC (1440px)
|--|--|
|  <img width="1440" height="923" alt="image" src="https://github.com/user-attachments/assets/41d13c97-abfb-4cab-954a-797209f1a4e1" /> |  <img width="1440" height="1021" alt="image" src="https://github.com/user-attachments/assets/17a2fd3e-2cb4-426f-a65e-684ec9677cdb" /> |
