### PR TITLE
Feat: 회원 인증 기능 개선 및 비밀번호 재설정 실패 시 자동 로그인 방지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "dnchurch",
       "version": "0.1.0",
       "dependencies": {
-        "@supabase/ssr": "^0.5.1",
-        "@supabase/supabase-js": "^2.46.1",
+        "@supabase/ssr": "^0.8.0",
+        "@supabase/supabase-js": "^2.86.0",
         "@tanstack/react-table": "^8.20.6",
         "base64-arraybuffer": "^1.0.2",
         "clsx": "^2.1.1",
@@ -1643,89 +1643,95 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.65.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.65.1.tgz",
-      "integrity": "sha512-IA7i2Xq2SWNCNMKxwmPlHafBQda0qtnFr8QnyyBr+KaSxoXXqEzFCnQ1dGTy6bsZjVBgXu++o3qrDypTspaAPw==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.86.0.tgz",
+      "integrity": "sha512-3xPqMvBWC6Haqpr6hEWmSUqDq+6SA1BAEdbiaHdAZM9QjZ5uiQJ+6iD9pZOzOa6MVXZh4GmwjhC9ObIG0K1NcA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.3.tgz",
-      "integrity": "sha512-sOLXy+mWRyu4LLv1onYydq+10mNRQ4rzqQxNhbrKLTLTcdcmS9hbWif0bGz/NavmiQfPs4ZcmQJp4WqOXlR4AQ==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.86.0.tgz",
+      "integrity": "sha512-AlOoVfeaq9XGlBFIyXTmb+y+CZzxNO4wWbfgRM6iPpNU5WCXKawtQYSnhivi3UVxS7GA0rWovY4d6cIAxZAojA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.16.3.tgz",
-      "integrity": "sha512-HI6dsbW68AKlOPofUjDTaosiDBCtW4XAm0D18pPwxoW3zKOE2Ru13Z69Wuys9fd6iTpfDViNco5sgrtnP0666A==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.86.0.tgz",
+      "integrity": "sha512-QVf+wIXILcZJ7IhWhWn+ozdf8B+oO0Ulizh2AAPxD/6nQL+x3r9lJ47a+fpc/jvAOGXMbkeW534Kw6jz7e8iIA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.7.tgz",
-      "integrity": "sha512-OLI0hiSAqQSqRpGMTUwoIWo51eUivSYlaNBgxsXZE7PSoWh12wPRdVt0psUMaUzEonSB85K21wGc7W5jHnT6uA==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.86.0.tgz",
+      "integrity": "sha512-dyS8bFoP29R/sj5zLi0AP3JfgG8ar1nuImcz5jxSx7UIW7fbFsXhUCVrSY2Ofo0+Ev6wiATiSdBOzBfWaiFyPA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.14.2"
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/ssr": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.5.1.tgz",
-      "integrity": "sha512-+G94H/GZG0nErZ3FQV9yJmsC5Rj7dmcfCAwOt37hxeR1La+QTl8cE9whzYwPUrTJjMLGNXoO+1BMvVxwBAbz4g==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
+      "integrity": "sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^0.6.0"
+        "cookie": "^1.0.2"
       },
       "peerDependencies": {
-        "@supabase/supabase-js": "^2.43.4"
+        "@supabase/supabase-js": "^2.76.1"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.86.0.tgz",
+      "integrity": "sha512-PM47jX/Mfobdtx7NNpoj9EvlrkapAVTQBZgGGslEXD6NS70EcGjhgRPBItwHdxZPM5GwqQ0cGMN06uhjeY2mHQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.46.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.46.1.tgz",
-      "integrity": "sha512-HiBpd8stf7M6+tlr+/82L8b2QmCjAD8ex9YdSAKU+whB/SHXXJdus1dGlqiH9Umy9ePUuxaYmVkGd9BcvBnNvg==",
+      "version": "2.86.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.86.0.tgz",
+      "integrity": "sha512-BaC9sv5+HGNy1ulZwY8/Ev7EjfYYmWD4fOMw9bDBqTawEj6JHAiOHeTwXLRzVaeSay4p17xYLN2NSCoGgXMQnw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.65.1",
-        "@supabase/functions-js": "2.4.3",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.16.3",
-        "@supabase/realtime-js": "2.10.7",
-        "@supabase/storage-js": "2.7.1"
+        "@supabase/auth-js": "2.86.0",
+        "@supabase/functions-js": "2.86.0",
+        "@supabase/postgrest-js": "2.86.0",
+        "@supabase/realtime-js": "2.86.0",
+        "@supabase/storage-js": "2.86.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -1818,9 +1824,9 @@
       }
     },
     "node_modules/@types/phoenix": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.5.tgz",
-      "integrity": "sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
@@ -1862,9 +1868,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2751,12 +2757,16 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cross-spawn": {
@@ -4212,6 +4222,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.0.tgz",
+      "integrity": "sha512-kmgmea2nguZEvRqW79gDqNXyxA3OS5WIgMVffrHpqXV4F/J4UmNIw2vstixioLTNSkd5rFB8G0s3Lwzogm6OFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -6522,12 +6541,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6765,22 +6778,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7012,9 +7009,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.46.1",
         "@tanstack/react-table": "^8.20.6",
         "base64-arraybuffer": "^1.0.2",
+        "clsx": "^2.1.1",
         "dayjs": "^1.11.13",
         "lodash-es": "^4.17.21",
         "next": "^16.0.3",
@@ -2695,6 +2696,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/cmd-shim": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@supabase/supabase-js": "^2.46.1",
     "@tanstack/react-table": "^8.20.6",
     "base64-arraybuffer": "^1.0.2",
+    "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "lodash-es": "^4.17.21",
     "next": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "generate:types": "supabase gen types typescript --project-id ndimreqwgdiwtjonjjzq --schema public > src/shared/types/database.types.ts"
   },
   "dependencies": {
-    "@supabase/ssr": "^0.5.1",
-    "@supabase/supabase-js": "^2.46.1",
+    "@supabase/ssr": "^0.8.0",
+    "@supabase/supabase-js": "^2.86.0",
     "@tanstack/react-table": "^8.20.6",
     "base64-arraybuffer": "^1.0.2",
     "clsx": "^2.1.1",

--- a/src/actions/bulletin/bulletin.action.ts
+++ b/src/actions/bulletin/bulletin.action.ts
@@ -28,7 +28,7 @@ export const createBulletinAction = async (
   const imagefileUrls = getUrlsFromApiResponse(uploadResults);
 
   try {
-    const supabase = await createServerSideClient({});
+    const supabase = await createServerSideClient();
     const { error } = await supabase
       .from(BULLETIN_BUCKET)
       .insert({
@@ -85,7 +85,7 @@ export const updateBulletinAction = async (
   }
 
   try {
-    const supabase = await createServerSideClient({});
+    const supabase = await createServerSideClient();
     const { error } = await supabase
       .from(BULLETIN_BUCKET)
       .update({ ...updatedObject })

--- a/src/actions/file.action.ts
+++ b/src/actions/file.action.ts
@@ -12,7 +12,7 @@ export const uploadFileAction = async (file: ImageFileData) => {
   const buffer = decode(base64);
 
   try {
-    const supabase = await createServerSideClient({});
+    const supabase = await createServerSideClient();
     const { data, error } = await supabase.storage.from(BULLETIN_BUCKET).upload(filename, buffer, {
       contentType: file.filetype
     });
@@ -43,7 +43,7 @@ export const updateFileAction = async (file: ImageFileData) => {
   const buffer = decode(base64);
 
   try {
-    const supabase = await createServerSideClient({});
+    const supabase = await createServerSideClient();
     const { data, error } = await supabase.storage.from(BULLETIN_BUCKET).update(filename, buffer, {
       contentType: file.filetype
     });

--- a/src/apis/announcement.ts
+++ b/src/apis/announcement.ts
@@ -8,7 +8,7 @@ export type AnnouncementWithProfile = PostType & {
 };
 
 export const getAnnouncement = async () => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'announcement' });
+  const supabase = await createServerSideClient();
   const {
     data: posts,
     count,

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -35,20 +35,23 @@ export async function signInWithPassword({ email, password }: Credentials) {
   return data;
 }
 
-export async function signInWithKakao(nextUrl: string | null) {
-  await supabase.auth.signInWithOAuth({
+export async function signInWithKakao() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const redirectedFrom = searchParams.get('redirect') || '/';
+
+  const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: nextUrl
-        ? `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback?next=${nextUrl}`
-        : `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`
+      redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectedFrom)}`
     }
   });
+
+  if (error) throw error;
+  return data;
 }
 
 export async function signOut() {
   await supabase.auth.signOut();
-  window.location.reload();
 }
 
 export async function requestPasswordResetEmail(email: string) {

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -35,14 +35,11 @@ export async function signInWithPassword({ email, password }: Credentials) {
   return data;
 }
 
-export async function signInWithKakao() {
-  const searchParams = new URLSearchParams(window.location.search);
-  const redirectedFrom = searchParams.get('redirect') || '/';
-
+export async function signInWithKakao(redirect = '/') {
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
-      redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectedFrom)}`
+      redirectTo: `${window.location.origin}/auth/callback?next=${redirect}`
     }
   });
 

--- a/src/apis/bulletin.ts
+++ b/src/apis/bulletin.ts
@@ -4,10 +4,7 @@ import { BulletinType } from '@/shared/types/types';
 import { convertYearToTimestamptz } from '@/shared/util/time';
 
 export const getPrevAndNextBulletin = async (targetId: number) => {
-  const supabase = await createServerSideClient({
-    cache: 'force-cache',
-    tag: ['bulletin', 'prev-next']
-  });
+  const supabase = await createServerSideClient();
 
   const { data, error } = await supabase
     .rpc(
@@ -25,10 +22,7 @@ export const getPrevAndNextBulletin = async (targetId: number) => {
 };
 
 export const getLatestBulletin = async () => {
-  const supabase = await createServerSideClient({
-    cache: 'force-cache',
-    tag: ['last-bulletin', 'bulletin']
-  });
+  const supabase = await createServerSideClient();
   const { data: bulletin } = await supabase
     .from(BULLETIN_BUCKET)
     .select('*')
@@ -39,21 +33,18 @@ export const getLatestBulletin = async () => {
 };
 
 export const getBulletinsById = async (id: string): Promise<BulletinWithUserName | null> => {
-  const supabase = await createServerSideClient({
-    cache: 'force-cache',
-    tag: [`bulletin-${id}`, 'bulletin']
-  });
+  const supabase = await createServerSideClient();
   const { data: bulletin } = await supabase
     .from(BULLETIN_BUCKET)
     .select(`*, profiles ( user_name )`)
-    .eq('id', id)
+    .eq('id', Number(id))
     .single();
 
   return bulletin as BulletinWithUserName | null;
 };
 
 export const getBulletin = async () => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
+  const supabase = await createServerSideClient();
   const {
     data: bulletins,
     count,
@@ -70,7 +61,7 @@ export const getBulletin = async () => {
 };
 
 export const getBulletinByYearAndPage = async (page = '1', year = '2025') => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
+  const supabase = await createServerSideClient();
   const startDateTime = convertYearToTimestamptz(year);
   const endDateTime = convertYearToTimestamptz(Number(year) + 1);
 
@@ -94,7 +85,7 @@ export const getBulletinByYearAndPage = async (page = '1', year = '2025') => {
 };
 
 export const getBulletinByYear = async (year = '2024') => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
+  const supabase = await createServerSideClient();
   const startDateTime = convertYearToTimestamptz(year);
   const endDateTime = convertYearToTimestamptz(Number(year) + 1);
 
@@ -116,7 +107,7 @@ export const getBulletinByYear = async (year = '2024') => {
 };
 
 export const getBulletinByPage = async (page = '1') => {
-  const supabase = await createServerSideClient({ cache: 'force-cache', tag: 'bulletin' });
+  const supabase = await createServerSideClient();
   const from = (Number(page) - 1) * ITEM_PER_PAGE;
   const to = from + ITEM_PER_PAGE - 1;
 

--- a/src/apis/home.ts
+++ b/src/apis/home.ts
@@ -2,7 +2,7 @@ import { createServerSideClient } from '@/shared/supabase/server';
 import { STORAGE_NAME } from '@/shared/constants/supabase';
 
 export const getStorageImageUrl = async (filename: string) => {
-  const supabase = await createServerSideClient({});
+  const supabase = await createServerSideClient();
   const {
     data: { publicUrl: imageUrl }
   } = supabase.storage.from(STORAGE_NAME.home).getPublicUrl(filename);

--- a/src/apis/user.action.ts
+++ b/src/apis/user.action.ts
@@ -2,7 +2,7 @@ import { createServerSideClient } from '@/shared/supabase/server';
 import { UserProps } from '@/shared/types/types';
 
 export const getCurrentUser = async (): Promise<UserProps> => {
-  const supabase = await createServerSideClient({});
+  const supabase = await createServerSideClient();
   const { data } = await supabase.auth.getUser();
 
   return data.user as UserProps;
@@ -10,7 +10,7 @@ export const getCurrentUser = async (): Promise<UserProps> => {
 
 export const getUserAdminStatus = async (userId: string | undefined): Promise<boolean> => {
   if (!userId) return false;
-  const supabase = await createServerSideClient({});
+  const supabase = await createServerSideClient();
   const { data } = await supabase.from('profiles').select('is_admin').eq('id', userId).single();
 
   return data?.is_admin || false;

--- a/src/app/(with-navbar)/news/bulletin/[id]/update/page.tsx
+++ b/src/app/(with-navbar)/news/bulletin/[id]/update/page.tsx
@@ -63,7 +63,7 @@ export default function UpdateBulletin() {
       const { data } = await supabase
         .from(BULLETIN_BUCKET)
         .select(`*, profiles ( user_name )`)
-        .eq('id', id)
+        .eq('id', Number(id))
         .single();
 
       if (!data) {

--- a/src/app/_component/auth/AuthSubmitBtn.module.scss
+++ b/src/app/_component/auth/AuthSubmitBtn.module.scss
@@ -1,25 +1,3 @@
-.input_group {
-  margin-bottom: $spacing-sm;
-
-  label {
-    @include blind;
-  }
-
-  input {
-    padding: $spacing-sm;
-    display: block;
-    width: 100%;
-    border: 1px solid $color-border-default;
-    border-radius: $border-radius-md;
-    outline: none;
-    transition: border 0.1s ease-in-out;
-
-    &:focus {
-      border: 1px solid $color-border-focus !important;
-    }
-  }
-}
-
 .disabled_button,
 .active_button {
   padding: $spacing-sm;

--- a/src/app/_component/auth/AuthSubmitBtn.tsx
+++ b/src/app/_component/auth/AuthSubmitBtn.tsx
@@ -1,0 +1,19 @@
+import Loader from '@/app/_component/common/Loader';
+import styles from './AuthSubmitBtn.module.scss';
+
+type Props = {
+  isDisabled: boolean;
+  isSubmitting: boolean;
+  label: string;
+};
+
+export default function AuthSubmitBtn({ isDisabled, isSubmitting, label }: Props) {
+  return (
+    <button
+      className={isDisabled ? styles.disabled_button : styles.active_button}
+      disabled={isDisabled || isSubmitting}
+    >
+      {isSubmitting ? <Loader /> : label}
+    </button>
+  );
+}

--- a/src/app/_component/auth/EmailVerificationRequestForm.tsx
+++ b/src/app/_component/auth/EmailVerificationRequestForm.tsx
@@ -3,13 +3,13 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import useTimer from '@/hooks/useTimer';
+import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
-import Loader from '@/app/_component/common/Loader';
+import FormField from '@/app/_component/auth/FormField';
 import { requestPasswordResetEmail } from '@/apis/auth';
 import { generateErrorMessage } from '@/shared/constants/error';
 import { EMAIL_RESEND_DELAY_SECONDS } from '@/shared/constants/timer';
-import { EMAIL_REGEX } from '@/shared/util/regex';
-import styles from './SignInForm.module.scss';
+import { FORM_VALIDATIONS } from '@/shared/constants/validation';
 
 type Inputs = {
   email: string;
@@ -28,13 +28,10 @@ export default function EmailVerificationRequestForm() {
   const { start, isFinished, isRunning, formattedRemain } = useTimer();
 
   const getButtonContent = () => {
-    if (isSubmitting) return <Loader />;
-
     if (isSubmitSuccessful) {
       if (isRunning) return `재요청 가능 시간: ${formattedRemain}`;
       if (isFinished) return '인증 메일 재요청하기';
     }
-
     return '인증 메일 요청하기';
   };
 
@@ -56,27 +53,19 @@ export default function EmailVerificationRequestForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className={styles.input_group}>
-        <input
-          {...register('email', {
-            required: '이메일을 입력해주세요',
-            pattern: {
-              value: EMAIL_REGEX,
-              message: '유효한 이메일 형식이 아닙니다.'
-            }
-          })}
-          id="email"
-          autoComplete="email"
-          placeholder="example@service.com"
-        />
-        {errors.email && <FormAlertMessage type="error" message={errors.email.message} />}
-      </div>
-      <button
-        className={!isValid || isRunning ? styles.disabled_button : styles.active_button}
-        disabled={!isValid || isRunning}
-      >
-        {getButtonContent()}
-      </button>
+      <FormField
+        id="email"
+        label="이메일"
+        placeholder="example@service.com"
+        register={register('email', FORM_VALIDATIONS.email)}
+        error={errors.email?.message}
+        blindLabel
+      />
+      <AuthSubmitBtn
+        isDisabled={!isValid || isRunning}
+        isSubmitting={isSubmitting}
+        label={getButtonContent()}
+      />
       {alertMessage && (
         <FormAlertMessage
           type={alertType === 'success' ? 'success' : 'error'}

--- a/src/app/_component/auth/FormField.module.scss
+++ b/src/app/_component/auth/FormField.module.scss
@@ -1,11 +1,21 @@
 .input_group {
   margin-bottom: $spacing-sm;
 
-  label {
+  .label {
     margin-bottom: $spacing-xs;
     display: block;
     position: relative;
+  }
 
+  .label_blind {
+    @include blind;
+
+    &::after {
+      content: none !important;
+    }
+  }
+
+  .label_required {
     &::after {
       content: '*';
       margin-left: 0.2rem;
@@ -28,26 +38,4 @@
       border: 1px solid $color-border-focus !important;
     }
   }
-}
-
-.disabled_button,
-.active_button {
-  padding: $spacing-sm;
-  width: 100%;
-  border: 1px solid $color-border-default;
-  border-radius: $border-radius-md;
-  font-size: $font-size-md;
-}
-
-.disabled_button {
-  background-color: $color-disabled-bg;
-  border: 1px solid $color-disabled-border;
-  color: $color-disabled-text;
-  cursor: not-allowed;
-}
-
-.active_button {
-  background-color: $color-primary-active;
-  border: 1px solid $color-primary-active;
-  color: $color-white;
 }

--- a/src/app/_component/auth/FormField.tsx
+++ b/src/app/_component/auth/FormField.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { type UseFormRegisterReturn } from 'react-hook-form';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
 import styles from './FormField.module.scss';
 
@@ -6,7 +7,7 @@ type Props = {
   id: string;
   label: string;
   type?: string;
-  register: any;
+  register: UseFormRegisterReturn;
   error?: string;
   placeholder?: string;
   blindLabel?: boolean;

--- a/src/app/_component/auth/FormField.tsx
+++ b/src/app/_component/auth/FormField.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx';
+import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
+import styles from './FormField.module.scss';
+
+type Props = {
+  id: string;
+  label: string;
+  type?: string;
+  register: any;
+  error?: string;
+  placeholder?: string;
+  blindLabel?: boolean;
+  required?: boolean;
+};
+
+export default function FormField({
+  id,
+  label,
+  type = 'text',
+  register,
+  error,
+  placeholder,
+  blindLabel = false,
+  required = false
+}: Props) {
+  return (
+    <div className={styles.input_group}>
+      <label
+        htmlFor={id}
+        className={clsx(styles.label, {
+          [styles.label_required]: required,
+          [styles.label_blind]: blindLabel
+        })}
+      >
+        {label}
+      </label>
+      <input id={id} type={type} placeholder={placeholder} {...register} />
+      {error && <FormAlertMessage type="error" message={error} />}
+    </div>
+  );
+}

--- a/src/app/_component/auth/KakaoLoginBtn.tsx
+++ b/src/app/_component/auth/KakaoLoginBtn.tsx
@@ -1,18 +1,18 @@
 'use client';
 
 import { signInWithKakao } from '@/apis/auth';
-import { useSearchParams } from 'next/navigation';
 
 export default function KakaoLoginBtn() {
-  const pathname = useSearchParams();
-
-  const handleClick = () => {
-    const nextUrl = pathname.get('redirect');
-    signInWithKakao(nextUrl);
+  const handleKakaoLogin = async () => {
+    try {
+      await signInWithKakao();
+    } catch (error) {
+      console.error('카카오 로그인 실패:', error);
+    }
   };
 
   return (
-    <button onClick={handleClick}>
+    <button onClick={handleKakaoLogin}>
       <img src="/images/kakao_login_large_wide.png" alt="카카오 로그인 버튼" />
     </button>
   );

--- a/src/app/_component/auth/KakaoLoginBtn.tsx
+++ b/src/app/_component/auth/KakaoLoginBtn.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { signInWithKakao } from '@/apis/auth';
 
 export default function KakaoLoginBtn() {
+  const params = useSearchParams();
+  const redirect = params.get('redirect') || '/';
+
   const handleKakaoLogin = async () => {
     try {
-      await signInWithKakao();
+      await signInWithKakao(redirect);
     } catch (error) {
       console.error('카카오 로그인 실패:', error);
     }

--- a/src/app/_component/auth/PasswordUpdateForm.tsx
+++ b/src/app/_component/auth/PasswordUpdateForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
@@ -20,9 +20,17 @@ export default function PasswordUpdateForm() {
     register,
     handleSubmit,
     watch,
+    setError: setFormError,
+    clearErrors,
     formState: { errors, isValid, isSubmitting }
   } = useForm<Inputs>({ mode: 'onChange' });
-  const password = watch('password');
+  const { password, confirmPassword } = watch();
+
+  useEffect(() => {
+    if (password !== confirmPassword && confirmPassword) {
+      setFormError('confirmPassword', { message: '두 비밀번호가 일치하지 않습니다.' });
+    } else clearErrors('confirmPassword');
+  }, [password]);
 
   const onSubmit: SubmitHandler<Inputs> = async ({ password }) => {
     setError('');

--- a/src/app/_component/auth/PasswordUpdateForm.tsx
+++ b/src/app/_component/auth/PasswordUpdateForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
@@ -15,6 +16,7 @@ type Inputs = {
 };
 
 export default function PasswordUpdateForm() {
+  const router = useRouter();
   const [error, setError] = useState('');
   const {
     register,
@@ -36,8 +38,9 @@ export default function PasswordUpdateForm() {
     setError('');
 
     try {
-      const { error } = await updatePasswordAndSignOut(password);
+      const { error, redirectTo } = await updatePasswordAndSignOut(password);
       if (error) setError(error);
+      if (redirectTo) router.push(redirectTo);
     } catch (error) {
       const message = generateErrorMessage(error);
       setError(message);

--- a/src/app/_component/auth/PasswordUpdateForm.tsx
+++ b/src/app/_component/auth/PasswordUpdateForm.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
-import Loader from '@/app/_component/common/Loader';
+import FormField from '@/app/_component/auth/FormField';
 import { updatePasswordAndSignOut } from '@/app/reset-password/actions';
 import { generateErrorMessage } from '@/shared/constants/error';
-import { PASSWORD_REGEX } from '@/shared/util/regex';
-import styles from './SignUpForm.module.scss';
+import { FORM_VALIDATIONS } from '@/shared/constants/validation';
 
 type Inputs = {
   password: string;
@@ -38,47 +38,28 @@ export default function PasswordUpdateForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className={styles.input_group}>
-        <label htmlFor="password">비밀번호</label>
-        <input
-          {...register('password', {
-            required: '비밀번호를 입력해주세요.',
-            pattern: {
-              value: PASSWORD_REGEX,
-              message: '비밀번호는 영문, 숫자 포함 8자 이상이여야 합니다.'
-            }
-          })}
-          id="password"
-          type="password"
-          name="password"
-          autoComplete="new-password"
-          placeholder="영문, 숫자 포함 6자 이상"
-        />
-        {errors.password && <FormAlertMessage type="error" message={errors.password.message} />}
-      </div>
-      <div className={styles.input_group}>
-        <label htmlFor="confirm-password">비밀번호 확인</label>
-        <input
-          {...register('confirmPassword', {
-            required: '비밀번호 확인을 입력해주세요.',
-            validate: (value) => value === password || '두 비밀번호가 일치하지 않습니다.'
-          })}
-          id="confirm-password"
-          type="password"
-          autoComplete="new-password"
-          placeholder="비밀번호 재입력"
-        />
-        {errors.confirmPassword && (
-          <FormAlertMessage type="error" message={errors.confirmPassword.message} />
-        )}
-      </div>
-      <button
-        type="submit"
-        className={!isValid ? styles.disabled_button : styles.active_button}
-        disabled={!isValid || isSubmitting}
-      >
-        {isSubmitting ? <Loader /> : '비밀번호 변경하기'}
-      </button>
+      <FormField
+        id="password"
+        label="비밀번호"
+        type="password"
+        register={register('password', FORM_VALIDATIONS.password)}
+        error={errors.password?.message}
+        placeholder="영문, 숫자 포함 8자 이상"
+        required
+      />
+      <FormField
+        id="confirm-password"
+        label="비밀번호 확인"
+        type="password"
+        register={register('confirmPassword', {
+          required: '비밀번호 확인을 입력해주세요.',
+          validate: (value) => value === password || '두 비밀번호가 일치하지 않습니다.'
+        })}
+        error={errors.confirmPassword?.message}
+        placeholder="비밀번호 재입력"
+        required
+      />
+      <AuthSubmitBtn isDisabled={!isValid} isSubmitting={isSubmitting} label="비밀번호 변경하기" />
       {error && <FormAlertMessage type="error" message={error} />}
     </form>
   );

--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
+import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
-import Loader from '@/app/_component/common/Loader';
+import FormField from '@/app/_component/auth/FormField';
 import { signInWithPassword } from '@/apis/auth';
-import { EMAIL_REGEX, PASSWORD_REGEX } from '@/shared/util/regex';
 import { generateErrorMessage } from '@/shared/constants/error';
-import styles from './SignInForm.module.scss';
+import { FORM_VALIDATIONS } from '@/shared/constants/validation';
 
 type Inputs = {
   email: string;
@@ -34,46 +34,24 @@ export default function SignInForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className={styles.input_group}>
-        <label htmlFor="email">이메일</label>
-        <input
-          {...register('email', {
-            required: '이메일을 입력해주세요',
-            pattern: {
-              value: EMAIL_REGEX,
-              message: '유효한 이메일 형식이 아닙니다.'
-            }
-          })}
-          id="email"
-          autoComplete="email"
-          placeholder="이메일 입력"
-        />
-        {errors.email && <FormAlertMessage type="error" message={errors.email.message} />}
-      </div>
-      <div className={styles.input_group}>
-        <label htmlFor="password">비밀번호</label>
-        <input
-          {...register('password', {
-            required: '비밀번호를 입력해주세요.',
-            pattern: {
-              value: PASSWORD_REGEX,
-              message: '영문, 숫자 포함 6자 이상 입력해주세요.'
-            }
-          })}
-          id="password"
-          type="password"
-          autoComplete="current-password"
-          placeholder="비밀번호 입력 (영문 숫자 포함 6자 이상)"
-        />
-        {errors.password && <FormAlertMessage type="error" message={errors.password.message} />}
-      </div>
-      <button
-        type="submit"
-        className={!isValid ? styles.disabled_button : styles.active_button}
-        disabled={!isValid || isSubmitting}
-      >
-        {isSubmitting ? <Loader /> : '이메일로 로그인'}
-      </button>
+      <FormField
+        id="email"
+        label="이메일"
+        placeholder="이메일 입력"
+        register={register('email', FORM_VALIDATIONS.email)}
+        error={errors.email?.message}
+        blindLabel
+      />
+      <FormField
+        id="password"
+        label="비밀번호"
+        type="password"
+        placeholder="비밀번호 입력 (영문 숫자 포함 8자 이상)"
+        register={register('password', FORM_VALIDATIONS.password)}
+        error={errors.password?.message}
+        blindLabel={true}
+      />
+      <AuthSubmitBtn isDisabled={!isValid} isSubmitting={isSubmitting} label="이메일로 로그인" />
       {logInError && <FormAlertMessage type="error" message={logInError} />}
     </form>
   );

--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -6,8 +6,8 @@ import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
 import FormField from '@/app/_component/auth/FormField';
 import { signInWithPassword } from '@/apis/auth';
-import { generateErrorMessage } from '@/shared/constants/error';
 import { FORM_VALIDATIONS } from '@/shared/constants/validation';
+import { generateErrorMessage } from '@/shared/constants/error';
 
 type Inputs = {
   email: string;

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -54,7 +54,6 @@ export default function SignUpForm() {
             }
           })}
           id="email"
-          autoComplete="email"
           placeholder="example@service.com"
         />
         {errors.email && <FormAlertMessage type="error" message={errors.email.message} />}
@@ -72,7 +71,6 @@ export default function SignUpForm() {
           id="password"
           type="password"
           name="password"
-          autoComplete="new-password"
           placeholder="영문, 숫자 포함 6자 이상"
         />
         {errors.password && <FormAlertMessage type="error" message={errors.password.message} />}
@@ -86,7 +84,6 @@ export default function SignUpForm() {
           })}
           id="confirm-password"
           type="password"
-          autoComplete="new-password"
           placeholder="비밀번호 재입력"
         />
         {errors.confirmPassword && (
@@ -104,7 +101,6 @@ export default function SignUpForm() {
             }
           })}
           id="name"
-          type="name"
           placeholder="홍길동"
         />
         {errors.name && <FormAlertMessage type="error" message={errors.name.message} />}
@@ -113,21 +109,18 @@ export default function SignUpForm() {
         <label htmlFor="username">프로필 이름 (닉네임)</label>
         <input
           {...register('username', {
-            required: '이름을 입력해주세요.',
+            required: '프로필 이름을 입력해주세요.',
             maxLength: {
               value: 10,
               message: '10자 이내로 입력해주세요.'
             }
           })}
           id="username"
-          type="username"
-          autoComplete="username"
           placeholder="사용할 닉네임 10자 이내"
         />
         {errors.username && <FormAlertMessage type="error" message={errors.username.message} />}
       </div>
       <button
-        type="submit"
         className={!isValid ? styles.disabled_button : styles.active_button}
         disabled={!isValid || isSubmitting}
       >

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { signUp } from '@/apis/auth';
 import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
@@ -19,27 +18,33 @@ type Inputs = {
 };
 
 export default function SignUpForm() {
-  const router = useRouter();
   const [signUpError, setSignUpError] = useState('');
   const {
     register,
     handleSubmit,
     watch,
+    setError,
+    clearErrors,
     formState: { errors, isValid, isSubmitting }
   } = useForm<Inputs>({ mode: 'onChange' });
-  const password = watch('password');
+  const { password, confirmPassword } = watch();
 
   const onSubmit: SubmitHandler<Inputs> = async ({ email, password, name, username }) => {
     setSignUpError('');
 
     try {
       await signUp({ email, password, name, username });
-      router.push('/');
     } catch (error) {
       const message = generateErrorMessage(error);
       setSignUpError(message);
     }
   };
+
+  useEffect(() => {
+    if (password !== confirmPassword && confirmPassword) {
+      setError('confirmPassword', { message: '두 비밀번호가 일치하지 않습니다.' });
+    } else clearErrors('confirmPassword');
+  }, [password]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -4,11 +4,11 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { signUp } from '@/apis/auth';
-import Loader from '@/app/_component/common/Loader';
+import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
 import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
+import FormField from '@/app/_component/auth/FormField';
 import { generateErrorMessage } from '@/shared/constants/error';
-import { EMAIL_REGEX, NAME_REGEX, PASSWORD_REGEX } from '@/shared/util/regex';
-import styles from './SignUpForm.module.scss';
+import { FORM_VALIDATIONS } from '@/shared/constants/validation';
 
 type Inputs = {
   email: string;
@@ -43,89 +43,52 @@ export default function SignUpForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <div className={styles.input_group}>
-        <label htmlFor="email">이메일</label>
-        <input
-          {...register('email', {
-            required: '이메일 주소를 입력해주세요',
-            pattern: {
-              value: EMAIL_REGEX,
-              message: '올바른 이메일 형식이 아닙니다.'
-            }
-          })}
-          id="email"
-          placeholder="example@service.com"
-        />
-        {errors.email && <FormAlertMessage type="error" message={errors.email.message} />}
-      </div>
-      <div className={styles.input_group}>
-        <label htmlFor="password">비밀번호</label>
-        <input
-          {...register('password', {
-            required: '비밀번호를 입력해주세요.',
-            pattern: {
-              value: PASSWORD_REGEX,
-              message: '비밀번호는 영문, 숫자 포함 8자 이상이여야 합니다.'
-            }
-          })}
-          id="password"
-          type="password"
-          name="password"
-          placeholder="영문, 숫자 포함 6자 이상"
-        />
-        {errors.password && <FormAlertMessage type="error" message={errors.password.message} />}
-      </div>
-      <div className={styles.input_group}>
-        <label htmlFor="confirm-password">비밀번호 확인</label>
-        <input
-          {...register('confirmPassword', {
-            required: '비밀번호 확인을 입력해주세요.',
-            validate: (value) => value === password || '두 비밀번호가 일치하지 않습니다.'
-          })}
-          id="confirm-password"
-          type="password"
-          placeholder="비밀번호 재입력"
-        />
-        {errors.confirmPassword && (
-          <FormAlertMessage type="error" message={errors.confirmPassword.message} />
-        )}
-      </div>
-      <div className={styles.input_group}>
-        <label htmlFor="name">이름</label>
-        <input
-          {...register('name', {
-            required: '이름을 입력해주세요.',
-            pattern: {
-              value: NAME_REGEX,
-              message: '한글 또는 영문으로만 입력해주세요.'
-            }
-          })}
-          id="name"
-          placeholder="홍길동"
-        />
-        {errors.name && <FormAlertMessage type="error" message={errors.name.message} />}
-      </div>
-      <div className={styles.input_group}>
-        <label htmlFor="username">프로필 이름 (닉네임)</label>
-        <input
-          {...register('username', {
-            required: '프로필 이름을 입력해주세요.',
-            maxLength: {
-              value: 10,
-              message: '10자 이내로 입력해주세요.'
-            }
-          })}
-          id="username"
-          placeholder="사용할 닉네임 10자 이내"
-        />
-        {errors.username && <FormAlertMessage type="error" message={errors.username.message} />}
-      </div>
-      <button
-        className={!isValid ? styles.disabled_button : styles.active_button}
-        disabled={!isValid || isSubmitting}
-      >
-        {isSubmitting ? <Loader /> : '회원가입'}
-      </button>
+      <FormField
+        id="email"
+        label="이메일"
+        register={register('email', FORM_VALIDATIONS.email)}
+        error={errors.email?.message}
+        placeholder="example@service.com"
+        required
+      />
+      <FormField
+        id="password"
+        label="비밀번호"
+        type="password"
+        register={register('password', FORM_VALIDATIONS.password)}
+        error={errors.password?.message}
+        placeholder="영문, 숫자 포함 8자 이상"
+        required
+      />
+      <FormField
+        id="confirm-password"
+        label="비밀번호 확인"
+        type="password"
+        register={register('confirmPassword', {
+          required: '비밀번호 확인을 입력해주세요.',
+          validate: (value) => value === password || '두 비밀번호가 일치하지 않습니다.'
+        })}
+        error={errors.confirmPassword?.message}
+        placeholder="비밀번호 재입력"
+        required
+      />
+      <FormField
+        id="name"
+        label="이름"
+        register={register('name', FORM_VALIDATIONS.name)}
+        error={errors.name?.message}
+        placeholder="홍길동"
+        required
+      />
+      <FormField
+        id="username"
+        label="프로필 이름 (닉네임)"
+        register={register('username', FORM_VALIDATIONS.username)}
+        error={errors.username?.message}
+        placeholder="사용할 닉네임 10자 이내"
+        required
+      />
+      <AuthSubmitBtn isDisabled={!isValid} isSubmitting={isSubmitting} label="회원가입" />
       {signUpError && <FormAlertMessage type="error" message={signUpError} />}
     </form>
   );

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -7,7 +7,7 @@ export async function GET(request: Request) {
   const next = searchParams.get('next') ?? '/';
 
   if (code) {
-    const supabase = await createServerSideClient({});
+    const supabase = await createServerSideClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
     if (!error) {

--- a/src/app/auth/reset-password/route.ts
+++ b/src/app/auth/reset-password/route.ts
@@ -4,6 +4,7 @@ import { EMAIL_OTP_EXPIRATION_SECONDS } from '@/shared/constants/timer';
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
+
   if (code) {
     const response = NextResponse.redirect(new URL('/reset-password', origin));
     response.cookies.set('reset_auth_code', code, {
@@ -15,5 +16,6 @@ export async function GET(request: Request) {
     });
     return response;
   }
+
   return NextResponse.redirect(new URL('/login', origin));
 }

--- a/src/app/auth/reset-password/route.ts
+++ b/src/app/auth/reset-password/route.ts
@@ -4,7 +4,6 @@ import { EMAIL_OTP_EXPIRATION_SECONDS } from '@/shared/constants/timer';
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
-
   if (code) {
     const response = NextResponse.redirect(new URL('/reset-password', origin));
     response.cookies.set('reset_auth_code', code, {
@@ -14,9 +13,7 @@ export async function GET(request: Request) {
       maxAge: EMAIL_OTP_EXPIRATION_SECONDS,
       path: '/'
     });
-
     return response;
   }
-
   return NextResponse.redirect(new URL('/login', origin));
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
 import { LayoutContainer } from '@/app/_component/layout/common';
 import KakaoLoginBtn from '@/app/_component/auth/KakaoLoginBtn';
 import SignInForm from '@/app/_component/auth/SignInForm';
@@ -36,9 +35,7 @@ export default function Login() {
             <span className={styles.caption}>SNS 계정으로 로그인</span>
           </div>
           <div className={styles.btn_group}>
-            <Suspense fallback={null}>
-              <KakaoLoginBtn />
-            </Suspense>
+            <KakaoLoginBtn />
           </div>
         </div>
       </LayoutContainer>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 import { LayoutContainer } from '@/app/_component/layout/common';
 import KakaoLoginBtn from '@/app/_component/auth/KakaoLoginBtn';
 import SignInForm from '@/app/_component/auth/SignInForm';
@@ -35,7 +36,9 @@ export default function Login() {
             <span className={styles.caption}>SNS 계정으로 로그인</span>
           </div>
           <div className={styles.btn_group}>
-            <KakaoLoginBtn />
+            <Suspense fallback={null}>
+              <KakaoLoginBtn />
+            </Suspense>
           </div>
         </div>
       </LayoutContainer>

--- a/src/app/reset-password/actions.ts
+++ b/src/app/reset-password/actions.ts
@@ -5,12 +5,19 @@ import { createServerSideClient } from '@/shared/supabase/server';
 import { generateErrorMessage } from '@/shared/constants/error';
 
 export async function updatePasswordAndSignOut(newPassword: string) {
+  const supabase = await createServerSideClient();
+  const supabaseAdmin = await createServerSideClient(true);
   const cookieStore = await cookies();
+
   const authCode = cookieStore.get('reset_auth_code')?.value;
-  const supabase = await createServerSideClient({});
+  let userId = cookieStore.get('reset_user_id')?.value;
 
   if (authCode) {
-    const { error: exchangeError } = await supabase.auth.exchangeCodeForSession(authCode);
+    const {
+      error: exchangeError,
+      data: { session }
+    } = await supabase.auth.exchangeCodeForSession(authCode);
+    userId = session?.user.id;
     cookieStore.delete('reset_auth_code');
 
     if (exchangeError) {
@@ -18,15 +25,36 @@ export async function updatePasswordAndSignOut(newPassword: string) {
         error: '링크가 만료되었습니다. 인증 메일을 다시 요청해주세요.'
       };
     }
+
+    cookieStore.set('reset_user_id', userId!, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 60 * 10,
+      path: '/'
+    });
+
+    await supabase.auth.signOut();
+  }
+
+  if (userId) {
+    const { error: updateError } = await supabaseAdmin.auth.admin.updateUserById(userId, {
+      password: newPassword
+    });
+
+    if (updateError) {
+      return { error: generateErrorMessage(updateError) };
+    }
+
+    cookieStore.delete('reset_user_id');
+    return { error: null, redirectTo: '/login' };
   }
 
   const { error: updateError } = await supabase.auth.updateUser({ password: newPassword });
 
   if (updateError) {
-    const message = generateErrorMessage(updateError);
-    return { error: message };
+    return { error: generateErrorMessage(updateError) };
   }
 
-  await supabase.auth.signOut();
-  return { error: null };
+  return { error: null, redirectTo: '/' };
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,7 +2,6 @@ import { type NextRequest } from 'next/server';
 import { updateSession } from '@/shared/supabase/middleware';
 
 export async function proxy(request: NextRequest) {
-  console.log('proxy');
   return await updateSession(request);
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,5 +6,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/login', '/news/bulletin/create', '/news/bulletin/:id*/update']
+  matcher: ['/login', '/sign-up', '/forget-password']
 };

--- a/src/shared/constants/validation.ts
+++ b/src/shared/constants/validation.ts
@@ -1,0 +1,32 @@
+import { EMAIL_REGEX, PASSWORD_REGEX, NAME_REGEX } from '@/shared/util/regex';
+
+export const FORM_VALIDATIONS = {
+  email: {
+    required: '이메일 주소를 입력해주세요',
+    pattern: {
+      value: EMAIL_REGEX,
+      message: '올바른 이메일 형식이 아닙니다.'
+    }
+  },
+  password: {
+    required: '비밀번호를 입력해주세요.',
+    pattern: {
+      value: PASSWORD_REGEX,
+      message: '비밀번호는 영문, 숫자 포함 8자 이상이여야 합니다.'
+    }
+  },
+  name: {
+    required: '이름을 입력해주세요.',
+    pattern: {
+      value: NAME_REGEX,
+      message: '한글 또는 영문으로만 입력해주세요.'
+    }
+  },
+  username: {
+    required: '프로필 이름을 입력해주세요.',
+    maxLength: {
+      value: 10,
+      message: '10자 이내로 입력해주세요.'
+    }
+  }
+} as const;

--- a/src/shared/supabase/middleware.ts
+++ b/src/shared/supabase/middleware.ts
@@ -27,18 +27,14 @@ export async function updateSession(request: NextRequest) {
     }
   );
 
+  const { data } = await supabase.auth.getClaims();
+  const user = data?.claims;
   const pathname = request.nextUrl.pathname;
 
-  const {
-    data: { user }
-  } = await supabase.auth.getUser();
+  const noAuthPages = ['/login', '/sign-up', '/forget-password'];
 
-  if (!user && !pathname.startsWith('/login')) {
-    return NextResponse.redirect(new URL(`/login?redirect=${pathname}`, request.nextUrl));
-  }
-
-  if (user && pathname.startsWith('/login')) {
-    return NextResponse.redirect(new URL('/', request.nextUrl));
+  if (user && noAuthPages.includes(pathname)) {
+    return NextResponse.redirect(new URL('/', request.url));
   }
 
   return supabaseResponse;

--- a/src/shared/supabase/middleware.ts
+++ b/src/shared/supabase/middleware.ts
@@ -1,31 +1,9 @@
-import { createServerClient } from '@supabase/ssr';
-import { NextRequest, NextResponse } from 'next/server';
+import { createMiddlewareClient } from '@/shared/supabase/server';
+import { NextResponse, type NextRequest } from 'next/server';
 
 export async function updateSession(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({
-    request
-  });
-
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll() {
-          return request.cookies.getAll();
-        },
-        setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
-          supabaseResponse = NextResponse.next({
-            request
-          });
-          cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options)
-          );
-        }
-      }
-    }
-  );
+  let response = NextResponse.next({ request });
+  const supabase = await createMiddlewareClient(request, response);
 
   const { data } = await supabase.auth.getClaims();
   const user = data?.claims;
@@ -37,5 +15,5 @@ export async function updateSession(request: NextRequest) {
     return NextResponse.redirect(new URL('/', request.url));
   }
 
-  return supabaseResponse;
+  return response;
 }

--- a/src/shared/supabase/server.ts
+++ b/src/shared/supabase/server.ts
@@ -1,52 +1,89 @@
 import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient } from '@supabase/ssr';
-import { Database } from '../types/database.types';
+import { Database } from '@/shared/types/database.types';
 
-export const createFetch =
-  (options: Pick<RequestInit, 'next' | 'cache'>) =>
-  (url: RequestInfo | URL, init?: RequestInit) => {
-    return fetch(url, {
-      ...init,
-      ...options
-    });
-  };
-
-// ServerActions, RouterHandler
-export const createServerSideClient = async ({
-  cache,
-  tag
-}: {
-  cache?: RequestCache;
-  tag?: string | string[];
-}) => {
+export const createServerSideClient = async (isAdmin = false) => {
   const cookieStore = await cookies();
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    isAdmin ? process.env.NEXT_SUPABASE_SERVICE_ROLE! : process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      global: {
-        fetch: createFetch({
-          next: {
-            tags: [...(tag || 'supabase')]
-          },
-          cache
-        })
-      },
       cookies: {
-        get: (key) => cookieStore.get(key)?.value,
-        set: (key, value, options) => {
-          cookieStore.set(key, value, options);
+        getAll() {
+          return cookieStore.getAll();
         },
-        remove: (key, options) => {
-          cookieStore.set(key, '', options);
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value }) => cookieStore.set(name, value));
+          } catch {}
         }
       }
     }
   );
 };
 
-// RSC
-// export const createServerSideClientRSC = async () => {
-//   return createServerSideClient(true);
+export const createMiddlewareClient = async (request: NextRequest, response: NextResponse) => {
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+          response = NextResponse.next({
+            request
+          });
+          cookiesToSet.forEach(({ name, value }) => response.cookies.set(name, value));
+        }
+      }
+    }
+  );
+};
+
+// export const createFetch =
+//   (options: Pick<RequestInit, 'next' | 'cache'>) =>
+//   (url: RequestInfo | URL, init?: RequestInit) => {
+//     return fetch(url, {
+//       ...init,
+//       ...options
+//     });
+//   };
+
+// export const createServerSideClient = async ({
+//   cache,
+//   tag
+// }: {
+//   cache?: RequestCache;
+//   tag?: string | string[];
+// }) => {
+//   const cookieStore = await cookies();
+
+//   return createServerClient<Database>(
+//     process.env.NEXT_PUBLIC_SUPABASE_URL!,
+//     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+//     {
+//       global: {
+//         fetch: createFetch({
+//           next: {
+//             tags: [...(tag || 'supabase')]
+//           },
+//           cache
+//         })
+//       },
+//       cookies: {
+//         get: (key) => cookieStore.get(key)?.value,
+//         set: (key, value, options) => {
+//           cookieStore.set(key, value, options);
+//         },
+//         remove: (key, options) => {
+//           cookieStore.set(key, '', options);
+//         }
+//       }
+//     }
+//   );
 // };

--- a/src/shared/util/regex.ts
+++ b/src/shared/util/regex.ts
@@ -1,4 +1,4 @@
 export const EMAIL_REGEX =
   /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i;
-export const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*[0-9]).{6,25}$/;
+export const PASSWORD_REGEX = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/;
 export const NAME_REGEX = /^[가-힣A-Za-z]+$/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -384,69 +384,62 @@
   resolved "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@supabase/auth-js@2.65.1":
-  version "2.65.1"
-  resolved "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.65.1.tgz"
-  integrity sha512-IA7i2Xq2SWNCNMKxwmPlHafBQda0qtnFr8QnyyBr+KaSxoXXqEzFCnQ1dGTy6bsZjVBgXu++o3qrDypTspaAPw==
+"@supabase/auth-js@2.86.0":
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.86.0.tgz"
+  integrity sha512-3xPqMvBWC6Haqpr6hEWmSUqDq+6SA1BAEdbiaHdAZM9QjZ5uiQJ+6iD9pZOzOa6MVXZh4GmwjhC9ObIG0K1NcA==
   dependencies:
-    "@supabase/node-fetch" "^2.6.14"
+    tslib "2.8.1"
 
-"@supabase/functions-js@2.4.3":
-  version "2.4.3"
-  resolved "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.3.tgz"
-  integrity sha512-sOLXy+mWRyu4LLv1onYydq+10mNRQ4rzqQxNhbrKLTLTcdcmS9hbWif0bGz/NavmiQfPs4ZcmQJp4WqOXlR4AQ==
+"@supabase/functions-js@2.86.0":
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.86.0.tgz"
+  integrity sha512-AlOoVfeaq9XGlBFIyXTmb+y+CZzxNO4wWbfgRM6iPpNU5WCXKawtQYSnhivi3UVxS7GA0rWovY4d6cIAxZAojA==
   dependencies:
-    "@supabase/node-fetch" "^2.6.14"
+    tslib "2.8.1"
 
-"@supabase/node-fetch@^2.6.14", "@supabase/node-fetch@2.6.15":
-  version "2.6.15"
-  resolved "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz"
-  integrity sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==
+"@supabase/postgrest-js@2.86.0":
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.86.0.tgz"
+  integrity sha512-QVf+wIXILcZJ7IhWhWn+ozdf8B+oO0Ulizh2AAPxD/6nQL+x3r9lJ47a+fpc/jvAOGXMbkeW534Kw6jz7e8iIA==
   dependencies:
-    whatwg-url "^5.0.0"
+    tslib "2.8.1"
 
-"@supabase/postgrest-js@1.16.3":
-  version "1.16.3"
-  resolved "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.16.3.tgz"
-  integrity sha512-HI6dsbW68AKlOPofUjDTaosiDBCtW4XAm0D18pPwxoW3zKOE2Ru13Z69Wuys9fd6iTpfDViNco5sgrtnP0666A==
+"@supabase/realtime-js@2.86.0":
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.86.0.tgz"
+  integrity sha512-dyS8bFoP29R/sj5zLi0AP3JfgG8ar1nuImcz5jxSx7UIW7fbFsXhUCVrSY2Ofo0+Ev6wiATiSdBOzBfWaiFyPA==
   dependencies:
-    "@supabase/node-fetch" "^2.6.14"
+    "@types/phoenix" "^1.6.6"
+    "@types/ws" "^8.18.1"
+    tslib "2.8.1"
+    ws "^8.18.2"
 
-"@supabase/realtime-js@2.10.7":
-  version "2.10.7"
-  resolved "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.10.7.tgz"
-  integrity sha512-OLI0hiSAqQSqRpGMTUwoIWo51eUivSYlaNBgxsXZE7PSoWh12wPRdVt0psUMaUzEonSB85K21wGc7W5jHnT6uA==
+"@supabase/ssr@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz"
+  integrity sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==
   dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-    "@types/phoenix" "^1.5.4"
-    "@types/ws" "^8.5.10"
-    ws "^8.14.2"
+    cookie "^1.0.2"
 
-"@supabase/ssr@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.5.1.tgz"
-  integrity sha512-+G94H/GZG0nErZ3FQV9yJmsC5Rj7dmcfCAwOt37hxeR1La+QTl8cE9whzYwPUrTJjMLGNXoO+1BMvVxwBAbz4g==
+"@supabase/storage-js@2.86.0":
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.86.0.tgz"
+  integrity sha512-PM47jX/Mfobdtx7NNpoj9EvlrkapAVTQBZgGGslEXD6NS70EcGjhgRPBItwHdxZPM5GwqQ0cGMN06uhjeY2mHQ==
   dependencies:
-    cookie "^0.6.0"
+    iceberg-js "^0.8.0"
+    tslib "2.8.1"
 
-"@supabase/storage-js@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz"
-  integrity sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==
+"@supabase/supabase-js@^2.76.1", "@supabase/supabase-js@^2.86.0":
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.86.0.tgz"
+  integrity sha512-BaC9sv5+HGNy1ulZwY8/Ev7EjfYYmWD4fOMw9bDBqTawEj6JHAiOHeTwXLRzVaeSay4p17xYLN2NSCoGgXMQnw==
   dependencies:
-    "@supabase/node-fetch" "^2.6.14"
-
-"@supabase/supabase-js@^2.43.4", "@supabase/supabase-js@^2.46.1":
-  version "2.46.1"
-  resolved "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.46.1.tgz"
-  integrity sha512-HiBpd8stf7M6+tlr+/82L8b2QmCjAD8ex9YdSAKU+whB/SHXXJdus1dGlqiH9Umy9ePUuxaYmVkGd9BcvBnNvg==
-  dependencies:
-    "@supabase/auth-js" "2.65.1"
-    "@supabase/functions-js" "2.4.3"
-    "@supabase/node-fetch" "2.6.15"
-    "@supabase/postgrest-js" "1.16.3"
-    "@supabase/realtime-js" "2.10.7"
-    "@supabase/storage-js" "2.7.1"
+    "@supabase/auth-js" "2.86.0"
+    "@supabase/functions-js" "2.86.0"
+    "@supabase/postgrest-js" "2.86.0"
+    "@supabase/realtime-js" "2.86.0"
+    "@supabase/storage-js" "2.86.0"
 
 "@swc/helpers@0.5.15":
   version "0.5.15"
@@ -501,10 +494,10 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/phoenix@^1.5.4":
-  version "1.6.5"
-  resolved "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.5.tgz"
-  integrity sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w==
+"@types/phoenix@^1.6.6":
+  version "1.6.6"
+  resolved "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz"
+  integrity sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==
 
 "@types/prop-types@*":
   version "15.7.13"
@@ -533,10 +526,10 @@
     "@types/prop-types" "*"
     csstype "^3.0.2"
 
-"@types/ws@^8.5.10":
-  version "8.5.13"
-  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz"
-  integrity sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==
+"@types/ws@^8.18.1":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
   dependencies:
     "@types/node" "*"
 
@@ -967,10 +960,10 @@ convert-source-map@^2.0.0:
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
 
-cookie@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+cookie@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz"
+  integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.6:
   version "7.0.6"
@@ -1777,6 +1770,11 @@ https-proxy-agent@^7.0.2:
   dependencies:
     agent-base "^7.0.2"
     debug "4"
+
+iceberg-js@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.0.tgz"
+  integrity sha512-kmgmea2nguZEvRqW79gDqNXyxA3OS5WIgMVffrHpqXV4F/J4UmNIw2vstixioLTNSkd5rFB8G0s3Lwzogm6OFw==
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -2970,11 +2968,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 ts-api-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz"
@@ -2990,7 +2983,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.8.0:
+tslib@^2.8.0, tslib@2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -3097,19 +3090,6 @@ web-streams-polyfill@^3.0.3:
   resolved "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz"
   integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
-
 which-boxed-primitive@^1.1.0, which-boxed-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz"
@@ -3201,10 +3181,10 @@ write-file-atomic@^6.0.0:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@^8.14.2:
-  version "8.18.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@^8.18.2:
+  version "8.18.3"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 yallist@^3.0.2:
   version "3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -935,6 +935,11 @@ client-only@0.0.1:
   resolved "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+clsx@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"
+  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+
 cmd-shim@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/cmd-shim/-/cmd-shim-7.0.0.tgz"


### PR DESCRIPTION
## 🚀 개요 (Summary)

> 로그인 및 비로그인 유저 모두의 비밀번호 변경 경험을 개선하고 FormField 컴포넌트 도입과 로그인 리다이렉트 복원을 통해 UI/UX를 일관되게 개선
> 비로그인 유저의 비밀번호 변경 실패 시 안전하게 재시도할 수 있는 플로우 구현

## 📌 주요 구현 및 문제 해결 내용

### FormField 컴포넌트 도입 및 Validation 통합 리팩토링

- 각 Form마다 Label/Input/Error 로직 및 스타일이 중복
- `<FormField />` 컴포넌트 추가로 UI, 에러 렌더링, 접근성, 스타일을 일원화
- VALIDATIONS 객체로 email/password/name 등 규칙을 중앙화해 재사용성 개선
- CSS 클래스 조건 처리를 위해 `clsx` 라이브러리 적용

```tsx
// Before
<div className={styles.input_group}>
  <input
    {...register('email', {
      required: '이메일을 입력해주세요',
      pattern: {
        value: EMAIL_REGEX,
        message: '유효한 이메일 형식이 아닙니다.'
      }
    })}
    id="email"
    placeholder="example@service.com"
  />
  {errors.email && <FormAlertMessage type="error" message={errors.email.message} />}
</div>

// After
<FormField
  id="email"
  label="이메일"
  placeholder="example@service.com"
  register={register('email', FORM_VALIDATIONS.email)}
  error={errors.email?.message}
  blindLabel
/>
```

### 클라이언트 로그인 리다이렉트 복원 구현

**문제 상황**
- 로그인 완료 후 항상 기본 경로(/)로 이동되어 원래 페이지로 복귀되지 않음 → UX 불편
- kakao OAuth 로그인과 Email/Password 로그인은 처리 방식이 달라 동일한 방식으로 처리할 수 없음

**원인:**
- `signInWithOAuth`와 `signInWithPassword` 로그인 흐름 차이
  - `signInWithOAuth`: 서버(Route Handler) → Kakao 인증 → 서버 → 클라이언트 복귀
  - `signInWithPassword`: 클라이언트에서 수행 - 로그인 성공 → onAuthStateChange 즉시 감지 → redirect 파라미터로 복귀 페이지 이동
- `signInWithOAuth`와 `signInWithPassword` 함수 구현 차이
  - `signInWithOAuth`는 매개변수로 redirect 전달 가능하지만 `signInWithPassword`는 불가능
 
```tsx
// signInWithOAuth 반환 타입
export type OAuthResponse =
  | { data: { provider: Provider, url: string }, error: null } // 성공 케이스

// signInWithPassword 반환 타입
export type AuthTokenResponsePassword = RequestResultSafeDestructure<{
  user: User
  session: Session
  weakPassword?: WeakPassword
}>
```
> 정리)
> OAuth 로그인은 외부 인증 과정이 포함 → redirect URL 전달 가능, 서버 측 인증 + redirect 제어 가능
> Email/Password 로그인은 클라이언트 내부에서 모든 처리가 이뤄지기 때문에 인증 성공 후 redirect를 호출 직후 하기보다는 세션 상태 변화로 판단

**해결 방안**

- 클라이언트에서 redirect 정보를 명시적으로 전달
  - 로그인 페이지로 이동하는 시점에 `?redirect={현재 페이지}` 전달 
  - `<Link href={{ pathname: '/login', query: { redirect: pathname } }}>로그인</Link>`
- **(1) OAuth Kakao 로그인**
  -  요청 시 redirect를 callback으로 전달
  - Route Handler에서 next 파라미터 가져와 로그인 완료 후 해당 페이지로 redirect
```tsx
// /apis/auth.ts
export async function signInWithKakao(redirect = '/') {
  const { data, error } = await supabase.auth.signInWithOAuth({
    provider: 'kakao',
    options: {
      redirectTo: `${window.location.origin}/auth/callback?next=${redirect}`
    }
  });
} 
```
```ts
// auth/callback/route.ts
export async function GET(request: Request) {
  const { searchParams, origin } = new URL(request.url);
  const code = searchParams.get('code');
  const next = searchParams.get('next') ?? '/';

  // 생략

 return NextResponse.redirect(`${origin}${next}`);
}
```
- **(2) Email/Password 로그인**
  - 클라이언트 측에서 로그인 수행 -> onAuthStateChange에서 감지 -> redirect
```tsx
// /context/SessionContextProvider.tsx
supabase.auth.onAuthStateChange((event, session) => {
  if (event === 'SIGNED_IN' && session) {
    const redirectFrom = new URLSearchParams(window.location.search).get('redirect') || '/';
    router.push(decodeURIComponent(redirectFrom));
  }
});
```

### 비로그인 유저의 비밀번호 재설정 실패 시 자동 로그인 방지

**문제 상황**
- Supabase 기본 비밀번호 재설정 흐름은 사용자가 이메일 링크를 클릭하면
  - exchangeCodeForSession 로 code를 session으로 교환
  - Supabase가 access token + refresh token을 발급
  - 즉시 로그인 상태가 됨
- 비밀번호 변경이 실패한 경우
  - code는 이미 사용됨 → 재시도 불가
  - session은 남아 로그인됨 → 자동 로그인 문제 재발

**원인:**
- Supabase의 비밀번호 재설정 링크는 PKCE 기반으로 동작하며 code는 단 한 번만 사용할 수 있는 일회성 토큰
- 비밀번호 변경 실패 시 code는 이미 소비되었으나 session은 남아 있음 -> 로그인된 상태가 되어 자동 로그인 발생
- code 없이 재시도하려면 userId가 필요하지만 session을 삭제하면 userId를 알 수 없고 session을 유지하면 자동 로그인이 발생

**해결 방안**
- 최초 요청 시 code 검증하여 생성된 session에서 userId를 쿠키(reset_user_id)에 저장
- 이후 비밀번호 변경은 session을 사용하지 않고 **Admin API 사용**
  - Admin API는 로그인 세션이 필요 없기 때문에 session 없이도 userId만 있으면 비밀번호 변경 가능
- 사용자가 비밀번호 변경에 실패하더라도 userId 쿠키를 유지하고 있으므로 비밀번호 변경 재시도
- (+) 로그인 유저는 기존 session을 그대로 사용
