### PR TITLE
Fix: 클라이언트 측 프로필 동기화 문제 및 중복 API 호출 해결

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -48,7 +48,9 @@ export async function signInWithKakao(redirect = '/') {
 }
 
 export async function signOut() {
-  await supabase.auth.signOut();
+  const { error } = await supabase.auth.signOut();
+
+  if (error) throw error;
 }
 
 export async function requestPasswordResetEmail(email: string) {

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -16,9 +16,7 @@ export const getProfileById = async (userId = '') => {
     .eq('id', userId)
     .single();
 
-  if (error) {
-    throw new Error(error.message);
-  }
+  if (error) throw error;
 
   return profile;
 };

--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import AuthSubmitBtn from '@/app/_component/auth/AuthSubmitBtn';
@@ -21,10 +22,13 @@ export default function SignInForm() {
     handleSubmit,
     formState: { errors, isValid, isSubmitting }
   } = useForm<Inputs>({ mode: 'onChange' });
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect') ?? '/';
 
   const onSubmit: SubmitHandler<Inputs> = async ({ email, password }) => {
     try {
       setLogInError('');
+      localStorage.setItem('redirect_after_login', redirect);
       await signInWithPassword({ email, password });
     } catch (error) {
       const message = generateErrorMessage(error);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -25,7 +25,9 @@ export default function Login() {
               로그인 후, 더욱 편리한 서비스를 이용해 보세요.
             </p>
           </div>
-          <SignInForm />
+          <Suspense fallback={null}>
+            <SignInForm />
+          </Suspense>
           <div className={styles.link_group}>
             <Link href="/sign-up">회원가입</Link>
             <div className={styles.divide}></div>

--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -60,6 +60,12 @@ function SessionContextProvider({ children }: PropsWithChildren) {
           lastUserIdRef.current = userId;
           fetchProfile(userId);
         }
+
+        const redirectTo = localStorage.getItem('redirect_after_login');
+        if (redirectTo) {
+          localStorage.removeItem('redirect_after_login');
+          router.replace(redirectTo);
+        }
       }
 
       if (event === 'SIGNED_OUT') {

--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -58,7 +58,7 @@ function SessionContextProvider({ children }: PropsWithChildren) {
       if ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') && userId) {
         if (lastUserIdRef.current !== userId) {
           lastUserIdRef.current = userId;
-          await fetchProfile(userId);
+          fetchProfile(userId);
         }
       }
 


### PR DESCRIPTION
## 🚀 개요 (Summary)

> SessionContextProvider의 프로필 페칭 로직을 안정화하고 불필요한 중복 API 호출을 방지하여 사용자 경험(UX)과 시스템 성능을 개선

## 📌 주요 구현 및 문제 해결 내용

### SessionContextProvider의 프로필 페칭 동기화 문제

**문제 상황**

- 클라이언트 측 인증 상태를 관리하는 SessionContextProvider에서 첫 페이지 로딩 직후 브라우저 탭을 전환할 경우 사용자 프로필 데이터가 간헐적으로 누락
- cookie에 토큰에 저장되어 있음에도 로그인한 사용자 프로필이 보이지 않고 새로고침을 해야 프로필이 보이는 현상

**원인**

- `onAuthStateChange` 이벤트 핸들러 내부의 `"await" fetchProfile(userId)`
- INITIAL_SESSION 이벤트 핸들러가 네트워크 API 호출이 완료될 때까지 실행을 중단하고 대기
- 대기 시간 동안 사용자가 탭을 전환하면 Supabase는 다른 인증 관련 이벤트를 발생시켜 이벤트 대기열에 추가
- 이벤트 핸들러가 API 대기로 인해 블로킹되면서 대기 중이던 이벤트들의 처리 순서가 꼬이고 최종적인 setProfile 상태 업데이트가 누락되거나 무효화

**해결 방안**

- 이벤트 핸들러의 실행을 막는 await 키워드를 제거하여 이벤트 흐름을 논블로킹 방식으로 변경
- fetchProfile을 비동기 독립 작업으로 분리하여 이벤트 큐가 막히지 않도록 보장함으로써 경쟁 상태로 인한 프로필 누락 문제를 해결
```tsx
// Before
if (lastUserIdRef.current !== userId) {
  lastUserIdRef.current = userId;
  await fetchProfile(userId); // ❌

// After
if (lastUserIdRef.current !== userId) {
  lastUserIdRef.current = userId;
  fetchProfile(userId); // ✅
}
```

<br/>

### 탭 포커스 전환 시 프로필 API가 반복 호출되는 문제 해결

**문제 상황**

- 브라우저 탭을 전환할 때마다 SIGNED_IN 이벤트가 트리거되어 fetchProfile()이 반복 호출되는 문제로 인한 불필요한 API 부하와 성능 저하

**원인**

- `onAuthStateChange`의 동작으로 탭 포커스 변화에 SIGNED_IN 이벤트가 발생됨
- `event === 'SIGNED_IN` 이벤트가 감지되었을 때 항상 fetchProfile() 반복해서 API 요청

**해결 방안**
- `useRef`를 이용해 현재 `session.user.id`와 비교하여 이전과 동일한 userId라면 fetchProfile을 실행하지 않도록 방지

```tsx
const userId = session?.user?.id ?? null;

if ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') && userId) {
  if (lastUserIdRef.current !== userId) {
    lastUserIdRef.current = userId;
    fetchProfile(userId);
  }
}
```
<br/>

### (+) 비밀번호 로그인 후 이전 페이지로 자동 리다이렉트 개선
- `/login?redirect=/path`로 전달된 값을 login 직전에 localStorage.redirect_after_login에 저장
- SIGNED_IN 이벤트 발생 후 redirect_after_login 값이 있으면 해당 경로로 이동, localStorage에서 삭제
```tsx
const redirectTo = localStorage.getItem('redirect_after_login');
if (redirectTo) {
  localStorage.removeItem('redirect_after_login');
  router.replace(redirectTo);
}
```