### PR TITLE
Fix: 회원가입 후 리다이렉트 로직 누락

### DIFF
--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -9,6 +9,7 @@ import FormField from '@/app/_component/auth/FormField';
 import { signInWithPassword } from '@/apis/auth';
 import { FORM_VALIDATIONS } from '@/shared/constants/validation';
 import { generateErrorMessage } from '@/shared/constants/error';
+import { REDIRECT_AFTER_LOGIN_KEY } from '@/shared/constants/storageConstants';
 
 type Inputs = {
   email: string;
@@ -28,7 +29,7 @@ export default function SignInForm() {
   const onSubmit: SubmitHandler<Inputs> = async ({ email, password }) => {
     try {
       setLogInError('');
-      localStorage.setItem('redirect_after_login', redirect);
+      localStorage.setItem(REDIRECT_AFTER_LOGIN_KEY, redirect);
       await signInWithPassword({ email, password });
     } catch (error) {
       const message = generateErrorMessage(error);

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -9,6 +9,7 @@ import FormAlertMessage from '@/app/_component/auth/FormAlertMessage';
 import FormField from '@/app/_component/auth/FormField';
 import { generateErrorMessage } from '@/shared/constants/error';
 import { FORM_VALIDATIONS } from '@/shared/constants/validation';
+import { REDIRECT_AFTER_LOGIN_KEY } from '@/shared/constants/storageConstants';
 
 type Inputs = {
   email: string;
@@ -34,10 +35,9 @@ export default function SignUpForm() {
 
   const onSubmit: SubmitHandler<Inputs> = async ({ email, password, name, username }) => {
     setSignUpError('');
-
     try {
-      localStorage.setItem('redirect_after_login', redirect);
       await signUp({ email, password, name, username });
+      localStorage.setItem(REDIRECT_AFTER_LOGIN_KEY, redirect);
     } catch (error) {
       const message = generateErrorMessage(error);
       setSignUpError(message);

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { signUp } from '@/apis/auth';
@@ -28,11 +29,14 @@ export default function SignUpForm() {
     formState: { errors, isValid, isSubmitting }
   } = useForm<Inputs>({ mode: 'onChange' });
   const { password, confirmPassword } = watch();
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect') ?? '/';
 
   const onSubmit: SubmitHandler<Inputs> = async ({ email, password, name, username }) => {
     setSignUpError('');
 
     try {
+      localStorage.setItem('redirect_after_login', redirect);
       await signUp({ email, password, name, username });
     } catch (error) {
       const message = generateErrorMessage(error);

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { Suspense } from 'react';
 import { LayoutContainer } from '@/app/_component/layout/common';
 import SignUpForm from '@/app/_component/auth/SignUpForm';
 import styles from '../login/page.module.scss';
@@ -22,7 +23,9 @@ export default function SignUpPage() {
               회원가입 후, 더욱 편리한 서비스를 이용해 보세요.
             </p>
           </div>
-          <SignUpForm />
+          <Suspense fallback={null}>
+            <SignUpForm />
+          </Suspense>
           <div className={styles.link_group}>
             <p>이미 계정이 있으신가요?</p>
             <Link href="/login">로그인</Link>

--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -14,6 +14,7 @@ import {
 import { supabase } from '@/shared/supabase/client';
 import { AuthError, PostgrestError, Session } from '@supabase/supabase-js';
 import { getProfileById } from '@/apis/user';
+import { REDIRECT_AFTER_LOGIN_KEY } from '@/shared/constants/storageConstants';
 import { ProfileType } from '@/shared/types/types';
 
 const SessionContext = createContext<{
@@ -57,9 +58,9 @@ function SessionContextProvider({ children }: PropsWithChildren) {
           fetchProfile(userId);
         }
 
-        const redirectTo = localStorage.getItem('redirect_after_login');
+        const redirectTo = localStorage.getItem(REDIRECT_AFTER_LOGIN_KEY);
         if (redirectTo) {
-          localStorage.removeItem('redirect_after_login');
+          localStorage.removeItem(REDIRECT_AFTER_LOGIN_KEY);
           router.replace(redirectTo);
         }
       }

--- a/src/shared/constants/storageConstants.ts
+++ b/src/shared/constants/storageConstants.ts
@@ -1,0 +1,3 @@
+export const REDIRECT_AFTER_LOGIN_KEY = 'redirect_after_login';
+export const RESET_AUTH_CODE_KEY = 'reset_auth_code';
+export const RESET_USER_ID_KEY = 'reset_user_id';


### PR DESCRIPTION
## 📌 주요 구현 및 문제 해결 내용

- 회원가입 후 리다이렉트 로직 추가

```tsx
const searchParams = useSearchParams();
const redirect = searchParams.get('redirect') ?? '/';

const onSubmit: SubmitHandler<Inputs> = async ({ email, password, name, username }) => {
  setSignUpError('');
  try {
    localStorage.setItem('redirect_after_login', redirect);
    await signUp({ email, password, name, username });
  } catch (error) {
    const message = generateErrorMessage(error);
    setSignUpError(message);
  }
};
```

## TODO
- [ ] 성공 피드백 제공