### PR TITLE
Feat: 메인 페이지 이미지 최적화로 LCP 7.7s → 1.1s 단축 및 PhotoSwipe 모바일 탭 동작 수정

### DIFF
--- a/src/app/_component/home/AboutOurChurch.module.scss
+++ b/src/app/_component/home/AboutOurChurch.module.scss
@@ -14,28 +14,29 @@
 
 .image_container {
   order: 1;
+  width: 100%;
   display: flex;
   justify-content: center;
+  align-items: center;
   flex-basis: 35%;
 
   .frame {
-    display: inline-flex;
-    align-items: center;
     position: relative;
-    overflow: hidden;
-  }
-
-  img {
     width: 100%;
-    height: auto;
-    aspect-ratio: 5 / 3;
     border: 1px solid $color-border-card;
     border-radius: $border-radius-lg;
+    aspect-ratio: 5 / 3;
+    overflow: hidden;
 
     @include respond-up($breakpoint-lg) {
       border: none;
-      aspect-ratio: 1 / 1;
       border-radius: 50%;
+      aspect-ratio: 1 / 1;
+    }
+
+    img {
+      width: 100%;
+      height: 100%;
     }
   }
 }

--- a/src/app/_component/home/AboutOurChurch.tsx
+++ b/src/app/_component/home/AboutOurChurch.tsx
@@ -1,11 +1,10 @@
 import Link from 'next/link';
 import { LayoutContainer } from '@/components/layout';
-import { getStorageImageUrl } from '@/apis/home';
-import { IMAGE_FILENAME } from '@/constants/assets';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
 import styles from './AboutOurChurch.module.scss';
 
 export default async function AboutOurChurch() {
-  const churchImageUrl = await getStorageImageUrl(IMAGE_FILENAME.church);
+  const IMAGE_PUBLIC_ID = 'about_church_qyqtpk';
 
   return (
     <section className={styles.about}>
@@ -13,7 +12,13 @@ export default async function AboutOurChurch() {
         <div className={styles.container}>
           <div className={styles.image_container}>
             <div className={styles.frame}>
-              <img src={churchImageUrl} alt="대구동남교회 예배당 전경" />
+              <CloudinaryImage
+                src={IMAGE_PUBLIC_ID}
+                alt="대구동남교회 입구 아치형 구조물"
+                fill
+                sizes="(max-width:768px) 100vw, 40vw"
+                style={{ objectFit: 'cover', objectPosition: 'center' }}
+              />
             </div>
           </div>
           <div className={styles.about_info}>

--- a/src/app/_component/home/Banner.module.scss
+++ b/src/app/_component/home/Banner.module.scss
@@ -1,22 +1,42 @@
 $desktop-gradient: linear-gradient(90deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1));
 $mobile-gradient: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
-$banner-image-url: 'https://ndimreqwgdiwtjonjjzq.supabase.co/storage/v1/object/public/homepage_assets/banner_wide.png';
+
+.banner_container {
+  position: relative;
+}
 
 .banner {
   --banner-gradient: #{$mobile-gradient};
+  position: relative;
   padding: $spacing-xxxxl 0;
-  background-image: var(--banner-gradient), url($banner-image-url);
-  background-position:
-    0 0,
-    45% top;
-  background-size: auto, cover;
-  background-repeat: repeat, no-repeat;
   z-index: 1;
 
+  @include respond-up($breakpoint-md) {
+    --banner-gradient: #{$desktop-gradient};
+    padding: $spacing-layout 0;
+  }
+
   .content {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: $spacing-sm;
+    z-index: 2;
+  }
+
+  .banner_image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: 45% 10%;
+    z-index: 0;
+  }
+
+  .overlay {
+    position: absolute;
+    inset: 0;
+    background: var(--banner-gradient);
+    z-index: 1;
   }
 
   h1 {

--- a/src/app/_component/home/Banner.tsx
+++ b/src/app/_component/home/Banner.tsx
@@ -1,12 +1,24 @@
 import Link from 'next/link';
 import { LayoutContainer } from '@/components/layout';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
 import styles from './Banner.module.scss';
 
 export default async function Banner() {
+  const BANNER_PUBLIC_ID = 'banner_nkbhnp';
+
   return (
     <section>
       <div className={styles.banner}>
         <LayoutContainer>
+          <CloudinaryImage
+            src={BANNER_PUBLIC_ID}
+            alt="대구동남교회 전경과 십자가 탑"
+            fill
+            fetchPriority="high"
+            sizes="100vw"
+            className={styles.banner_image}
+          />
+          <div className={styles.overlay} aria-hidden="true" />
           <div className={styles.content}>
             <h1>
               동남교회에 오신 것을

--- a/src/types/photoswipe.ts
+++ b/src/types/photoswipe.ts
@@ -1,0 +1,18 @@
+export type ImageState = {
+  w: number;
+  h: number;
+  loaded: boolean;
+};
+
+export type FallbackSize = {
+  w: number;
+  h: number;
+};
+
+export type PhotoSwipeProps = {
+  images: string[];
+  width: number;
+  height: number;
+  sizes?: string;
+  className?: string;
+};

--- a/src/utils/photoswipe.ts
+++ b/src/utils/photoswipe.ts
@@ -1,0 +1,33 @@
+import { type PhotoSwipeOptions } from 'photoswipe';
+import { type FallbackSize, type ImageState } from '@/types/photoswipe';
+
+export const BACKGROUND_CLASS_NAMES = new Set(['pswp__item', 'pswp__zoom-wrap', 'pswp__container']);
+
+export const BASE_PHOTOSWIPE_OPTIONS: PhotoSwipeOptions = {
+  loop: false,
+  wheelToZoom: true,
+  initialZoomLevel: 'fit',
+  secondaryZoomLevel: 2.5,
+  maxZoomLevel: 6,
+  spacing: 0.01,
+  hideAnimationDuration: 100,
+  errorMsg: '이미지를 불러올 수 없습니다.'
+};
+
+export function isBackgroundTarget(target: HTMLElement): boolean {
+  return [...target.classList].some((cls) => BACKGROUND_CLASS_NAMES.has(cls));
+}
+
+export function getAspectRatio(state: ImageState | undefined, fallback: FallbackSize): string {
+  return state?.loaded ? `${state.w} / ${state.h}` : `${fallback.w} / ${fallback.h}`;
+}
+
+export function getSlideSize(
+  state: ImageState | undefined,
+  fallback: FallbackSize
+): { width: number; height: number } {
+  return {
+    width: Math.round(state?.w ?? fallback.w),
+    height: Math.round(state?.h ?? fallback.h)
+  };
+}


### PR DESCRIPTION
## 🚀 개요 (Summary)

> Cloudinary CDN 도입 및 배너 이미지 렌더링 방식 변경으로 LCP 7.7s → 1.1s (약 85%) 단축
> 모바일 환경에서 갤러리 배경 탭 시 닫히지 않는 버그를 수정, 컴포넌트 구조 개선

## 📌 주요 구현 및 문제 해결 내용

### 메인 페이지 이미지 최적화로 LCP 7.7s → 1.1s로 개선

**문제 상황**

- CSS background-image → <Image priority /> 전환
- 배너 이미지를 CSS background-image로 로드하면 브라우저가 HTML 파싱 → CSS 파싱 → CSSOM 생성 이후에야 이미지를 발견
- preload가 걸리지 않아 LCP에 불리하게 작용

**해결 방안**

- Cloudinary 로더 적용 (f_auto, q_auto)
- PNG 원본(7.9MB)을 뷰포트/디바이스에 맞는 크기의 WebP/AVIF로 변환해 전송

```ts
// utils/cloudinary.ts
const params = ['f_auto', 'q_auto', `w_${width}`].join(',');
return `https://res.cloudinary.com/<cloud-name>/image/upload/${params}/${src}`;
```
**결과**
| 지표                  | Before | After       |
| --------------------- | ------ | ----------- |
| **Performance Score** | 75    | 98         |
| **LCP**               | 7.7s  | 1.1s       |
| FCP                   | 0.7s   | 0.7s        |
| TBT                   | 0ms    | 0ms         |
| 이미지 포맷           | PNG    | WebP / AVIF |
| 이미지 크기           | ~7.9MB | ~300–600KB  |


| Before | After |
|--|--|
| <img width="1920" height="1020" alt="0  메인 페이지 이미지 최적화 전 Lighthouse" src="https://github.com/user-attachments/assets/d8a0373d-c5a5-4cae-88a5-74fe497a9397" /> | <img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/d554bd15-d3cb-45fd-a016-b7866211add7" />|



### 모바일 탭 동작 수정 및 컴포넌트 리팩토링

**문제 상황**

- 모바일 배경 탭 시 갤러리가 닫히지 않는 문제

**원인**
- bgClickAction은 마우스 click 이벤트에만 반응하고 터치 이벤트를 처리하지 않음

**해결 방안**
- tapAction에 커스텀 함수를 작성해 이벤트 타겟의 클래스명으로 배경/이미지 영역을 구분
```tsx
// Before
bgClickAction: 'close'  // 모바일에서 동작 안 함

// After
tapAction: (_, originalEvent) => {
  const target = originalEvent?.target as HTMLElement;
  if (isBackgroundTarget(target)) {
    pswpRef.current?.close();
  } else {
    pswpRef.current?.element?.classList.toggle('pswp--ui-visible');
  }
}
```

**리팩토링**

- `imgDimensions`, `loadedImages` 두 개의 state를 `imageStates: Record<number, ImageState>`로 통합
- 타입 → `src/types/photoswipe.ts`, 상수 및 유틸 → `src/utils/photoswipe.ts` 분리
- `clsx` 적용으로 조건부 className 조합 개선
- 실질적 효과 없는 `useMemo`, `useCallback` 제거

### (+) Gemini Code Assistant 코드 리뷰 반영
**originalEvent.target 타입 단언 → instanceof 타입 가드**
- as HTMLElement 단언은 EventTarget이 HTMLElement가 아닌 경우(예: SVGElement, document) classList 접근 시 런타임 오류 발생 가능
- nstanceof 가드로 교체

```ts
// Before
const target = originalEvent?.target as HTMLElement;
if (isBackgroundTarget(target)) { ... }

// After
const target = originalEvent?.target;
if (target instanceof HTMLElement && isBackgroundTarget(target)) { ... }
```

**IMAGE_PUBLIC_ID 상수 파일 분리**
- Cloudinary public_id를 @/constants/images.ts로 추출

```ts
// src/constants/images.ts
export const IMAGE_PUBLIC_IDS = {
  banner: 'banner_nkbhnp',
  church: 'about_church_qyqtpk',
} as const;
```

**isBackgroundTarget 불필요한 배열 생성 제거**
- [...target.classList]는 탭 이벤트마다 중간 배열을 생성
- DOMTokenList는 이터러블이므로 for...of로 직접 순회해 메모리 할당 최소화

```ts
// Before
return [...target.classList].some((cls) => BACKGROUND_CLASS_NAMES.has(cls));

// After
for (const cls of target.classList) {
  if (BACKGROUND_CLASS_NAMES.has(cls)) return true;
}
return false;
```