### PR TITLE
[Feat] 하드코딩 콘텐츠 DB 연동 및 사이트 설정 관리 기반 구축

### DIFF
--- a/src/apis/site-settings.ts
+++ b/src/apis/site-settings.ts
@@ -1,0 +1,17 @@
+import { createStaticClient } from '@/lib/supabase/static';
+
+export type SiteSettings = Record<string, string>;
+
+export const getSiteSettings = async (keys: string[]): Promise<SiteSettings> => {
+  const supabase = createStaticClient({
+    tags: ['site-settings'],
+    cache: 'force-cache'
+  });
+
+  const { data } = await supabase
+    .from('site_settings')
+    .select('key, value')
+    .in('key', keys);
+
+  return Object.fromEntries((data ?? []).map(({ key, value }) => [key, value]));
+};

--- a/src/apis/staff.ts
+++ b/src/apis/staff.ts
@@ -1,0 +1,10 @@
+import { createStaticClient } from '@/lib/supabase/static';
+
+export const getActiveStaff = () => {
+  const supabase = createStaticClient({
+    tags: ['staff'],
+    cache: 'force-cache'
+  });
+
+  return supabase.from('staff').select('*').eq('is_active', true).order('order_index');
+};

--- a/src/apis/worship-schedules.ts
+++ b/src/apis/worship-schedules.ts
@@ -1,0 +1,14 @@
+import { createStaticClient } from '@/lib/supabase/static';
+
+export const getWorshipSchedules = () => {
+  const supabase = createStaticClient({
+    tags: ['worship-schedules'],
+    cache: 'force-cache'
+  });
+
+  return supabase
+    .from('worship_schedules')
+    .select('*')
+    .eq('is_active', true)
+    .order('order_index');
+};

--- a/src/app/(with-navbar)/about/directions/_component/LocationMap.tsx
+++ b/src/app/(with-navbar)/about/directions/_component/LocationMap.tsx
@@ -4,7 +4,7 @@ import { Map, MapMarker, useMap, ZoomControl } from 'react-kakao-maps-sdk';
 
 export default function LocationMap({ lat, lng, width, height }: LocationMapProps) {
   return (
-    <Map center={{ lat, lng }} style={{ width, height }}>
+    <Map center={{ lat, lng }} style={{ width: '100%', height: '100%' }}>
       <ZoomControl position={'RIGHT'} />
       <EventMarkerContainer lat={lat} lng={lng} />
     </Map>

--- a/src/app/(with-navbar)/about/directions/_component/LocationMapClient.tsx
+++ b/src/app/(with-navbar)/about/directions/_component/LocationMapClient.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const LocationMap = dynamic(() => import('./LocationMap'), { ssr: false });
+
+type Props = { lat: number; lng: number; width: string; height: string };
+
+export default function LocationMapClient({ lat, lng, width, height }: Props) {
+  return (
+    <div style={{ width, height }}>
+      <LocationMap lat={lat} lng={lng} width={width} height={height} />
+    </div>
+  );
+}

--- a/src/app/(with-navbar)/about/directions/page.tsx
+++ b/src/app/(with-navbar)/about/directions/page.tsx
@@ -1,27 +1,37 @@
 import type { Metadata } from 'next';
 import MainContainer from '@/components/layout/container/MainContainer';
-import LocationMap from './_component/LocationMap';
+import { getSiteSettings } from '@/apis/site-settings';
 import styles from './page.module.scss';
 import { MdDirectionsBus, MdLocationOn } from 'react-icons/md';
+import LocationMapClient from './_component/LocationMapClient';
 
 export const metadata: Metadata = {
-  title: '오시는 길 - 대구동남교회',
+  title: '오시는 길',
   description: '대구동남교회에 오시는 방법을 안내합니다.',
   openGraph: {
-    title: '오시는 길 - 대구동남교회',
+    title: '오시는 길',
     description: '대구동남교회에 오시는 방법을 안내합니다.'
   }
 };
 
-const location = {
-  lat: 35.85262832577055,
-  lng: 128.53467835707838
-};
+export default async function Directions() {
+  const settings = await getSiteSettings([
+    'church_address',
+    'church_lat',
+    'church_lng',
+    'directions_subway',
+    'directions_bus_stop_1',
+    'directions_bus_routes_1',
+    'directions_bus_stop_2',
+    'directions_bus_routes_2'
+  ]);
 
-export default function Directions() {
+  const lat = parseFloat(settings.church_lat ?? '35.85262832577055');
+  const lng = parseFloat(settings.church_lng ?? '128.53467835707838');
+
   return (
     <MainContainer title="오시는 길">
-      <LocationMap lat={location.lat} lng={location.lng} width="100%" height="35rem" />
+      <LocationMapClient lat={lat} lng={lng} width="100%" height="35rem" />
       <div className={styles.directions_info}>
         <div className={styles.container}>
           <div className={styles.icon}>
@@ -29,7 +39,7 @@ export default function Directions() {
           </div>
           <div className={styles.info}>
             <h4>주소</h4>
-            <p>대구광역시 달서구 달구벌대로307길 58 (죽전동)</p>
+            <p>{settings.church_address}</p>
           </div>
         </div>
         <div className={styles.container}>
@@ -41,17 +51,18 @@ export default function Directions() {
             <ul>
               <li>
                 <p>
-                  <mark>지하철</mark> 2호선 죽전역 1번 출구 (도보 8분)
+                  <mark>지하철</mark> {settings.directions_subway}
                 </p>
               </li>
               <li>
                 <p>
-                  <mark>버스</mark> 죽전네거리 405 425 509 527 달서5 성서2 250
+                  <mark>버스</mark> {settings.directions_bus_stop_1}{' '}
+                  {settings.directions_bus_routes_1}
                 </p>
               </li>
               <li>
                 <p>
-                  <mark></mark> 죽전119안전센터앞 503 서구 1-1
+                  <mark></mark> {settings.directions_bus_stop_2} {settings.directions_bus_routes_2}
                 </p>
               </li>
             </ul>

--- a/src/app/(with-navbar)/about/serving-people/page.tsx
+++ b/src/app/(with-navbar)/about/serving-people/page.tsx
@@ -1,47 +1,32 @@
 import type { Metadata } from 'next';
 import React from 'react';
 import MainContainer from '@/components/layout/container/MainContainer';
+import { getActiveStaff } from '@/apis/staff';
+import type { StaffType } from '@/types/common';
 import styles from './page.module.scss';
 
 export const metadata: Metadata = {
-  title: '섬기는 이 - 대구동남교회',
+  title: '섬기는 이',
   description: '각 사역자들의 역할과 사역에 대한 정보를 확인해 보세요.',
   openGraph: {
-    title: '섬기는 이 - 대구동남교회',
+    title: '섬기는 이',
     description: '각 사역자들의 역할과 사역에 대한 정보를 확인해 보세요.'
   }
 };
 
-const pastorProfile = [
-  {
-    name: '김성규',
-    title: '담임목사',
-    image: '/images/senior-profile-image.jpg',
-    education: ['합동신학대학원대학교 졸업'],
-    experience: ['합신 총동문회장'],
-    contact: 'purityk@hanmail.net'
-  },
-  {
-    name: '박지권',
-    title: '교육목사',
-    image: '/images/assistant-profile-image.jpg',
-    education: ['합동신학대학원대학교 졸업'],
-    experience: ['대구 DFC 대표'],
-    contact: 'gwon56@naver.com'
-  }
-];
+export default async function ServingPeople() {
+  const { data: staffList } = await getActiveStaff();
 
-export default function ServingPeople() {
   return (
     <MainContainer title="섬기는 이">
       <div className={styles.wrap}>
-        {pastorProfile.map((profile, idx) =>
+        {(staffList ?? []).map((staff, idx) =>
           idx === 0 ? (
-            <PastorProfile key={profile.name + idx} profile={profile} />
+            <StaffProfile key={staff.id} staff={staff} />
           ) : (
-            <React.Fragment key={profile.name + idx}>
+            <React.Fragment key={staff.id}>
               <hr className={styles.divide} />
-              <PastorProfile profile={profile} />
+              <StaffProfile staff={staff} />
             </React.Fragment>
           )
         )}
@@ -50,40 +35,46 @@ export default function ServingPeople() {
   );
 }
 
-const PastorProfile = ({ profile }: { profile: (typeof pastorProfile)[0] }) => (
+const StaffProfile = ({ staff }: { staff: StaffType }) => (
   <div className={styles.profile}>
     <div className={styles.title}>
       <h4>
-        {profile.title} {profile.name}
+        {staff.title} {staff.name}
       </h4>
     </div>
     <div className={styles.detail}>
       <div className={styles.image_wrap}>
-        <img src={profile.image} alt="프로필 이미지" />
+        <img src={staff.image_url ?? ''} alt="프로필 이미지" />
       </div>
       <div className={styles.content}>
-        <div>
-          <h5>학력</h5>
-          <ul>
-            {profile.education.map((edu, idx) => (
-              <li key={idx}>{edu}</li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h5>약력</h5>
-          <ul>
-            {profile.experience.map((exp, idx) => (
-              <li key={idx}>{exp}</li>
-            ))}
-          </ul>
-        </div>
-        <div>
-          <h5>연락처</h5>
-          <ul>
-            <li>{profile.contact}</li>
-          </ul>
-        </div>
+        {staff.education.length > 0 && (
+          <div>
+            <h5>학력</h5>
+            <ul>
+              {staff.education.map((edu, idx) => (
+                <li key={idx}>{edu}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {staff.experience.length > 0 && (
+          <div>
+            <h5>약력</h5>
+            <ul>
+              {staff.experience.map((exp, idx) => (
+                <li key={idx}>{exp}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {staff.contact && (
+          <div>
+            <h5>연락처</h5>
+            <ul>
+              <li>{staff.contact}</li>
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   </div>

--- a/src/app/(with-navbar)/about/worship/_component/WorshipSchedule.module.scss
+++ b/src/app/(with-navbar)/about/worship/_component/WorshipSchedule.module.scss
@@ -3,16 +3,16 @@
   border-collapse: collapse;
 
   th {
-    padding: 0.8rem 1rem;
-    background-color: rgba(35, 19, 5, 0.9);
-    border-collapse: collapse;
-    color: white;
-    font-weight: 500;
+    padding: $spacing-xs $spacing-sm;
+    background-color: $color-primary;
+    color: $color-white;
+    font-size: $font-size-default;
+
+    font-weight: $font-weight-medium;
     text-align: center;
 
     &:first-child {
       width: 37%;
-      border-left: none;
     }
 
     &:nth-child(2) {
@@ -21,7 +21,6 @@
 
     &:nth-child(3) {
       width: 30%;
-      border-right: none;
     }
   }
 
@@ -30,18 +29,13 @@
     word-break: keep-all;
 
     td {
-      padding: 1rem;
-      border-collapse: collapse;
-      background-color: rgba(253, 231, 211, 0.2);
+      padding: $spacing-sm;
+      background-color: $color-bg-default;
+      font-size: $font-size-md;
     }
 
     td:first-child {
-      font-weight: 500;
-      border-left: none;
-    }
-
-    td:last-child {
-      border-right: none;
+      font-weight: $font-weight-medium;
     }
   }
 }

--- a/src/app/(with-navbar)/about/worship/_component/WorshipSchedule.tsx
+++ b/src/app/(with-navbar)/about/worship/_component/WorshipSchedule.tsx
@@ -6,12 +6,12 @@ import {
   getCoreRowModel,
   useReactTable
 } from '@tanstack/react-table';
-import { ScheduleType } from '../page';
+import type { WorshipScheduleType } from '@/types/common';
 import styles from './WorshipSchedule.module.scss';
 
-const columnHelper = createColumnHelper<ScheduleType[0]>();
+const columnHelper = createColumnHelper<WorshipScheduleType>();
 const columns = [
-  columnHelper.accessor('worship', {
+  columnHelper.accessor('name', {
     id: '구분',
     header: (info) => info.column.id,
     cell: (info) => info.getValue()
@@ -28,7 +28,7 @@ const columns = [
   })
 ];
 
-export default function WorshipSchedule({ schedule }: { schedule: ScheduleType }) {
+export default function WorshipSchedule({ schedule }: { schedule: WorshipScheduleType[] }) {
   const table = useReactTable({
     data: schedule,
     columns,

--- a/src/app/(with-navbar)/about/worship/page.module.scss
+++ b/src/app/(with-navbar)/about/worship/page.module.scss
@@ -1,19 +1,19 @@
 .container {
-  padding: 0 2rem;
+  padding: $spacing-0 $spacing-lg;
 
   @include respond($breakpoint-lg) {
-    padding: 0;
+    padding: $spacing-0;
   }
 
   div:first-child {
-    margin-bottom: 4rem;
+    margin-bottom: $spacing-xxl;
   }
 }
 
 .schedule {
   h4 {
-    margin-bottom: 1.4rem;
-    padding-left: 1.6rem;
+    margin-bottom: $spacing-md;
+    padding-left: $spacing-md;
     position: relative;
   }
 
@@ -22,8 +22,8 @@
     position: absolute;
     top: 50%;
     left: 0;
-    width: 0.8rem;
-    height: 0.8rem;
+    width: $spacing-xs;
+    height: $spacing-xs;
     background-color: $color-primary;
     border-radius: 50%;
     transform: translateY(-50%);

--- a/src/app/(with-navbar)/about/worship/page.tsx
+++ b/src/app/(with-navbar)/about/worship/page.tsx
@@ -1,46 +1,37 @@
 import type { Metadata } from 'next';
 import MainContainer from '@/components/layout/container/MainContainer';
 import WorshipSchedule from './_component/WorshipSchedule';
+import { getWorshipSchedules } from '@/apis/worship-schedules';
 import styles from './page.module.scss';
 
 export const metadata: Metadata = {
-  title: '예배안내 - 대구동남교회',
+  title: '예배안내',
   description:
     '대구동남교회 예배안내 - 주일낮예배(11:00), 주일저녁예배(18:00), 새벽기도회(05:30), 수요기도회(19:00), 금요기도회(20:00)',
   openGraph: {
-    title: '예배안내 - 대구동남교회',
+    title: '예배안내',
     description:
       '대구동남교회 예배안내 - 주일낮예배(11:00), 주일저녁예배(18:00), 새벽기도회(05:30), 수요기도회(19:00), 금요기도회(20:00)'
   }
 };
 
-export type ScheduleType = typeof churchData;
-const churchData = [
-  { worship: '새벽기도회', time: '매일 오전 05:30', location: '소예배실' },
-  { worship: '주일낮예배', time: '오전 11:00', location: '대예배실' },
-  { worship: '주일저녁예배', time: '오후 06:00', location: '대예배실' },
-  { worship: '수요기도회', time: '오후 07:00', location: '대예배실' },
-  { worship: '금요기도회', time: '오후 08:00', location: '대예배실' }
-];
+export default async function Worship() {
+  const { data } = await getWorshipSchedules();
+  const schedules = data ?? [];
 
-const sundaySchoolData = [
-  { worship: '유치부', time: '오전 09:00', location: '소예배실' },
-  { worship: '초등부', time: '오전 09:00', location: '교육관 유초등부실' },
-  { worship: '중고등부', time: '오전 09:00', location: '대예배실' },
-  { worship: '청년부', time: '오후 01:30', location: '대예배실' }
-];
+  const mainSchedules = schedules.filter((s) => s.category === 'main');
+  const churchSchoolSchedules = schedules.filter((s) => s.category === 'church_school');
 
-export default function Worship() {
   return (
     <MainContainer title="예배안내">
       <div className={styles.container}>
         <div className={styles.schedule}>
           <h4>예배시간</h4>
-          <WorshipSchedule schedule={churchData} />
+          <WorshipSchedule schedule={mainSchedules} />
         </div>
         <div className={styles.schedule}>
           <h4>교회학교 예배시간</h4>
-          <WorshipSchedule schedule={sundaySchoolData} />
+          <WorshipSchedule schedule={churchSchoolSchedules} />
         </div>
       </div>
     </MainContainer>

--- a/src/app/(with-navbar)/layout.tsx
+++ b/src/app/(with-navbar)/layout.tsx
@@ -1,13 +1,15 @@
-'use client';
-
 import { PropsWithChildren } from 'react';
 import HeroSection from '@/components/layout/hero/HeroSection';
 import Breadcrumb from '@/components/layout/hero/Breadcrumb';
+import { getSiteSettings } from '@/apis/site-settings';
+import { getAllHeroImageKeys } from '@/utils/sitemap';
 
-export default function Layout({ children }: PropsWithChildren) {
+export default async function Layout({ children }: PropsWithChildren) {
+  const heroImageOverrides = await getSiteSettings(getAllHeroImageKeys());
+
   return (
     <>
-      <HeroSection />
+      <HeroSection heroImageOverrides={heroImageOverrides} />
       <Breadcrumb />
       {children}
     </>

--- a/src/app/_component/home/AboutOurChurch.tsx
+++ b/src/app/_component/home/AboutOurChurch.tsx
@@ -1,10 +1,12 @@
 import Link from 'next/link';
 import { LayoutContainer } from '@/components/layout';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
-import { IMAGE_PUBLIC_IDS } from '@/constants/images';
+import { getSiteSettings } from '@/apis/site-settings';
 import styles from './AboutOurChurch.module.scss';
 
 export default async function AboutOurChurch() {
+  const settings = await getSiteSettings(['about_slogan', 'about_intro_1', 'about_intro_2', 'about_church_image']);
+
   return (
     <section className={styles.about}>
       <LayoutContainer>
@@ -12,7 +14,7 @@ export default async function AboutOurChurch() {
           <div className={styles.image_container}>
             <div className={styles.frame}>
               <CloudinaryImage
-                src={IMAGE_PUBLIC_IDS.church}
+                src={settings.about_church_image ?? 'about_church_qyqtpk'}
                 alt="대구동남교회 입구 아치형 구조물"
                 fill
                 sizes="(max-width:768px) 100vw, 40vw"
@@ -21,19 +23,11 @@ export default async function AboutOurChurch() {
             </div>
           </div>
           <div className={styles.about_info}>
-            <span>바른 신학, 바른 교회, 바른 생활</span>
+            <span>{settings.about_slogan}</span>
             <h2>동남교회를 소개합니다</h2>
             <div className={styles.about_content}>
-              <p>
-                동남교회는 대한예수교장로회(합신) 교단 소속으로, 오직 성경만을 유일한 규칙으로 삼는
-                개혁주의 신앙을 고백합니다. 바른 신학 위에 굳건히 서서 이 땅에 하나님 나라를
-                확장하는 건강한 공동체를 세우는 것을 최우선 목적으로 합니다.
-              </p>
-              <p>
-                바른 신학의 토대 위에서 바른 교회, 바른 생활의 정신을 실천합니다. 그리스도께서
-                모범을 보이신 것처럼 모든 성도가 겸손한 섬김의 자세로 서로를 존중하며 사랑 안에서
-                굳건히 연합하는 공동체를 지향합니다.
-              </p>
+              <p>{settings.about_intro_1}</p>
+              <p>{settings.about_intro_2}</p>
             </div>
             <Link href="/about">교회소개 살펴보기</Link>
           </div>

--- a/src/app/_component/home/Banner.module.scss
+++ b/src/app/_component/home/Banner.module.scss
@@ -1,45 +1,55 @@
 $desktop-gradient: linear-gradient(90deg, rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.1));
 $mobile-gradient: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4));
 
-.banner_container {
-  position: relative;
-}
-
 .banner {
   margin-top: calc(-1 * $header-height);
-
-  --banner-gradient: #{$mobile-gradient};
   position: relative;
-  padding: calc($spacing-xxxxl + $header-height / 2) 0;
-
-  z-index: 1;
+  height: calc(36rem + $header-height);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
   @include respond-up($breakpoint-md) {
-    --banner-gradient: #{$desktop-gradient};
-    padding: calc($spacing-layout + $header-height / 2) 0;
+    height: calc(42rem + $header-height);
   }
+}
 
-  .content {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: $spacing-sm;
-    z-index: 2;
-  }
+.bg {
+  position: absolute;
+  inset: 0;
 
-  .banner_image {
+  img {
     width: 100%;
     height: 100%;
     object-fit: cover;
     object-position: 45% 10%;
-    z-index: 0;
   }
+}
 
-  .overlay {
-    position: absolute;
-    inset: 0;
-    background: var(--banner-gradient);
-    z-index: 1;
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: $mobile-gradient;
+
+  @include respond-up($breakpoint-md) {
+    background: $desktop-gradient;
+  }
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-sm;
+  padding: $header-height $spacing-lg $spacing-lg;
+  max-width: $max-width;
+  margin: 0 auto;
+  width: 100%;
+
+  @include respond-up($breakpoint-md) {
+    padding: $header-height $spacing-xl $spacing-xl;
   }
 
   h1 {
@@ -52,30 +62,22 @@ $mobile-gradient: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4)
     line-height: $line-height-wide;
     animation: slideUp 0.6s ease-out;
   }
+}
 
-  .learn_more {
-    padding: $spacing-sm $spacing-xl;
-    margin-top: $spacing-xs;
-    display: inline-block;
-    width: fit-content;
-    background-color: $color-gray-100;
-    border-radius: $border-radius-lg;
-    font-size: $font-size-md;
-    color: $color-black;
-    animation: slideUp 0.6s ease-out;
-    transition: transform 325ms cubic-bezier(0, 0, 0.2, 1);
+.learn_more {
+  padding: $spacing-sm $spacing-xl;
+  margin-top: $spacing-xs;
+  display: inline-block;
+  width: fit-content;
+  background-color: $color-gray-100;
+  border-radius: $border-radius-lg;
+  font-size: $font-size-md;
+  color: $color-black;
+  animation: slideUp 0.6s ease-out;
+  transition: transform 325ms cubic-bezier(0, 0, 0.2, 1);
 
-    &:hover {
-      transform: scale(1.05);
-    }
-  }
-
-  @include respond-up($breakpoint-md) {
-    --banner-gradient: #{$desktop-gradient};
-    padding: $spacing-layout 0;
-    background-position:
-      0 0,
-      50% 10%;
+  &:hover {
+    transform: scale(1.05);
   }
 }
 

--- a/src/app/_component/home/Banner.tsx
+++ b/src/app/_component/home/Banner.tsx
@@ -1,39 +1,30 @@
 import Link from 'next/link';
-import { LayoutContainer } from '@/components/layout';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
-import { IMAGE_PUBLIC_IDS } from '@/constants/images';
+import SettingsText from '@/components/common/SettingsText';
+import { getSiteSettings } from '@/apis/site-settings';
 import styles from './Banner.module.scss';
 
 export default async function Banner() {
+  const settings = await getSiteSettings(['banner_title', 'banner_subtitle', 'banner_image']);
+
   return (
-    <section>
-      <div className={styles.banner}>
-        <LayoutContainer>
-          <CloudinaryImage
-            src={IMAGE_PUBLIC_IDS.banner}
-            alt="대구동남교회 전경과 십자가 탑"
-            fill
-            fetchPriority="high"
-            sizes="100vw"
-            className={styles.banner_image}
-          />
-          <div className={styles.overlay} aria-hidden="true" />
-          <div className={styles.content}>
-            <h1>
-              동남교회에 오신 것을
-              <br />
-              환영합니다
-            </h1>
-            <p>
-              수고하고 무거운 짐진 당신을 주님의 사랑으로 초대합니다.&nbsp;
-              <br className="hidden-on-mobile" />
-              마음의 짐을 내려놓고 참된 안식을 누리세요.
-            </p>
-            <Link href="/about" className={styles.learn_more}>
-              처음 오셨나요?
-            </Link>
-          </div>
-        </LayoutContainer>
+    <section className={styles.banner}>
+      <div className={styles.bg}>
+        <CloudinaryImage
+          src={settings.banner_image ?? 'banner_nkbhnp'}
+          alt="대구동남교회 전경과 십자가 탑"
+          fill
+          fetchPriority="high"
+          sizes="100vw"
+        />
+        <div className={styles.overlay} aria-hidden="true" />
+      </div>
+      <div className={styles.content}>
+        <h1><SettingsText value={settings.banner_title} /></h1>
+        <p><SettingsText value={settings.banner_subtitle} /></p>
+        <Link href="/about" className={styles.learn_more}>
+          처음 오셨나요?
+        </Link>
       </div>
     </section>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
         />
       </head>
       <body>
-        <Script src={API_KEY} strategy="lazyOnload" />
+        <Script src={API_KEY} strategy="afterInteractive" />
         <KakaoScript />
         <div id="root">
           <SessionContextProvider>

--- a/src/components/common/SettingsText.tsx
+++ b/src/components/common/SettingsText.tsx
@@ -1,0 +1,21 @@
+type Props = {
+  value: string | undefined;
+  fallback?: string;
+};
+
+export default function SettingsText({ value, fallback = '' }: Props) {
+  const lines = (value ?? fallback).split('\n');
+
+  if (lines.length === 1) return <>{lines[0]}</>;
+
+  return (
+    <>
+      {lines.map((line, i) => (
+        <span key={i}>
+          {line}
+          {i < lines.length - 1 && <br />}
+        </span>
+      ))}
+    </>
+  );
+}

--- a/src/components/layout/header/Drawer.module.scss
+++ b/src/components/layout/header/Drawer.module.scss
@@ -18,7 +18,7 @@
   }
 
   .top {
-    padding: $spacing-sm $spacing-lg;
+    padding: $spacing-sm $spacing-xl;
     display: flex;
     justify-content: flex-end;
     align-items: center;

--- a/src/components/layout/header/MobileNavigation.module.scss
+++ b/src/components/layout/header/MobileNavigation.module.scss
@@ -34,6 +34,10 @@
 
 .menu_list {
   border-top: 0.2rem solid $color-black;
+
+  li:first-child {
+    margin-top: $spacing-xs;
+  }
 }
 
 .menu_header {

--- a/src/components/layout/hero/HeroSection.module.scss
+++ b/src/components/layout/hero/HeroSection.module.scss
@@ -1,8 +1,6 @@
 .hero {
   margin-top: calc(-1 * $header-height);
-
   position: relative;
-  width: 100%;
   height: calc(30rem + $header-height);
   overflow: hidden;
 

--- a/src/components/layout/hero/HeroSection.tsx
+++ b/src/components/layout/hero/HeroSection.tsx
@@ -5,9 +5,13 @@ import { resolveHeroMeta } from '@/utils/sitemap';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
 import styles from './HeroSection.module.scss';
 
-export default function HeroSection() {
+type Props = {
+  heroImageOverrides?: Record<string, string>;
+};
+
+export default function HeroSection({ heroImageOverrides = {} }: Props) {
   const pathname = usePathname();
-  const { title, description, heroImageId } = resolveHeroMeta(pathname);
+  const { title, description, heroImageId } = resolveHeroMeta(pathname, heroImageOverrides);
 
   return (
     <section className={styles.hero} aria-label={`${title} 히어로 섹션`}>

--- a/src/constants/images.ts
+++ b/src/constants/images.ts
@@ -1,4 +1,0 @@
-export const IMAGE_PUBLIC_IDS = {
-  banner: 'banner_nkbhnp',
-  church: 'about_church_qyqtpk'
-} as const;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,6 +1,8 @@
 import { Tables } from '@/types/database.types';
 
 export type ProfileType = Tables<'profiles'>;
+export type StaffType = Tables<'staff'>;
+export type WorshipScheduleType = Tables<'worship_schedules'>;
 export type BulletinType = Tables<'bulletins'>;
 export type BulletinImageType = Tables<'bulletin_images'>;
 export type NoticeType = Tables<'notices'>;

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -175,6 +175,105 @@ export type Database = {
         }
         Relationships: []
       }
+      site_settings: {
+        Row: {
+          key: string
+          value: string
+          description: string | null
+          updated_at: string
+        }
+        Insert: {
+          key: string
+          value: string
+          description?: string | null
+          updated_at?: string
+        }
+        Update: {
+          key?: string
+          value?: string
+          description?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      worship_schedules: {
+        Row: {
+          id: number
+          name: string
+          time: string
+          location: string
+          category: Database["public"]["Enums"]["worship_category"]
+          order_index: number
+          is_active: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: never
+          name: string
+          time: string
+          location: string
+          category: Database["public"]["Enums"]["worship_category"]
+          order_index?: number
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: never
+          name?: string
+          time?: string
+          location?: string
+          category?: Database["public"]["Enums"]["worship_category"]
+          order_index?: number
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      staff: {
+        Row: {
+          contact: string | null
+          created_at: string
+          education: string[]
+          experience: string[]
+          id: number
+          image_url: string | null
+          is_active: boolean
+          name: string
+          order_index: number
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          contact?: string | null
+          created_at?: string
+          education?: string[]
+          experience?: string[]
+          id?: number
+          image_url?: string | null
+          is_active?: boolean
+          name: string
+          order_index?: number
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          contact?: string | null
+          created_at?: string
+          education?: string[]
+          experience?: string[]
+          id?: number
+          image_url?: string | null
+          is_active?: boolean
+          name?: string
+          order_index?: number
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       [_ in never]: never
@@ -252,6 +351,7 @@ export type Database = {
         | "행정"
         | "긴급"
         | "기타"
+      worship_category: "main" | "church_school"
       profile_status_enum: "pending" | "approved" | "rejected"
       role_enum: "admin" | "dept_manager" | "member"
     }

--- a/src/utils/sitemap.ts
+++ b/src/utils/sitemap.ts
@@ -15,16 +15,31 @@ export function resolveCurrentNode(pathname: string): {
   return { parent: null, child: null };
 }
 
-export function resolveHeroMeta(pathname: string): {
+export function resolveHeroMeta(
+  pathname: string,
+  overrides: Record<string, string> = {}
+): {
   title: string;
   description: string;
   heroImageId: string;
 } {
   const { parent, child } = resolveCurrentNode(pathname);
   const node = child ?? parent;
+  const key = pathToHeroImageKey(pathname);
   return {
     title: node?.title ?? '',
     description: node?.description ?? '',
-    heroImageId: node?.heroImageId ?? ''
+    heroImageId: overrides[key] ?? node?.heroImageId ?? ''
   };
+}
+
+export function pathToHeroImageKey(path: string): string {
+  return `hero_image${path.replaceAll('/', '_')}`;
+}
+
+export function getAllHeroImageKeys(): string[] {
+  return sitemap.flatMap((item) => [
+    pathToHeroImageKey(item.path),
+    ...(item.children?.map((c) => pathToHeroImageKey(c.path)) ?? [])
+  ]);
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

하드코딩으로 관리되던 사이트 콘텐츠(사역자 프로필, 예배 일정, 배너·이미지·주소 등)를 Supabase DB 기반으로 전환. 관리자 콘텐츠 관리 기능의 기반 구축 및 Kakao 지도 미표시·Layout Shift 버그 수정.

<br/>

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- 사역자 프로필, 예배 일정, 배너 텍스트·이미지, 교회 주소 등 JSX/상수 파일 하드코딩 → 내용 수정 시 코드 배포 필수
- `IMAGE_PUBLIC_IDS` 상수의 Cloudinary 경로가 flat 구조 → 환경 분리(dev/prod) 불가, 이미지 교체 시 배포 강제
- HeroSection 히어로 이미지 전 페이지 동일(`bible_qfgnyq`) 하드코딩 → 페이지별 커스터마이징 불가
- `/about/directions` 페이지 Kakao 지도 미렌더링 버그 (`ssr: false` in Server Component, Script strategy 오류, CLS)

<br/>

## 🔧 주요 변경점 (Key Changes)

- `staff`, `worship_schedules`, `site_settings` 테이블 신설 및 RLS 설정 (마이그레이션 3개 추가)
- `src/apis/` 레이어에 `site-settings.ts`, `staff.ts`, `worship-schedules.ts` 추가 — `force-cache` 기반 정적 fetch
- 홈 배너·교회소개, 예배 일정, 사역자 프로필, 오시는 길 페이지 DB 조회 전환
- `src/constants/images.ts` (`IMAGE_PUBLIC_IDS`) 삭제 — `site_settings.banner_image`, `site_settings.about_church_image` 대체
- `SettingsText` 공용 컴포넌트 추가 — `site_settings` 텍스트의 `\n` 개행을 `<br>` 렌더링
- `Banner` 컴포넌트 HeroSection과 동일한 `bg` / `content` 분리 구조로 통일
- HeroSection `heroImageOverrides` prop 추가, `(with-navbar)/layout.tsx` Server Component 전환 — 히어로 이미지 `site_settings` 일괄 fetch 후 전달
- `utils/sitemap.ts`에 `pathToHeroImageKey`, `getAllHeroImageKeys` 유틸 추가
- `LocationMapClient.tsx` 분리 — `ssr: false` Server Component 오류 해결, 래퍼 div CLS 제거

<br/>

## 🏗️ 설계 결정 사항 (Design Decisions)

| 고려한 대안 | 선택한 방법 | 선택 이유 |
| ----------- | ----------- | --------- |
| `site_settings`에 Cloudinary 전체 URL 저장 | Cloudinary **public ID** 저장 | URL 저장 시 CloudinaryImage 커스텀 로더 우회 → 이미지 최적화 불가 |
| 히어로 이미지용 `page_settings` 별도 테이블 | `site_settings`에 경로 기반 키(`hero_image_{path}`) | 변경 빈도 낮음, 추가 테이블 없이 기존 패턴 재사용. title/description 관리 필요 시 분리 예정 |
| `dangerouslySetInnerHTML` + DOMPurify 줄바꿈 처리 | `SettingsText` 컴포넌트 (`\n` split) | Server Component에서 DOMPurify 동작 불가(DOM 의존). isomorphic-dompurify는 jsdom으로 번들 과다 증가. `site_settings` admin 전용 쓰기(RLS)로 XSS 위험 낮음 |
| `directions/page.tsx` `'use client'` 전환 | `LocationMapClient.tsx` Client Component 래퍼 분리 | 페이지 레벨 `getSiteSettings` Server-side fetch 필요 → Server Component 유지 |
| 히어로 이미지 `revalidate: N` TTL 기반 캐싱 | `force-cache` + `revalidateTag` | 변경 주체가 관리자로 한정 → 명시적 무효화가 TTL보다 정확, 불필요한 재검증 제거 |

> ⚠️ **트레이드오프:**
> - `site_settings` 키 누적 증가(히어로 이미지 11개, 홈 섹션 10개 등) → 관리자 UI 없이는 Supabase 대시보드 직접 수정 필요. Phase 1 관리자 UI 구현 전까지 운영 난이도 존재.
> - `getAllHeroImageKeys()` `sitemap.ts` 전체 순회 → 사이트맵 확장 시 fetch 키 수 비례 증가. 현재 페이지 수 기준 무관.

<br/>

## 📊 다이어그램 (Diagrams)

### site_settings 데이터 흐름

```mermaid
flowchart TD
    DB[(Supabase\nsite_settings)] -->|force-cache| API[getSiteSettings]
    DB2[(Supabase\nstaff)] -->|force-cache| API2[getActiveStaff]
    DB3[(Supabase\nworship_schedules)] -->|force-cache| API3[getWorshipSchedules]

    API --> Banner[Banner.tsx\nServer Component]
    API --> About[AboutOurChurch.tsx]
    API --> Directions[directions/page.tsx]
    API --> Layout["(with-navbar)/layout.tsx"]
    API2 --> ServingPeople[serving-people/page.tsx]
    API3 --> Worship[worship/page.tsx]

    Layout -->|heroImageOverrides props| Hero[HeroSection\nClient Component]
    Hero -->|usePathname + override| Render[히어로 이미지 렌더링]
```

### HeroSection 이미지 결정 로직

```mermaid
flowchart TD
    P[pathname] --> K[pathToHeroImageKey]
    K --> L{site_settings\noverrides에 키 존재?}
    L -->|Yes| DB[DB public ID 사용]
    L -->|No| S[sitemap.ts heroImageId fallback]
```

<br/>

## ✅ 검증 결과 (Verification)

**수행한 테스트:**

- [ ] 단위 테스트 (Unit Test)
- [ ] 통합 테스트 (Integration Test)
- [x] 수동 테스트 (Manual Test)

**테스트 결과 / 스크린샷:**

| 항목 | 결과 |
| ------ | ----- |
| 홈 배너 텍스트·이미지 DB 조회 | ✅ |
| 홈 교회소개 텍스트·이미지 DB 조회 | ✅ |
| 예배 안내 DB 조회 (main / church_school 분리) | ✅ |
| 사역자 프로필 DB 조회 | ✅ |
| 오시는 길 주소·지도 DB 조회 | ✅ |
| Kakao 지도 정상 렌더링 | ✅ |
| Kakao 지도 CLS 없음 | ✅ |

<br/>

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 원래 요구사항을 충족하는가?
- [x] Null, 빈 배열 등 엣지 케이스를 처리했는가?
  - `site_settings` 값 없을 때 기존 하드코딩 값 fallback 유지
  - `heroImageId` override 없을 때 `sitemap.ts` 값 fallback

**코드 품질**

- [x] 변수명·함수명이 의도를 명확히 드러내는가?
- [x] 복잡한 로직에 설명 주석을 추가했는가?
- [x] 불필요한 코드나 디버그 로그를 제거했는가?

**보안 및 견고성**

- [x] 하드코딩된 비밀값(토큰, 비밀번호)이 없는가?
- [x] 사용자 입력값이 적절히 검증되는가?
  - `site_settings` 쓰기 RLS로 admin 전용

**성능**

- [x] 불필요한 반복 연산이나 리소스 낭비가 없는가?
- [x] DB 쿼리가 효율적인가?
  - `force-cache` 캐싱, 관리자 수정 시만 `revalidateTag` 갱신
  - 히어로 이미지 설정 layout에서 단일 fetch

**테스트 및 문서화**

- [ ] 새 기능에 대한 테스트를 추가했는가?
- [x] README 또는 API 문서에 변경 사항을 반영했는가?
  - `CLAUDE.md` 데이터 페칭 전략 섹션 업데이트
  - `ADMIN_CONTENT_PLAN.md` 관리자 기능 로드맵 작성
- [x] 커밋 메시지가 Conventional Commits 규격을 따르는가?

<br/>

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

**Cloudinary 이미지 이전**

기존 이미지(`banner_nkbhnp`, `about_church_qyqtpk`) 새 폴더 구조로 이전 후 `site_settings` value 업데이트 필요:
```
dnchurch-prod/site/home/banner
dnchurch-prod/site/home/about-church
```

**관리자 UI 다음 단계**

Phase 1(사이트 설정 편집기) → Phase 2(사역자 관리) → Phase 3(예배 일정 관리) 순 구현 예정.
