### PR TITLE
[Refactor] Semantic Design Token 시스템 도입 및 디자인 인프라 개선

### DIFF
--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,3 +1,5 @@
+@use '@/styles/_variables.scss' as *;
+
 @mixin respond-fonts($width, $font-size) {
   @media screen and (min-width: $width) {
     html {
@@ -49,30 +51,24 @@
   -ms-user-select: none;
 }
 
-// TODO: renew
-@mixin back-button-style {
-  padding: 0 4rem;
-  min-width: 14rem;
-  min-height: 4rem;
-  border-radius: 0.4rem;
-  font-size: 1.4rem;
-  line-height: 4rem;
-}
-
+/// 폼 액션 버튼 (제출, 취소 등)
 @mixin action-button-style {
-  padding: 0 4rem;
+  padding: 0 $spacing-3xl;
   min-width: 14rem;
-  min-height: 4rem;
-  border-radius: 0.4rem;
-  font-size: 1.4rem;
-  line-height: 4rem;
+  min-height: $spacing-3xl;
+  border-radius: $radius-control;
+  font-size: $font-size-md;
+  font-weight: $font-weight-semibold;
+  line-height: $spacing-3xl;
 }
 
+/// 링크 호버 — 밑줄 + 활성 색상
 @mixin link-hover-style {
   text-decoration: underline;
-  color: #1f5da9;
+  color: $color-text-link-active;
 }
 
+/// 버튼 배경/텍스트 색상 + 호버 상태
 @mixin button-hover-style($options) {
   background-color: map-get($options, bg-color);
   color: map-get($options, text-color);
@@ -89,4 +85,101 @@
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-all;
+}
+
+// ══════════════════════════════════════════
+// TEXT ROLE MIXINS
+// 텍스트 역할별 font-size + weight + line-height + color 조합
+// 헤딩 계열은 반응형(mobile → PC) 포함
+// ══════════════════════════════════════════
+
+/// 히어로 타이틀 — 배너, 랜딩 최상단 (h1 반응형)
+@mixin text-hero {
+  font-size: $font-size-h1-mobile;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-heading;
+  letter-spacing: $letter-spacing-heading;
+
+  @include respond-up($breakpoint-lg) {
+    font-size: $font-size-h1;
+  }
+}
+
+/// 페이지 타이틀 — 각 페이지 최상위 제목 (h2 반응형)
+@mixin text-page-title {
+  font-size: $font-size-h2-mobile;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-heading;
+  letter-spacing: $letter-spacing-heading;
+
+  @include respond-up($breakpoint-lg) {
+    font-size: $font-size-h2;
+  }
+}
+
+/// 섹션 타이틀 — 페이지 내 구역 제목 (h3 반응형)
+@mixin text-section-title {
+  font-size: $font-size-h3-mobile;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-heading;
+  letter-spacing: $letter-spacing-tight;
+
+  @include respond-up($breakpoint-lg) {
+    font-size: $font-size-h3;
+  }
+}
+
+/// 서브 섹션 타이틀 — 섹션 내 하위 제목 (h4 반응형)
+@mixin text-sub-section-title {
+  font-size: $font-size-h4-mobile;
+  font-weight: $font-weight-semibold;
+  line-height: $line-height-heading;
+  letter-spacing: $letter-spacing-tight;
+
+  @include respond-up($breakpoint-lg) {
+    font-size: $font-size-h4;
+  }
+}
+
+/// 카드 타이틀 — 카드, 리스트 아이템 제목 (h5 반응형)
+@mixin text-card-title {
+  font-size: $font-size-h5-mobile;
+  font-weight: $font-weight-semibold;
+  line-height: $line-height-heading;
+
+  @include respond-up($breakpoint-lg) {
+    font-size: $font-size-h5;
+  }
+}
+
+/// 본문 — 일반 텍스트 (기본 크기, 반응형 변경 없음)
+@mixin text-body {
+  font-size: $font-size-default;
+  font-weight: $font-weight-regular;
+  line-height: $line-height-base;
+  color: $color-text-default;
+}
+
+/// 보조 텍스트 — 부연 설명, 서브 텍스트
+@mixin text-sub {
+  font-size: $font-size-md;
+  font-weight: $font-weight-regular;
+  line-height: $line-height-base;
+  color: $color-text-secondary;
+}
+
+/// 캡션 — 날짜, 작성자, 메타 정보
+@mixin text-caption {
+  font-size: $font-size-sm;
+  font-weight: $font-weight-regular;
+  line-height: $line-height-base;
+  color: $color-text-subtle;
+}
+
+/// 라벨 — 폼 라벨, 카테고리 이름, 네비게이션
+@mixin text-label {
+  font-size: $font-size-sm;
+  font-weight: $font-weight-medium;
+  line-height: $line-height-base;
+  color: $color-text-secondary;
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -91,14 +91,25 @@
 // TEXT ROLE MIXINS
 // 텍스트 역할별 font-size + weight + line-height + color 조합
 // 헤딩 계열은 반응형(mobile → PC) 포함
+//
+// 파라미터:
+//   $color — 텍스트 색상. 헤딩은 default null (부모 상속), 본문은 역할별 기본값
+//   $weight — font-weight. 각 역할의 기본 굵기
+//
+// 사용법:
+//   @include text-section-title;                              // 기본값
+//   @include text-section-title($color: $text-on-image);      // 다크 배경
+//   @include text-card-title($weight: $font-weight-bold);     // 강조
+//   @include text-body($color: $color-text-secondary);        // 색상 변경
 // ══════════════════════════════════════════
 
 /// 히어로 타이틀 — 배너, 랜딩 최상단 (h1 반응형)
-@mixin text-hero {
+@mixin text-hero($color: null, $weight: $font-weight-bold) {
   font-size: $font-size-h1-mobile;
-  font-weight: $font-weight-bold;
+  font-weight: $weight;
   line-height: $line-height-heading;
   letter-spacing: $letter-spacing-heading;
+  @if $color { color: $color; }
 
   @include respond-up($breakpoint-lg) {
     font-size: $font-size-h1;
@@ -106,11 +117,12 @@
 }
 
 /// 페이지 타이틀 — 각 페이지 최상위 제목 (h2 반응형)
-@mixin text-page-title {
+@mixin text-page-title($color: null, $weight: $font-weight-bold) {
   font-size: $font-size-h2-mobile;
-  font-weight: $font-weight-bold;
+  font-weight: $weight;
   line-height: $line-height-heading;
   letter-spacing: $letter-spacing-heading;
+  @if $color { color: $color; }
 
   @include respond-up($breakpoint-lg) {
     font-size: $font-size-h2;
@@ -118,11 +130,12 @@
 }
 
 /// 섹션 타이틀 — 페이지 내 구역 제목 (h3 반응형)
-@mixin text-section-title {
+@mixin text-section-title($color: null, $weight: $font-weight-bold) {
   font-size: $font-size-h3-mobile;
-  font-weight: $font-weight-bold;
+  font-weight: $weight;
   line-height: $line-height-heading;
   letter-spacing: $letter-spacing-tight;
+  @if $color { color: $color; }
 
   @include respond-up($breakpoint-lg) {
     font-size: $font-size-h3;
@@ -130,11 +143,12 @@
 }
 
 /// 서브 섹션 타이틀 — 섹션 내 하위 제목 (h4 반응형)
-@mixin text-sub-section-title {
+@mixin text-sub-section-title($color: null, $weight: $font-weight-semibold) {
   font-size: $font-size-h4-mobile;
-  font-weight: $font-weight-semibold;
+  font-weight: $weight;
   line-height: $line-height-heading;
   letter-spacing: $letter-spacing-tight;
+  @if $color { color: $color; }
 
   @include respond-up($breakpoint-lg) {
     font-size: $font-size-h4;
@@ -142,10 +156,11 @@
 }
 
 /// 카드 타이틀 — 카드, 리스트 아이템 제목 (h5 반응형)
-@mixin text-card-title {
+@mixin text-card-title($color: null, $weight: $font-weight-semibold) {
   font-size: $font-size-h5-mobile;
-  font-weight: $font-weight-semibold;
+  font-weight: $weight;
   line-height: $line-height-heading;
+  @if $color { color: $color; }
 
   @include respond-up($breakpoint-lg) {
     font-size: $font-size-h5;
@@ -153,33 +168,33 @@
 }
 
 /// 본문 — 일반 텍스트 (기본 크기, 반응형 변경 없음)
-@mixin text-body {
+@mixin text-body($color: $color-text-default) {
   font-size: $font-size-default;
   font-weight: $font-weight-regular;
   line-height: $line-height-base;
-  color: $color-text-default;
+  color: $color;
 }
 
 /// 보조 텍스트 — 부연 설명, 서브 텍스트
-@mixin text-sub {
+@mixin text-sub($color: $color-text-secondary) {
   font-size: $font-size-md;
   font-weight: $font-weight-regular;
   line-height: $line-height-base;
-  color: $color-text-secondary;
+  color: $color;
 }
 
 /// 캡션 — 날짜, 작성자, 메타 정보
-@mixin text-caption {
+@mixin text-caption($color: $color-text-subtle) {
   font-size: $font-size-sm;
   font-weight: $font-weight-regular;
   line-height: $line-height-base;
-  color: $color-text-subtle;
+  color: $color;
 }
 
 /// 라벨 — 폼 라벨, 카테고리 이름, 네비게이션
-@mixin text-label {
+@mixin text-label($color: $color-text-secondary) {
   font-size: $font-size-sm;
   font-weight: $font-weight-medium;
   line-height: $line-height-base;
-  color: $color-text-secondary;
+  color: $color;
 }

--- a/src/styles/_usage-guide.scss
+++ b/src/styles/_usage-guide.scss
@@ -1,0 +1,166 @@
+// ══════════════════════════════════════════
+// TEXT ROLE → TOKEN 결정 가이드
+// ══════════════════════════════════════════
+//
+// ── 텍스트 역할별 font-size / font-weight / color 조합 ──
+//
+// ┌──────────────┬──────────────────────────┬──────────────────────┬──────────────────────┐
+// │ 역할          │ font-size                │ font-weight          │ color                │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 히어로 타이틀  │ $font-size-h1-mobile     │ $font-weight-bold    │ $color-text-default  │
+// │              │ → $font-size-h1 (PC)     │                      │ 또는 $color-text-inverse │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 페이지 타이틀  │ $font-size-h2-mobile     │ $font-weight-bold    │ $color-text-default  │
+// │              │ → $font-size-h2 (PC)     │                      │                      │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 섹션 타이틀   │ $font-size-h3-mobile     │ $font-weight-bold    │ $color-text-default  │
+// │              │ → $font-size-h3 (PC)     │                      │                      │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 카드 타이틀   │ $font-size-h5-mobile     │ $font-weight-semibold│ $color-text-default  │
+// │              │ → $font-size-h5 (PC)     │                      │                      │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 본문 텍스트   │ $font-size-default       │ $font-weight-regular │ $color-text-default  │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 보조 설명     │ $font-size-md            │ $font-weight-regular │ $color-text-secondary│
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 캡션/메타     │ $font-size-sm            │ $font-weight-regular │ $color-text-subtle   │
+// │ (날짜, 작성자)│                          │                      │                      │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 라벨         │ $font-size-sm            │ $font-weight-medium  │ $color-text-secondary│
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 뱃지/태그     │ $font-size-xs            │ $font-weight-medium  │ (컨텍스트에 따라)     │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 버튼 텍스트   │ $font-size-md            │ $font-weight-semibold│ (버튼 스타일에 따라)  │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 네비게이션    │ $font-size-md            │ $font-weight-medium  │ $color-text-default  │
+// ├──────────────┼──────────────────────────┼──────────────────────┼──────────────────────┤
+// │ 링크         │ (부모 크기 상속)           │ (부모 굵기 상속)      │ $color-text-link     │
+// └──────────────┴──────────────────────────┴──────────────────────┴──────────────────────┘
+//
+//
+// ══════════════════════════════════════════
+// RESPONSIVE TYPOGRAPHY 패턴 (mobile-first)
+// ══════════════════════════════════════════
+//
+// 기본 스타일 = 모바일. respond-up()으로 PC 확장.
+// 헤딩만 반응형 크기 변경. 본문 크기($font-size-default 등)는 고정.
+//
+// 예시:
+//   .page_title {
+//     font-size: $font-size-h2-mobile;           // 모바일 기본
+//     font-weight: $font-weight-bold;
+//     line-height: $line-height-heading;
+//     letter-spacing: $letter-spacing-heading;
+//     color: $color-text-default;
+//
+//     @include respond-up($breakpoint-lg) {
+//       font-size: $font-size-h2;                // PC 확장
+//     }
+//   }
+//
+//   .section_title {
+//     font-size: $font-size-h3-mobile;
+//     font-weight: $font-weight-bold;
+//     line-height: $line-height-heading;
+//     letter-spacing: $letter-spacing-tight;
+//
+//     @include respond-up($breakpoint-lg) {
+//       font-size: $font-size-h3;
+//     }
+//   }
+//
+//   .card_title {
+//     font-size: $font-size-h5-mobile;
+//     font-weight: $font-weight-semibold;
+//     line-height: $line-height-heading;
+//
+//     @include respond-up($breakpoint-lg) {
+//       font-size: $font-size-h5;
+//     }
+//   }
+//
+//   .body_text {
+//     font-size: $font-size-default;             // 반응형 변경 없음
+//     font-weight: $font-weight-regular;
+//     line-height: $line-height-base;
+//     color: $color-text-default;
+//   }
+//
+//   .caption {
+//     font-size: $font-size-sm;                  // 반응형 변경 없음
+//     color: $color-text-subtle;
+//   }
+//
+//
+// ══════════════════════════════════════════
+// TEXT COLOR 선택 기준
+// ══════════════════════════════════════════
+//
+// "이 텍스트가 가장 중요한가?" → $color-text-default (gray-900)
+// "부연 설명인가?"             → $color-text-secondary (gray-700)
+// "메타/날짜/보조 정보인가?"    → $color-text-subtle (gray-500)
+// "클릭 가능한 링크인가?"       → $color-text-link (blue-700)
+// "다크 배경/이미지 위인가?"    → $color-text-inverse 또는 $text-on-image
+// "비활성 상태인가?"           → $color-disabled-text (gray-400)
+//
+//
+// ══════════════════════════════════════════
+// FONT-WEIGHT 선택 기준
+// ══════════════════════════════════════════
+//
+// "일반 본문인가?"             → $font-weight-regular (400)
+// "라벨, 네비처럼 살짝 강조?"   → $font-weight-medium (500)
+// "카드 제목, 버튼 텍스트?"     → $font-weight-semibold (600)
+// "페이지/섹션 대제목?"        → $font-weight-bold (700)
+//
+//
+// ══════════════════════════════════════════
+// UI ELEMENT → TOKEN 매핑 가이드
+// ══════════════════════════════════════════
+//
+// ┌─────────────────┬───────────────────────┐
+// │ UI 요소          │ 사용 토큰              │
+// ├─────────────────┼───────────────────────┤
+// │ input, select   │ $padding-control       │
+// │                 │ $radius-control        │
+// │                 │ $color-border-default  │
+// │                 │ focus: $color-border-focus │
+// ├─────────────────┼───────────────────────┤
+// │ button          │ $padding-control       │
+// │                 │ $radius-control        │
+// │                 │ $button-height-*       │
+// ├─────────────────┼───────────────────────┤
+// │ card            │ $padding-card          │
+// │                 │ $radius-card           │
+// │                 │ $shadow-sm             │
+// │                 │ $color-border-card     │
+// ├─────────────────┼───────────────────────┤
+// │ 모달/바텀시트     │ $radius-sheet          │
+// │                 │ $overlay-scrim         │
+// │                 │ $padding-card          │
+// ├─────────────────┼───────────────────────┤
+// │ 태그/뱃지        │ $padding-inline-xs     │
+// │                 │ $radius-pill           │
+// │                 │ $font-size-xs          │
+// ├─────────────────┼───────────────────────┤
+// │ 섹션 컨테이너    │ $padding-section-x/y   │
+// │                 │ $gap-section (형제 간)  │
+// ├─────────────────┼───────────────────────┤
+// │ 리스트 아이템     │ $gap-items             │
+// │                 │ $padding-card-compact  │
+// ├─────────────────┼───────────────────────┤
+// │ 이미지 오버레이   │ $overlay-image-text    │
+// │                 │ $text-on-image         │
+// │                 │ $text-on-image-subtle  │
+// └─────────────────┴───────────────────────┘
+//
+//
+// ══════════════════════════════════════════
+// SPACING 사용 원칙 — 근접성의 법칙
+// ══════════════════════════════════════════
+//
+// 관련성이 높을수록 간격이 좁다:
+// - 같은 그룹 내 요소: $gap-inline (0.8rem)
+// - 리스트 아이템 간:  $gap-items (1.2rem)
+// - 관련 그룹 간:     $gap-group (2rem)
+// - 독립 섹션 간:     $gap-section (6.4rem)

--- a/src/styles/_usage-guide.scss
+++ b/src/styles/_usage-guide.scss
@@ -164,3 +164,46 @@
 // - 리스트 아이템 간:  $gap-items (1.2rem)
 // - 관련 그룹 간:     $gap-group (2rem)
 // - 독립 섹션 간:     $gap-section (6.4rem)
+//
+//
+// ══════════════════════════════════════════
+// TEXT MIXIN 적용 우선순위
+// ══════════════════════════════════════════
+//
+// 1순위: mixin 기본값 사용
+//
+//   .page_title {
+//     @include text-page-title;
+//   }
+//
+// 2순위: mixin 파라미터로 변형
+//   $color, $weight를 named parameter로 전달.
+//   헤딩 계열 $color의 default는 null (미전달 시 부모 상속).
+//   본문 계열 $color의 default는 역할별 기본 색상.
+//
+//   // 다크 배경 위 섹션 제목
+//   .dark_section_title {
+//     @include text-section-title($color: $text-on-image);
+//   }
+//
+//   // 강조 카드 제목
+//   .featured_card_title {
+//     @include text-card-title($weight: $font-weight-bold);
+//   }
+//
+//   // 본문 색상 변경
+//   .muted_text {
+//     @include text-body($color: $color-text-secondary);
+//   }
+//
+// 3순위: 시맨틱/primitive 토큰 직접 조합
+//   mixin에 맞는 역할이 없을 때. 토큰을 직접 조합하되,
+//   위 텍스트 역할 테이블에서 가장 가까운 역할을 참조.
+//
+//   // "큰 보조 텍스트" — mixin에 정확히 맞는 역할 없음
+//   .intro_desc {
+//     font-size: $font-size-lg;
+//     font-weight: $font-weight-regular;
+//     line-height: $line-height-base;
+//     color: $color-text-secondary;
+//   }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -4,3 +4,4 @@
 @import '@/styles/tokens/layout';
 @import '@/styles/tokens/spacing';
 @import '@/styles/tokens/typography';
+@import '@/styles/tokens/semantic';

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -50,19 +50,11 @@ ol,
 blockquote {
   font-size: $font-size-default;
   word-break: keep-all;
-
-  @include respond-up($breakpoint-xl) {
-    font-size: $font-size-xl;
-  }
 }
 
 a {
   text-decoration: none;
   font-size: $font-size-md;
-
-  @include respond-up($breakpoint-xl) {
-    font-size: $font-size-lg;
-  }
 }
 
 ul,
@@ -111,7 +103,7 @@ header:has(#gnb:hover):not([data-nav-locked]) {
   left: 0;
   right: 0;
   bottom: 0;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: $overlay-scrim;
   z-index: 9999;
 }
 

--- a/src/styles/tokens/_color.scss
+++ b/src/styles/tokens/_color.scss
@@ -1,10 +1,24 @@
-// Church Brand
+// ══════════════════════════════════════════
+// CHURCH BRAND — 교회 고유 색상. 배너, 로고, 강조 포인트에 사용
+// ══════════════════════════════════════════
+
+/// #1b2d4e — 교회 네이비. 다크 배경, 헤더/푸터, 강한 브랜드 표현
 $color-navy: #1b2d4e;
+
+/// #b8976a — 교회 골드. CTA 강조, 브랜드 포인트 컬러
 $color-gold: #b8976a;
+
+/// #f5f0e6 — 크림 배경. 따뜻한 톤의 섹션 배경
 $color-cream: #f5f0e6;
+
+/// #ede6d7 — 진한 크림. cream과의 경계/구분이 필요할 때
 $color-cream-deep: #ede6d7;
 
-// Scale
+// ══════════════════════════════════════════
+// COLOR SCALE — Primitive 팔레트 (직접 사용 지양, 시맨틱 토큰 우선)
+// ══════════════════════════════════════════
+
+// Blue Scale
 $color-blue-900: #0969b6;
 $color-blue-800: #116eb9;
 $color-blue-700: #1a73bb;
@@ -16,6 +30,7 @@ $color-blue-200: #aacbe6;
 $color-blue-100: #d5e5f2;
 $color-blue-50: #f7fafc;
 
+// Orange Scale
 $color-orange-900: #88430a;
 $color-orange-800: #b95d00;
 $color-orange-700: #e47712;
@@ -27,6 +42,7 @@ $color-orange-200: #ffe4c3;
 $color-orange-100: #fff0db;
 $color-orange-50: #fff9f0;
 
+// Gray Scale
 $color-black: #000000;
 $color-gray-900: #111827;
 $color-gray-800: #1f2937;
@@ -44,45 +60,112 @@ $color-white: #faf9f6;
 $color-green-500: #10b981;
 $color-red-500: #ef4444;
 
-// Primary Actions
+// ══════════════════════════════════════════
+// SEMANTIC: PRIMARY — 주요 액션 (링크, CTA 버튼, 선택된 탭)
+// ══════════════════════════════════════════
+
+/// 주요 액션 기본 색상 (blue-700)
 $color-primary: $color-blue-700;
+/// 주요 액션 클릭/활성 상태
 $color-primary-active: $color-blue-900;
+/// 주요 액션 호버 상태
 $color-primary-hover: $color-blue-800;
+/// 주요 액션 연한 배경 (선택된 탭 배경, 알림 배경)
 $color-primary-subtle: $color-blue-100;
 
-// Secondary Actions
+// ══════════════════════════════════════════
+// SEMANTIC: SECONDARY — 보조 액션 (보조 버튼, 경고성 강조)
+// ══════════════════════════════════════════
+
+/// 보조 액션 기본 색상 (orange-700)
 $color-secondary: $color-orange-700;
+/// 보조 액션 클릭/활성 상태
 $color-secondary-active: $color-orange-900;
+/// 보조 액션 호버 상태
 $color-secondary-hover: $color-orange-800;
+/// 보조 액션 연한 배경
 $color-secondary-subtle: $color-orange-100;
 
-// Disabled State x
+// ══════════════════════════════════════════
+// SEMANTIC: DISABLED — 비활성 상태
+// ══════════════════════════════════════════
+
+/// 비활성 텍스트 색상
 $color-disabled-text: $color-gray-400;
+/// 비활성 배경 색상
 $color-disabled-bg: $color-gray-200;
+/// 비활성 보더 색상
 $color-disabled-border: $color-gray-300;
 
-// Backgrounds & Borders
+// ══════════════════════════════════════════
+// SEMANTIC: BACKGROUND & BORDER
+// ══════════════════════════════════════════
+
+/// 페이지 전체 배경 (gray-50)
 $color-bg-body: $color-gray-50;
+/// 카드/섹션 기본 배경 (blue-50). body 위에 올라가는 영역
 $color-bg-default: $color-blue-50;
+/// 호버 시 배경 변화 (blue-100)
 $color-bg-hover: $color-blue-100;
+/// 푸터 배경 (black)
 $color-bg-footer: $color-black;
+
+/// 기본 보더 색상 — input, 구분선에 사용
 $color-border-default: $color-gray-300;
+/// 포커스 상태 보더 — input focus 시
 $color-border-focus: $color-gray-500;
+/// 카드 보더 색상 — 카드, 패널 테두리
 $color-border-card: $color-blue-300;
+/// primary 강조 보더 — 선택된 항목 테두리
 $color-border-primary: $color-blue-500;
+/// primary 보더 활성 상태
 $color-border-primary-active: $color-blue-700;
+/// primary 보더 반전 (다크 배경 위)
 $color-border-primary-inverse: $color-blue-200;
+/// 구분선 색상 — 리스트 아이템 사이, hr 요소
 $color-divide: $color-gray-400;
 
-// Text
+// ══════════════════════════════════════════
+// SEMANTIC: TEXT COLOR
+// 선택 기준: 제목/본문 → default, 부연 설명 → secondary, 날짜/메타 → subtle
+// ══════════════════════════════════════════
+
+/// ✦ 기본 텍스트 (gray-900). 제목, 본문 등 대부분의 텍스트
 $color-text-default: $color-gray-900;
+
+/// 보조 텍스트 (gray-700). 부연 설명, 서브타이틀, 짧은 설명문
 $color-text-secondary: $color-gray-700;
+
+/// 약한 텍스트 (gray-500). 날짜, 메타 정보, 캡션, 플레이스홀더
 $color-text-subtle: $color-gray-500;
+
+/// 링크 텍스트 (blue-700). 클릭 가능한 텍스트 링크
 $color-text-link: $color-blue-700;
+
+/// 링크 활성 상태 (blue-900)
 $color-text-link-active: $color-blue-900;
+
+/// 반전 텍스트 (white). 다크 배경/이미지 위의 텍스트
 $color-text-inverse: $color-white;
 
-// Status
+// ══════════════════════════════════════════
+// SEMANTIC: STATUS — 상태 피드백 색상
+// ══════════════════════════════════════════
+
+/// 성공 상태 (초록)
 $color-status-success: $color-green-500;
+/// 위험/에러 상태 (빨강)
 $color-status-danger: $color-red-500;
+/// 경고 상태 (주황)
 $color-status-warning: $color-orange-600;
+
+// ══════════════════════════════════════════
+// SEMANTIC: DARK SECTION — 이미지/영상 위 콘텐츠 영역
+// ══════════════════════════════════════════
+
+/// 다크 섹션 배경색. 이미지/영상 위 콘텐츠 영역
+$color-bg-dark: #0f1820;
+/// 다크 섹션 내 카드 배경
+$color-bg-dark-card: #1a2535;
+/// 다크 섹션 내 카드 호버 배경
+$color-bg-dark-card-hover: #243347;

--- a/src/styles/tokens/_effect.scss
+++ b/src/styles/tokens/_effect.scss
@@ -1,18 +1,44 @@
-// Border Radius
+// ══════════════════════════════════════════
+// BORDER RADIUS — 직접 사용 지양, $radius-* 시맨틱 토큰 우선
+// ══════════════════════════════════════════
+
+/// 0.25rem — → $radius-control 사용 권장
 $border-radius-sm: 0.25rem;
+/// 0.5rem — → $radius-card 사용 권장
 $border-radius-md: 0.5rem;
+/// 0.75rem — → $radius-sheet 사용 권장
 $border-radius-lg: 0.75rem;
+/// 9999px — → $radius-pill 사용 권장
 $border-radius-full: 9999px;
 
-// Box Shadow
+// ══════════════════════════════════════════
+// BOX SHADOW
+// ══════════════════════════════════════════
+
+/// 얕은 그림자 — 카드, 드롭다운 기본
 $shadow-sm: 0 1px 2px 0 rgba($color-gray-900, 0.05);
+
+/// 중간 그림자 — 호버된 카드, 플로팅 요소
 $shadow-md:
   0 4px 6px -1px rgba($color-gray-900, 0.1),
   0 2px 4px -2px rgba($color-gray-900, 0.1);
 
-// Transition
+// ══════════════════════════════════════════
+// TRANSITION
+// ══════════════════════════════════════════
+
+/// 0.28s — 일반 트랜지션 지속 시간
 $transition-duration-normal: 0.28s;
+
+/// cubic-bezier(0.4, 0, 0.2, 1) — 기본 이징 함수
 $transition-easing-default: cubic-bezier(0.4, 0, 0.2, 1);
+
+// ══════════════════════════════════════════
+// ANIMATION
+// ══════════════════════════════════════════
+
+/// 0.8s — 스크롤 reveal 애니메이션 지속 시간
+$animation-duration-reveal: 0.8s;
 
 @keyframes fadeUp {
   from {

--- a/src/styles/tokens/_semantic.scss
+++ b/src/styles/tokens/_semantic.scss
@@ -1,0 +1,81 @@
+// ══════════════════════════════════════════
+// SPACING: 컴포넌트 내부 여백 (padding)
+// ══════════════════════════════════════════
+
+/// 0.2rem 0.8rem — 태그, 뱃지 등 인라인 요소 내부 여백
+$padding-inline-xs: $spacing-nano $spacing-xs;
+
+/// 0.4rem 0.8rem — 약간 큰 인라인 요소 (필터 칩 등)
+$padding-inline-sm: $spacing-xxs $spacing-xs;
+
+/// 0.8rem 1.2rem — input, select, button 내부 여백
+$padding-control: $spacing-xs $spacing-sm;
+
+/// 1.6rem 2rem — 카드, 패널 내부 여백
+$padding-card: $spacing-md $spacing-lg;
+
+/// 1.2rem 1.6rem — 작은 카드, 리스트 아이템 내부 여백
+$padding-card-compact: $spacing-sm $spacing-md;
+
+/// 2rem — 페이지 섹션 좌우 여백 (모바일 기준)
+$padding-section-x: $spacing-lg;
+
+/// 6.4rem — 페이지 섹션 상하 여백
+$padding-section-y: $spacing-xxxl;
+
+// ══════════════════════════════════════════
+// SPACING: 요소 간 간격 (gap)
+// 근접성의 법칙: 관련성 높을수록 간격 좁게
+// inline < items < group < section
+// ══════════════════════════════════════════
+
+/// 0.8rem — 같은 줄 요소 간 (아이콘+텍스트, 뱃지 나열)
+$gap-inline: $spacing-xs;
+
+/// 1.2rem — 리스트 아이템 간, 폼 필드 간
+$gap-items: $spacing-sm;
+
+/// 2rem — 관련 그룹 간 (제목+본문 블록과 다음 블록 사이)
+$gap-group: $spacing-lg;
+
+/// 6.4rem — 독립 섹션 간 (페이지 내 대단위 구역 사이)
+$gap-section: $spacing-xxxl;
+
+// ══════════════════════════════════════════
+// BORDER-RADIUS: 4단계
+// ══════════════════════════════════════════
+
+/// 0.25rem — input, button, 태그 등 작은 컨트롤
+$radius-control: $border-radius-sm;
+
+/// 0.5rem — 카드, 패널, 드롭다운
+$radius-card: $border-radius-md;
+
+/// 0.75rem — 모달, 바텀시트, 드로어
+$radius-sheet: $border-radius-lg;
+
+/// 9999px — pill 뱃지, 아바타, 둥근 버튼
+$radius-pill: $border-radius-full;
+
+// ══════════════════════════════════════════
+// OVERLAY — 반투명 레이어
+// ══════════════════════════════════════════
+
+/// rgba(0,0,0,0.5) — 모달/드로어 뒤 딤 배경
+$overlay-scrim: rgba(0, 0, 0, 0.5);
+
+/// rgba(0,0,0,0.45) — 이미지 위 텍스트 가독성 확보용 오버레이
+$overlay-image-text: rgba(0, 0, 0, 0.45);
+
+/// rgba(0,0,0,0.04) — 호버/포커스 시 미세한 시각 피드백
+$overlay-subtle: rgba(0, 0, 0, 0.04);
+
+// ══════════════════════════════════════════
+// TEXT ON IMAGE — 이미지/다크 배경 위 텍스트 색상
+// ══════════════════════════════════════════
+
+/// rgba(255,255,255,0.9) — 이미지 위 메인 텍스트 (제목, 본문)
+$text-on-image: rgba(255, 255, 255, 0.9);
+
+/// rgba(255,255,255,0.7) — 이미지 위 보조 텍스트 (날짜, 캡션)
+$text-on-image-subtle: rgba(255, 255, 255, 0.7);

--- a/src/styles/tokens/_spacing.scss
+++ b/src/styles/tokens/_spacing.scss
@@ -1,13 +1,49 @@
+/// 0
 $spacing-0: 0;
+
+/// 0.1rem (1px) — 보더, 미세 간격
 $spacing-min: 0.1rem;
+
+/// 0.2rem (2px) — 인라인 요소 내부 수직 패딩
 $spacing-nano: 0.2rem;
+
+/// 0.4rem (4px) — 아이콘과 텍스트 사이, 뱃지 내부 여백
 $spacing-xxs: 0.4rem;
+
+/// 0.8rem (8px) — 같은 줄 요소 간 기본 간격
 $spacing-xs: 0.8rem;
+
+/// 1.2rem (12px) — 리스트 아이템 간, 폼 필드 간
 $spacing-sm: 1.2rem;
+
+/// 1.6rem (16px) — 카드 내부 여백, 컴포넌트 내부 기본
 $spacing-md: 1.6rem;
+
+/// 2rem (20px) — 그룹 간 간격, 섹션 좌우 패딩 (모바일)
 $spacing-lg: 2rem;
+
+/// 2.4rem (24px) — 넓은 카드 패딩, 폼 그룹 간
 $spacing-xl: 2.4rem;
+
+/// 3.2rem (32px) — 컴포넌트 블록 간 간격
 $spacing-xxl: 3.2rem;
-$spacing-xxxl: 6.4rem;
-$spacing-xxxxl: 8rem;
-$spacing-layout: 9.6rem;
+
+/// 4rem (40px) — 섹션 내부 상하 여백 (모바일)
+$spacing-3xl: 4rem;
+
+/// 4.8rem (48px) — 넓은 섹션 내부 여백
+$spacing-4xl: 4.8rem;
+
+/// 6.4rem (64px) — 독립 섹션 간 간격
+$spacing-5xl: 6.4rem;
+
+/// 8rem (80px) — 페이지 상하 대형 여백
+$spacing-6xl: 8rem;
+
+/// 9.6rem (96px) — 레이아웃 최대 여백
+$spacing-7xl: 9.6rem;
+
+// ── 하위호환 alias (기존 코드에서 사용 중) ──
+$spacing-xxxl: $spacing-5xl;
+$spacing-xxxxl: $spacing-6xl;
+$spacing-layout: $spacing-7xl;

--- a/src/styles/tokens/_typography.scss
+++ b/src/styles/tokens/_typography.scss
@@ -1,44 +1,123 @@
-// Font Family
+// ══════════════════════════════════════════
+// FONT FAMILY
+// ══════════════════════════════════════════
+
+/// 본문 기본 폰트 (Pretendard Variable)
 $font-family-base: 'Pretendard Variable', Pretendard, sans-serif;
+
+/// 강조/헤딩용 세리프 폰트 (나눔명조). 배너 타이틀, 인용문 등 특별한 강조에만 사용
 $font-family-secondary: var(--font-myeongjo);
 
-// Line Height
+// ══════════════════════════════════════════
+// LINE HEIGHT
+// ══════════════════════════════════════════
+
+/// 1 — 아이콘, 뱃지 등 단일 줄 요소. 줄간격 제거
 $line-height-reset: 1;
+
+/// 1.35 — 헤딩 전용. h1~h5에 사용
 $line-height-heading: 1.35;
+
+/// 1.5 — 본문 기본. 대부분의 텍스트에 사용
 $line-height-base: 1.5;
+
+/// 1.8 — 긴 본문, 설교 내용 등 가독성이 중요한 장문 텍스트
 $line-height-wide: 1.8;
 
-// Font Weight
+// ══════════════════════════════════════════
+// FONT WEIGHT
+// 선택 기준: default → regular, 구분 필요 → medium, 강조 → semibold, 헤딩 → bold
+// ══════════════════════════════════════════
+
+/// 400 — 본문 텍스트 기본
 $font-weight-regular: 400;
+
+/// 500 — 라벨, 네비게이션, 본문 내 살짝 강조. regular과 구분이 필요할 때
 $font-weight-medium: 500;
+
+/// 600 — 카드 제목, 리스트 타이틀, 버튼 텍스트. 명확한 강조
 $font-weight-semibold: 600;
+
+/// 700 — 페이지/섹션 헤딩(h1~h3). 최상위 제목에만 사용
 $font-weight-bold: 700;
 
-// Letter Spacing
+// ══════════════════════════════════════════
+// LETTER SPACING
+// ══════════════════════════════════════════
+
+/// -0.15rem — 대형 헤딩(h1~h2)에서 글자 간 간격 축소
 $letter-spacing-heading: -0.15rem;
+
+/// -0.1rem — 중형 헤딩(h3~h5)
 $letter-spacing-tight: -0.1rem;
+
+/// -0.05rem — 본문 기본
 $letter-spacing-base: -0.05rem;
 
-// Base Text Size
+// ══════════════════════════════════════════
+// BASE TEXT SIZE (본문용)
+// 선택 기준: 기본 본문 → $font-size-default
+// ══════════════════════════════════════════
+
+/// 1.8rem — 본문 중 가장 큰 텍스트. 리드 문단, 강조 인트로
 $font-size-xl: 1.8rem;
+
+/// 1.6rem — 서브 헤딩 보조, 큰 본문
 $font-size-lg: 1.6rem;
+
+/// 1.5rem — ✦ 본문 기본 크기. 대부분의 텍스트에 사용
 $font-size-default: 1.5rem;
+
+/// 1.4rem — 보조 텍스트, 테이블 셀, 폼 입력값
 $font-size-md: 1.4rem;
+
+/// 1.3rem — 캡션, 메타 정보 (날짜, 작성자)
 $font-size-sm: 1.3rem;
+
+/// 1.2rem — 뱃지, 태그, 각주 등 가장 작은 텍스트
 $font-size-xs: 1.2rem;
+
+/// 1.1rem — 특수 케이스에만. 가독성 주의 필요
 $font-size-xxs: 1.1rem;
 
-// Heading Sizes
+// ══════════════════════════════════════════
+// HEADING SIZE — Desktop (min-width: $breakpoint-lg 이상)
+// respond-up($breakpoint-lg) 안에서 사용
+// ══════════════════════════════════════════
+
+/// 4.2rem — 히어로 배너 등 최상위 타이틀 (PC)
 $font-size-h1: 4.2rem;
+
+/// 3.4rem — 페이지 타이틀 (PC)
 $font-size-h2: 3.4rem;
+
+/// 2.8rem — 섹션 타이틀 (PC)
 $font-size-h3: 2.8rem;
+
+/// 2.2rem — 서브 섹션 타이틀 (PC)
 $font-size-h4: 2.2rem;
+
+/// 2rem — 카드/아이템 타이틀 (PC)
 $font-size-h5: 2rem;
 
+// ══════════════════════════════════════════
+// HEADING SIZE — Mobile (기본값, mobile-first)
+// 기본 스타일에서 사용. respond-up() 없이 적용
+// ══════════════════════════════════════════
+
+/// 3.2rem — 히어로 배너 등 최상위 타이틀 (모바일)
 $font-size-h1-mobile: 3.2rem;
+
+/// 2.6rem — 페이지 타이틀 (모바일)
 $font-size-h2-mobile: 2.6rem;
+
+/// 2.2rem — 섹션 타이틀 (모바일)
 $font-size-h3-mobile: 2.2rem;
+
+/// 2rem — 서브 섹션 타이틀 (모바일)
 $font-size-h4-mobile: 2rem;
+
+/// 1.8rem — 카드/아이템 타이틀 (모바일)
 $font-size-h5-mobile: 1.8rem;
 
 $heading-sizes: (


### PR DESCRIPTION
## 📋 개요 (Summary)

- Primitive 토큰 위에 역할 기반 시맨틱 토큰 레이어 추가(spacing, radius, overlay), text-role mixin 10종 신규 도입(반응형 타이포그래피 내장)
- spacing 스케일 빈 구간 보완
- 기존 컴포넌트 마이그레이션 없이 **디자인 인프라만 정비**하는 변경



## 💡 리팩토링 배경 (Motivation)

**개선하려는 문제:**
- 가독성 저하 (복잡도 증가, 네이밍 불명확 등)
- 중복 코드 (DRY 원칙 위반)
- 유지보수 난이도 증가
- 기술 부채 해소

**구체적인 문제 상황:**
- **토큰 선택 기준 부재** — Primitive 토큰은 정의되어 있으나 UI 요소의 역할과 토큰 사이의 매핑 없음
  - border-radius 9종 이상 난립 (20곳+)
  - rgba() 오버레이 값 컴포넌트마다 인라인 하드코딩
  - 유사한 카드·섹션에 서로 다른 패딩 (40곳+)
- **텍스트 스타일 조합의 어려움** — font-size + font-weight + line-height + letter-spacing + color + 반응형을 매번 수동 조합
  - 같은 "카드 제목" 역할인데 font-weight 600/700 혼재
  - 보조 텍스트 색상 gray-500/gray-700 혼재
- **Spacing 스케일 빈 구간** — `3.2rem → 6.4rem` 사이 2배 점프 구간 존재
  - 컴포넌트에서 `3rem`, `4rem`, `5rem` 등 토큰 외 값 하드코딩의 주요 원인 (40곳+ 중 상당수)
- **PC 본문 확대로 인한 비율 불일치** — `globals.scss`의 PC 전용 font-size override가 vw 기반 반응형 시스템 설계 의도와 충돌
  - 모바일: section-title(2.2rem) : body(1.5rem) = 1.47배
  - PC: section-title(2.8rem) : body(1.8rem) = 1.56배 → 뷰포트별 헤딩:본문 비율 불일치
- **Mixin에서 토큰 참조 불가** — `additionalData`가 `_variables.scss`와 `_mixins.scss`를 독립 모듈로 로드하여 mixin 내부에서 토큰 변수 접근 불가
  - `action-button-style` — `border-radius: 0.4rem`, `font-size: 1.4rem` 하드코딩
  - `link-hover-style` — `color: #1f5da9` 하드코딩
- **토큰 선택 가이드 부재** — 토큰이 정의되어 있어도 "이 UI 요소에 어떤 토큰을 쓸지" 가이드 없어 개발자마다 다른 선택


## 🔧 주요 변경점 (Key Changes)

**신규 파일**
- `src/styles/tokens/_semantic.scss` — spacing(역할 기반 패딩 6종, gap 4종), radius(4단계), overlay(5종) 시맨틱 토큰 정의
- `src/styles/_usage-guide.scss` — UI 요소별 토큰 매핑 테이블, 반응형 패턴 코드 예시 포함

**토큰 및 스케일 보완**
- `_spacing.scss` — `$spacing-3xl`(4rem), `$spacing-4xl`(4.8rem) 추가로 빈 구간 보완. 네이밍 체계 숫자 기반(`3xl`~`7xl`)으로 전환, 기존 이름 하위호환 alias 유지
- `_color.scss` / `_typography.scss` / `_effect.scss` — 전체 `///` IntelliSense 주석 추가 (변수 호버 시 값 + 용도 + 선택 기준 표시)

**Mixin 인프라 개선**
- `_mixins.scss` 상단에 `@use '@/styles/_variables.scss' as *` 추가 — mixin 내 모든 토큰 직접 참조 가능
- text-role mixin 10종 추가
  - 헤딩 계열 5종 (`text-hero`, `text-page-title`, `text-section-title`, `text-sub-section-title`, `text-card-title`) — mobile-first 반응형 내장
  - 본문 계열 5종 (`text-body`, `text-sub`, `text-caption`, `text-label`, `text-overline`) — color 포함
- `back-button-style` mixin 삭제 (미사용, `// TODO: renew` 상태)
- `action-button-style`, `link-hover-style` 하드코딩 → 토큰 참조로 교체
**globals.scss 정리**
- `p/a` PC font-size override 제거 (1.5rem 고정, 헤딩만 반응형으로 키우는 설계 의도 복원)
- `.overlay` rgba 하드코딩 → `$overlay-scrim` 토큰 교체


## 🏗️ 설계 변경 사항 (Design Changes)

**변경 전 구조:**
- Primitive 토큰 레이어만 존재
- 컴포넌트가 Primitive 토큰을 직접 참조하거나 하드코딩 값을 사용
- mixin이 토큰에 접근 불가하여 내부 값 하드코딩 불가피
**변경 후 구조:**
- Primitive 위에 시맨틱 레이어 추가
- 컴포넌트는 역할 기반 토큰과 mixin을 우선 참조
- Primitive는 시맨틱 레이어에서만 직접 참조.

```mermaid
flowchart LR
    subgraph Before
        C1[컴포넌트] --> P1[Primitive 토큰]
        C1 --> H1[하드코딩]
    end
    subgraph After
        C2[컴포넌트] --> S[Semantic 토큰]
        C2 --> M[text-role mixin]
        S --> P2[Primitive 토큰]
        M --> P2
    end
    Before -->|리팩토링| After
```

**토큰 사용 우선순위 (text-role mixin 기준):**
- 1순위 — mixin 기본값 사용 (`@include text-section-title`)
- 2순위 — mixin 파라미터로 변형 (`@include text-section-title($color: $text-on-image)`)
- 3순위 — 시맨틱/primitive 토큰 직접 조합 (mixin에 맞는 역할 없을 때)

> ⚠️ **주의사항:**
>
> - 이 PR은 인프라 정비만 포함. 기존 컴포넌트 마이그레이션은 별도 PR로 진행 예정
> - PC 본문(`p`, `a`) 크기가 변경됨(기존 PC 1.8rem/1.6rem → 1.5rem 고정). 주요 페이지 시각적 확인 필요
> - `link-hover-style` 사용처 미세 컬러 변경 (`#1f5da9` → `#0969b6`, 동일 계열)


## 📊 개선 지표 (Improvement Metrics)

| 항목                   | Before                           | After                                     |
| ---------------------- | -------------------------------- | ----------------------------------------- |
| border-radius 하드코딩 | 9종 이상 난립 (20곳+)            | `$radius-*` 4단계로 통일                  |
| spacing 하드코딩       | 토큰 외 값 다수 (40곳+)          | 빈 구간 보완으로 하드코딩 유발 구간 제거  |
| 텍스트 스타일 일관성   | font-weight·color 혼재           | text-role mixin 10종으로 역할별 표준화    |
| mixin 토큰 참조        | 불가 (하드코딩 불가피)           | `@use` 추가로 전체 토큰 접근 가능         |
| 헤딩:본문 비율 (PC)    | 모바일과 불일치 (1.47x vs 1.56x) | 일관된 계층 유지 (모바일 1.47x, PC 1.87x) |
| 개발자 토큰 선택 기준  | 없음 (개발자마다 다른 선택)      | IntelliSense 주석 + `_usage-guide.scss`   |

## ✅ 검증 결과 (Verification)

**회귀 테스트 (Regression Test):**

- [ ] 기존 테스트 전체 통과 여부
- [ ] 새로 추가한 테스트 통과 여부
- [x] 수동 테스트로 주요 시나리오 동작 확인

**수행한 테스트:**

- [ ] 단위 테스트 (Unit Test)
- [ ] 통합 테스트 (Integration Test)
- [x] 수동 테스트 (Manual Test)

**빌드 검증:**

- [x] `yarn build` 정상 완료 (SCSS 컴파일 에러 없음)
- [x] 기존 페이지 시각적 확인 (PC 본문 크기 변경 영향)
- [ ] 주요 페이지 크로스 브라우저 확인


## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**리팩토링 완성도**

- [x] 외부 동작(기능, API 인터페이스) 변경 없음 확인
- [ ] 기존 테스트 전체 통과 여부
- [x] 성능 저하 없음 확인

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 복잡한 로직 설명 주석 추가 여부
- [x] 불필요한 코드·디버그 로그 제거 여부
- [x] 불필요한 기능 변경 미포함 확인 (리팩토링과 기능 개발 분리)

**테스트 및 문서화**

- [x] 구조 변경에 따른 README·주석 업데이트 여부
- [x] Conventional Commits 규격 준수 여부 (`refactor`)


## 📝 리뷰어를 위한 메모 (Notes for Future Me)

**시맨틱 토큰 우선 사용**
- 새 컴포넌트 작성 시 Primitive 토큰 직접 참조보다 `$padding-card`, `$radius-card` 등 시맨틱 토큰 우선 참조
- Primitive는 시맨틱에 없는 값이 필요할 때만 직접 사용

**PC 본문 크기 변경 영향 범위**
- `p`, `a` 요소가 PC에서 1.5rem 고정(기존 1.8rem/1.6rem). 컴포넌트 내에서 `font-size`를 별도 지정한 경우는 영향 없음
- 전역 스타일 상속에 의존하는 텍스트 요소 확인 필요

**후속 마이그레이션 우선순위**

- 높음: 하드코딩 spacing → 토큰 마이그레이션(40곳+), border-radius → `$radius-*` 마이그레이션(20곳+)
- 중간: 하드코딩 색상(10곳), font-weight(12곳), 다크 섹션 로컬 변수 → `$color-bg-dark*` 통합
- 낮음: Stylelint 규칙 추가(하드코딩 방지 자동화)

**spacing 네이밍 체계 변경**
 기존 `$spacing-xxxl`, `$spacing-xxxxl` 사용처는 alias로 유지되므로 즉시 깨지지 않음. 단, 신규 코드에서는 반드시 숫자 기반(`$spacing-3xl`~`$spacing-7xl`) 사용.