### PR TITLE
[Feat] 처음 오셨나요? NewHere 섹션 구현

### DIFF
--- a/src/app/_component/home/AboutOurChurch.module.scss
+++ b/src/app/_component/home/AboutOurChurch.module.scss
@@ -70,17 +70,22 @@
     }
   }
 
-  a {
+  .about_link {
     margin-top: $spacing-xs;
     width: fit-content;
     display: inline-block;
+    padding-bottom: $spacing-nano;
     color: $color-text-link;
-    transition: transform 0.3s ease;
     font-weight: $font-weight-medium;
+    text-decoration: none;
+    border-bottom: $spacing-min solid transparent;
+    transition:
+      border-color $transition-duration-normal $transition-easing-default,
+      opacity $transition-duration-normal $transition-easing-default;
 
     &:hover {
-      text-decoration: underline;
-      transform: translateX(0.5rem);
+      border-color: $color-text-link;
+      opacity: 0.8;
     }
   }
 }

--- a/src/app/_component/home/AboutOurChurch.tsx
+++ b/src/app/_component/home/AboutOurChurch.tsx
@@ -30,7 +30,7 @@ export default async function AboutOurChurch() {
               <p>{settings.about_intro_1}</p>
               <p>{settings.about_intro_2}</p>
             </div>
-            <Link href="/about">교회소개 살펴보기</Link>
+            <Link href="/about" className={styles.about_link}>교회소개 살펴보기 →</Link>
           </div>
         </div>
       </LayoutContainer>

--- a/src/app/_component/home/FeedContent.module.scss
+++ b/src/app/_component/home/FeedContent.module.scss
@@ -108,10 +108,15 @@ $radius-list-lg: 1.6rem;
   font-weight: $font-weight-semibold;
   text-decoration: none;
   color: $color-feed-accent;
-  transition: opacity $transition-duration-normal $transition-easing-default;
+  padding-bottom: $spacing-nano;
+  border-bottom: $spacing-min solid transparent;
+  transition:
+    border-color $transition-duration-normal $transition-easing-default,
+    opacity $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    opacity: 0.7;
+    border-color: $color-feed-accent;
+    opacity: 0.8;
   }
 }
 

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -1,0 +1,220 @@
+// Local variables
+$bg-section: #fdfaf5;
+
+// ─── Section ────────────────────────────────────────
+.section {
+  padding: $padding-section-y 0;
+  background: $bg-section;
+}
+
+// ─── Inner Grid ─────────────────────────────────────
+.inner {
+  @include respond-up($breakpoint-lg) {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: $spacing-5xl;
+  }
+}
+
+// ─── 좌측: 이미지 (PC only) ────────────────────────
+.image_area {
+  display: none;
+
+  @include respond-up($breakpoint-lg) {
+    display: block;
+    position: relative;
+    align-self: center;
+  }
+
+  @include respond-up($breakpoint-xl) {
+    align-self: stretch;
+  }
+}
+
+.image_frame {
+  position: relative;
+  height: 100%;
+  min-height: 30rem;
+  border-radius: $radius-control;
+  overflow: hidden;
+}
+
+.image {
+  @include prevent-img-drag;
+  object-fit: cover;
+  width: 100%;
+  height: 90%;
+}
+
+.year_badge {
+  position: absolute;
+  bottom: -$spacing-md;
+  right: -$spacing-md;
+  padding: $spacing-lg $spacing-xl;
+  background: $color-navy;
+  border-radius: $radius-control;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xxs;
+}
+
+.year_number {
+  font-family: $font-family-secondary;
+  font-size: 3.2rem;
+  font-weight: $font-weight-regular;
+  color: $color-gold;
+  line-height: $line-height-reset;
+}
+
+.year_label {
+  font-size: $font-size-xxs;
+  font-weight: $font-weight-regular;
+  color: rgba($color-white, 0.5);
+  letter-spacing: 0.1rem;
+}
+
+// ─── 우측: 콘텐츠 ──────────────────────────────────
+.content {
+  display: flex;
+  flex-direction: column;
+
+  @include respond-up($breakpoint-lg) {
+    align-self: center;
+  }
+}
+
+// ─── 헤더 ───────────────────────────────────────────
+.header {
+  margin-bottom: $spacing-md;
+}
+
+.caption {
+  @include text-label($color: $color-gold);
+  display: inline-block;
+  letter-spacing: 0.25rem;
+  text-transform: uppercase;
+  margin-bottom: $spacing-sm;
+}
+
+.title {
+  @include text-page-title();
+  font-family: $font-family-secondary;
+  font-weight: $font-weight-regular;
+  line-height: 1.25;
+  letter-spacing: $letter-spacing-heading;
+
+  strong {
+    font-family: inherit;
+    font-weight: $font-weight-bold;
+  }
+}
+
+.divider {
+  width: 4rem;
+  height: 0.2rem;
+  background: $color-gold;
+  margin: $spacing-lg 0;
+}
+
+.desc {
+  @include text-sub();
+  line-height: $line-height-wide;
+}
+
+// ─── FAQ 아코디언 ───────────────────────────────────
+.faq_list {
+  margin-bottom: $spacing-xl;
+}
+
+.faq_item {
+  border-bottom: 1px solid $color-border-default;
+}
+
+.faq_question {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: $spacing-sm;
+  width: 100%;
+  padding: $spacing-md 0;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: $font-family-base;
+  font-size: $font-size-md;
+  font-weight: $font-weight-medium;
+  color: $color-text-default;
+  line-height: $line-height-base;
+
+  @include respond-up($breakpoint-lg) {
+    font-size: $font-size-default;
+  }
+}
+
+.faq_toggle {
+  font-size: $font-size-xl;
+  color: $color-gold;
+  line-height: $line-height-reset;
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+
+  .faq_open & {
+    transform: rotate(45deg);
+  }
+}
+
+.faq_answer {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.35s $transition-easing-default;
+
+  .faq_open & {
+    grid-template-rows: 1fr;
+  }
+}
+
+.faq_answer_inner {
+  overflow: hidden;
+
+  > p {
+    margin: 0;
+    padding-bottom: $spacing-md;
+    font-size: $font-size-sm;
+    color: $color-text-secondary;
+    line-height: $line-height-wide;
+  }
+}
+
+// ─── CTA 링크 ───────────────────────────────────────
+.cta_link {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-xs;
+  font-size: $font-size-md;
+  font-weight: $font-weight-semibold;
+  color: $color-gold;
+  text-decoration: none;
+  padding-bottom: $spacing-xxs;
+  border-bottom: 1px solid rgba($color-gold, 0.3);
+  transition:
+    border-color $transition-duration-normal $transition-easing-default,
+    opacity $transition-duration-normal $transition-easing-default;
+
+  &:hover {
+    border-color: $color-gold;
+    opacity: 0.8;
+  }
+}
+
+// ─── 반응형 보정 ────────────────────────────────────
+@include respond($breakpoint-xs) {
+  .header {
+    // margin-bottom: $spacing-xl;
+  }
+
+  .faq_list {
+    margin-bottom: $spacing-lg;
+  }
+}

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -1,5 +1,7 @@
 // Local variables
 $bg-section: #fdfaf5;
+$divider-width: 4rem;
+$divider-height: 0.2rem;
 
 // ─── Section ────────────────────────────────────────
 .section {
@@ -110,8 +112,8 @@ $bg-section: #fdfaf5;
 }
 
 .divider {
-  width: 4rem;
-  height: 0.2rem;
+  width: $divider-width;
+  height: $divider-height;
   background: $color-gold;
   margin: $spacing-lg 0;
 }

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -25,25 +25,19 @@ $bg-section: #fdfaf5;
     position: relative;
     align-self: center;
   }
-
-  @include respond-up($breakpoint-xl) {
-    align-self: stretch;
-  }
 }
 
 .image_frame {
-  position: relative;
-  height: 100%;
-  min-height: 30rem;
+  aspect-ratio: 3 / 4;
   border-radius: $radius-control;
   overflow: hidden;
 }
 
 .image {
-  @include prevent-img-drag;
-  object-fit: cover;
   width: 100%;
-  height: 90%;
+  height: 100%;
+  object-fit: cover;
+  @include prevent-img-drag;
 }
 
 .year_badge {
@@ -119,6 +113,7 @@ $bg-section: #fdfaf5;
 
 .desc {
   @include text-sub();
+  font-size: $font-size-md;
   line-height: $line-height-wide;
 }
 
@@ -181,7 +176,7 @@ $bg-section: #fdfaf5;
   > p {
     margin: 0;
     padding-bottom: $spacing-md;
-    font-size: $font-size-sm;
+    font-size: $font-size-md;
     color: $color-text-secondary;
     line-height: $line-height-wide;
   }
@@ -192,6 +187,7 @@ $bg-section: #fdfaf5;
   display: inline-flex;
   align-items: center;
   gap: $spacing-xs;
+  width: fit-content;
   font-size: $font-size-md;
   font-weight: $font-weight-semibold;
   color: $color-gold;

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -23,8 +23,13 @@ $bg-section: #fdfaf5;
   @include respond-up($breakpoint-lg) {
     display: block;
     position: relative;
-    align-self: center;
+    align-self: start;
   }
+}
+
+.image_sticky {
+  position: sticky;
+  top: calc($header-height + $spacing-xl);
 }
 
 .image_frame {
@@ -172,13 +177,32 @@ $bg-section: #fdfaf5;
 
 .faq_answer_inner {
   overflow: hidden;
+}
 
-  > p {
-    margin: 0;
-    padding-bottom: $spacing-md;
-    font-size: $font-size-md;
-    color: $color-text-secondary;
-    line-height: $line-height-wide;
+.faq_answer_text {
+  margin: 0;
+  padding-bottom: $spacing-md;
+  font-size: $font-size-md;
+  color: $color-text-secondary;
+  line-height: $line-height-wide;
+}
+
+.faq_link {
+  display: inline-block;
+  margin-bottom: $spacing-md;
+  padding-bottom: $spacing-nano;
+  font-size: $font-size-sm;
+  font-weight: $font-weight-semibold;
+  color: $color-gold;
+  text-decoration: none;
+  border-bottom: $spacing-min solid transparent;
+  transition:
+    border-color $transition-duration-normal $transition-easing-default,
+    opacity $transition-duration-normal $transition-easing-default;
+
+  &:hover {
+    border-color: $color-gold;
+    opacity: 0.8;
   }
 }
 
@@ -206,10 +230,6 @@ $bg-section: #fdfaf5;
 
 // ─── 반응형 보정 ────────────────────────────────────
 @include respond($breakpoint-xs) {
-  .header {
-    // margin-bottom: $spacing-xl;
-  }
-
   .faq_list {
     margin-bottom: $spacing-lg;
   }

--- a/src/app/_component/home/NewHere.tsx
+++ b/src/app/_component/home/NewHere.tsx
@@ -8,6 +8,8 @@ import { LayoutContainer } from '@/components/layout';
 import { revealStyle, REVEAL_STEP_CONTENT } from '@/utils/reveal';
 import styles from './NewHere.module.scss';
 
+const FOUNDING_YEAR = 1958;
+
 const FAQ_ITEMS: { question: string; answer: string; link?: { href: string; label: string } }[] = [
   {
     question: '예배는 언제, 어디서 드리나요?',
@@ -60,7 +62,7 @@ export default function NewHere() {
                 />
               </div>
               <div className={styles.year_badge}>
-                <span className={styles.year_number}>1958</span>
+                <span className={styles.year_number}>{FOUNDING_YEAR}</span>
                 <span className={styles.year_label}>설립연도</span>
               </div>
             </div>

--- a/src/app/_component/home/NewHere.tsx
+++ b/src/app/_component/home/NewHere.tsx
@@ -8,11 +8,17 @@ import { LayoutContainer } from '@/components/layout';
 import { revealStyle, REVEAL_STEP_CONTENT } from '@/utils/reveal';
 import styles from './NewHere.module.scss';
 
-const FAQ_ITEMS = [
+const FAQ_ITEMS: { question: string; answer: string; link?: { href: string; label: string } }[] = [
   {
     question: '예배는 언제, 어디서 드리나요?',
     answer:
-      '주일오전예배는 매주 일요일 오전 11시, 수요예배는 매주 수요일 저녁 7시에 드립니다. 주소는 대구광역시 달서구 달구벌대로307길 58입니다.'
+      '주일오전예배는 매주 일요일 오전 11시, 수요예배는 매주 수요일 저녁 7시에 드립니다. 주소는 대구광역시 달서구 달구벌대로307길 58입니다.',
+    link: { href: '/about', label: '예배안내 보기 →' }
+  },
+  {
+    question: '대구동남교회는 어떤 교회인가요?',
+    answer:
+      '대한예수교장로회(합신) 소속의 개혁주의 교회로, 바른 신학·바른 교회·바른 생활을 지향합니다. 성경 본문에 충실한 강해 설교와 경건한 예배를 통해 성도의 삶을 세워갑니다.'
   },
   {
     question: '처음 가는데 특별히 준비할 게 있나요?',
@@ -23,11 +29,6 @@ const FAQ_ITEMS = [
     question: '아이들과 함께 가도 되나요?',
     answer:
       '물론입니다. 영아부부터 고등부까지 연령별 맞춤 교회학교를 운영하고 있어, 안전한 환경에서 예배드릴 수 있습니다.'
-  },
-  {
-    question: '주차 공간이 있나요?',
-    answer:
-      '교회 인근에 주차 공간을 이용하실 수 있습니다. 자세한 내용은 오시는 길 페이지를 참고해 주세요.'
   }
 ];
 
@@ -44,22 +45,24 @@ export default function NewHere() {
         <div className={styles.inner}>
           {/* 좌측: 교회 이미지 (PC only) */}
           <div className={styles.image_area} data-reveal style={revealStyle()}>
-            <div className={styles.image_frame}>
-              <CloudinaryImage
-                src="dnchurch-dev/site/home/sketch"
-                alt="대구동남교회 전경"
-                width={600}
-                height={800}
-                sizes="50vw"
-                cropMode="fill"
-                gravity="auto"
-                aspectRatio="3:4"
-                className={styles.image}
-              />
-            </div>
-            <div className={styles.year_badge}>
-              <span className={styles.year_number}>1958</span>
-              <span className={styles.year_label}>설립연도</span>
+            <div className={styles.image_sticky}>
+              <div className={styles.image_frame}>
+                <CloudinaryImage
+                  src="dnchurch-dev/site/home/sketch"
+                  alt="대구동남교회 전경"
+                  width={600}
+                  height={800}
+                  sizes="50vw"
+                  cropMode="fill"
+                  gravity="auto"
+                  aspectRatio="3:4"
+                  className={styles.image}
+                />
+              </div>
+              <div className={styles.year_badge}>
+                <span className={styles.year_number}>1958</span>
+                <span className={styles.year_label}>설립연도</span>
+              </div>
             </div>
           </div>
 
@@ -99,7 +102,12 @@ export default function NewHere() {
                   </button>
                   <div className={styles.faq_answer}>
                     <div className={styles.faq_answer_inner}>
-                      <p>{item.answer}</p>
+                      <p className={styles.faq_answer_text}>{item.answer}</p>
+                      {item.link && (
+                        <Link href={item.link.href} className={styles.faq_link}>
+                          {item.link.label}
+                        </Link>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/app/_component/home/NewHere.tsx
+++ b/src/app/_component/home/NewHere.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import clsx from 'clsx';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import { LayoutContainer } from '@/components/layout';
+import { revealStyle, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import styles from './NewHere.module.scss';
+
+const FAQ_ITEMS = [
+  {
+    question: '예배는 언제, 어디서 드리나요?',
+    answer:
+      '주일오전예배는 매주 일요일 오전 11시, 수요예배는 매주 수요일 저녁 7시 30분에 드립니다. 주소는 대구광역시 달서구 달구벌대로307길 58입니다.'
+  },
+  {
+    question: '처음 가는데 특별히 준비할 게 있나요?',
+    answer:
+      '편한 마음으로 오시면 됩니다. 별도의 드레스코드는 없으며, 새가족 담당자가 따뜻하게 맞이해 드립니다.'
+  },
+  {
+    question: '아이들과 함께 가도 되나요?',
+    answer:
+      '물론입니다. 영아부부터 고등부까지 연령별 맞춤 교회학교를 운영하고 있어, 안전한 환경에서 예배드릴 수 있습니다.'
+  },
+  {
+    question: '주차 공간이 있나요?',
+    answer:
+      '교회 인근에 주차 공간을 이용하실 수 있습니다. 자세한 내용은 오시는 길 페이지를 참고해 주세요.'
+  }
+];
+
+export default function NewHere() {
+  const [openIndex, setOpenIndex] = useState<number | null>(0);
+
+  const handleToggle = (index: number) => {
+    setOpenIndex((prev) => (prev === index ? null : index));
+  };
+
+  return (
+    <section className={styles.section} id="new-here">
+      <LayoutContainer>
+        <div className={styles.inner}>
+          {/* 좌측: 교회 이미지 (PC only) */}
+          <div className={styles.image_area} data-reveal style={revealStyle()}>
+            <div className={styles.image_frame}>
+              <CloudinaryImage
+                src="dnchurch-dev/site/home/sketch"
+                alt="대구동남교회 전경"
+                fill
+                sizes="50vw"
+                cropMode="fill"
+                gravity="center"
+                className={styles.image}
+              />
+            </div>
+            <div className={styles.year_badge}>
+              <span className={styles.year_number}>1958</span>
+              <span className={styles.year_label}>설립연도</span>
+            </div>
+          </div>
+
+          {/* 우측: 텍스트 + FAQ */}
+          <div className={styles.content} data-reveal style={revealStyle(REVEAL_STEP_CONTENT)}>
+            <div className={styles.header}>
+              <span className={styles.caption}>Welcome</span>
+              <h2 className={styles.title}>
+                처음 오셨나요?
+                <br />
+                <strong>환영합니다!</strong>
+              </h2>
+              <div className={styles.divider} />
+              <p className={styles.desc}>
+                동남교회의 모든 예배는 언제나 누구에게나 열려 있습니다.
+                <br />
+                방문하기 전 궁금하신 점들을 미리 확인해 보세요.
+              </p>
+            </div>
+
+            <div className={styles.faq_list}>
+              {FAQ_ITEMS.map((item, index) => (
+                <div
+                  key={item.question}
+                  className={clsx(styles.faq_item, openIndex === index && styles.faq_open)}
+                >
+                  <button
+                    type="button"
+                    className={styles.faq_question}
+                    onClick={() => handleToggle(index)}
+                    aria-expanded={openIndex === index}
+                  >
+                    <span>{item.question}</span>
+                    <span className={styles.faq_toggle} aria-hidden="true">
+                      +
+                    </span>
+                  </button>
+                  <div className={styles.faq_answer}>
+                    <div className={styles.faq_answer_inner}>
+                      <p>{item.answer}</p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <Link href="/newcomer" className={styles.cta_link}>
+              새가족부 안내 보기 →
+            </Link>
+          </div>
+        </div>
+      </LayoutContainer>
+    </section>
+  );
+}

--- a/src/app/_component/home/NewHere.tsx
+++ b/src/app/_component/home/NewHere.tsx
@@ -12,7 +12,7 @@ const FAQ_ITEMS = [
   {
     question: '예배는 언제, 어디서 드리나요?',
     answer:
-      '주일오전예배는 매주 일요일 오전 11시, 수요예배는 매주 수요일 저녁 7시 30분에 드립니다. 주소는 대구광역시 달서구 달구벌대로307길 58입니다.'
+      '주일오전예배는 매주 일요일 오전 11시, 수요예배는 매주 수요일 저녁 7시에 드립니다. 주소는 대구광역시 달서구 달구벌대로307길 58입니다.'
   },
   {
     question: '처음 가는데 특별히 준비할 게 있나요?',
@@ -48,10 +48,12 @@ export default function NewHere() {
               <CloudinaryImage
                 src="dnchurch-dev/site/home/sketch"
                 alt="대구동남교회 전경"
-                fill
+                width={600}
+                height={800}
                 sizes="50vw"
                 cropMode="fill"
-                gravity="center"
+                gravity="auto"
+                aspectRatio="3:4"
                 className={styles.image}
               />
             </div>

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -24,9 +24,8 @@ $icon_box_radius: 0.8rem;
   display: flex;
   align-items: center;
   gap: $gap-items;
-  padding: $spacing-lg;
+  padding: $spacing-lg $spacing-xl;
   border-bottom: $spacing-min solid $color-border-default;
-  text-decoration: none;
   transition: background $transition-duration-normal $transition-easing-default;
 
   &:last-child {

--- a/src/app/_component/home/index.ts
+++ b/src/app/_component/home/index.ts
@@ -1,6 +1,7 @@
 export { default as Banner } from './Banner';
 export { default as QuickAccess } from './QuickAccess';
 export { default as RecentSermons } from './RecentSermons';
+export { default as NewHere } from './NewHere';
 export { default as FeedSection } from './FeedSection';
 export { default as AboutOurChurch } from './AboutOurChurch';
 export { default as ChurchVision } from './ChurchVision';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { Banner, QuickAccess, RecentSermons, FeedSection } from './_component/home';
+import { Banner, QuickAccess, RecentSermons, NewHere, FeedSection } from './_component/home';
 
 export default async function Home() {
   return (
@@ -6,6 +6,7 @@ export default async function Home() {
       <Banner />
       <QuickAccess />
       <RecentSermons />
+      <NewHere />
       <FeedSection />
     </>
   );

--- a/src/components/layout/container/LayoutContainer.module.scss
+++ b/src/components/layout/container/LayoutContainer.module.scss
@@ -1,9 +1,5 @@
 .container {
-  padding: 0 $spacing-lg;
+  padding: 0 $padding-section-x;
   margin: 0 auto;
   max-width: $max-width;
-
-  @include respond-up($breakpoint-md) {
-    padding: 0 $spacing-lg;
-  }
 }

--- a/src/components/layout/header/DesktopNav.module.scss
+++ b/src/components/layout/header/DesktopNav.module.scss
@@ -1,4 +1,4 @@
-$nav-center: 60%;
+$nav-center: 65%;
 
 .desktop_nav {
   display: none;
@@ -61,7 +61,7 @@ $nav-center: 60%;
 
 .list {
   display: flex;
-  gap: 3rem;
+  gap: $spacing-md;
   align-items: stretch;
 }
 
@@ -76,7 +76,7 @@ $nav-center: 60%;
   align-items: center;
   padding: $spacing-sm $spacing-sm calc($spacing-sm - 0.2rem) $spacing-sm;
   border-bottom: 0.2rem solid transparent;
-  font-size: $font-size-default;
+  font-size: $font-size-md;
   font-weight: $font-weight-medium;
   color: inherit;
   white-space: nowrap;

--- a/src/components/layout/header/Logo.module.scss
+++ b/src/components/layout/header/Logo.module.scss
@@ -1,8 +1,23 @@
 .logo {
-  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-xxs;
+}
 
-  a {
-    font-size: $font-size-lg;
-    font-weight: $font-weight-bold;
-  }
+.logo_kr {
+  display: inline-block;
+  font-size: $font-size-default;
+  font-weight: $font-weight-semibold;
+  font-family: $font-family-secondary;
+  line-height: $line-height-reset;
+}
+
+.logo_en {
+  display: inline-block;
+  font-size: 1rem;
+  font-weight: $font-weight-semibold;
+  font-family: $font-family-secondary;
+  color: $color-gold;
+  line-height: $line-height-reset;
+  letter-spacing: 0.07rem;
 }

--- a/src/components/layout/header/Logo.tsx
+++ b/src/components/layout/header/Logo.tsx
@@ -3,8 +3,9 @@ import styles from './Logo.module.scss';
 
 export default function Logo() {
   return (
-    <div className={styles.logo}>
-      <Link href="/">대구동남교회</Link>
-    </div>
+    <Link href="/" className={styles.logo}>
+      <span className={styles.logo_kr}>대구동남교회</span>
+      <span className={styles.logo_en}>Dongnam Church · Hapshin</span>
+    </Link>
   );
 }

--- a/src/components/layout/header/MobileToggle.module.scss
+++ b/src/components/layout/header/MobileToggle.module.scss
@@ -5,8 +5,9 @@
     display: inline-flex;
   }
   svg {
-    width: 1.8rem;
-    height: 1.8rem;
+    width: 2.8rem;
+    height: 2.8rem;
+    color: inherit;
   }
 
   @include respond-up($header-breakpoint) {

--- a/src/components/layout/header/MobileToggle.tsx
+++ b/src/components/layout/header/MobileToggle.tsx
@@ -1,4 +1,4 @@
-import { GiHamburgerMenu } from 'react-icons/gi';
+import { RxHamburgerMenu } from 'react-icons/rx';
 import styles from './MobileToggle.module.scss';
 
 type Props = {
@@ -10,7 +10,7 @@ export default function MobileToggle({ ref, handleToggle }: Props) {
   return (
     <div className={styles.toggle} ref={ref}>
       <button onClick={handleToggle} aria-label="Toggle Navigation">
-        <GiHamburgerMenu />
+        <RxHamburgerMenu />
       </button>
     </div>
   );

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -10,7 +10,6 @@ body {
   font-family: $font-family-base;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  letter-spacing: $letter-spacing-base;
   line-height: $line-height-base;
   color: $color-text-default;
   overflow-x: hidden;
@@ -92,7 +91,6 @@ header:has(#gnb:hover):not([data-nav-locked]) {
   flex: 1;
 }
 
-
 #footer {
   width: 100%;
   border-top: 0.1rem solid $color-divide;
@@ -115,7 +113,6 @@ header:has(#gnb:hover):not([data-nav-locked]) {
     display: inline-block;
   }
 }
-
 
 @each $width, $vw-value in $responsive-font-vw-map {
   @include respond-fonts($width, $vw-value);

--- a/src/styles/tokens/_layout.scss
+++ b/src/styles/tokens/_layout.scss
@@ -1,5 +1,5 @@
 $max-width: 100rem;
-$header-height: 5.6rem;
+$header-height: 5.8rem;
 $lnb-min-height: 22rem;
 
 // Button

--- a/src/styles/tokens/_semantic.scss
+++ b/src/styles/tokens/_semantic.scss
@@ -20,8 +20,8 @@ $padding-card: $spacing-md $spacing-lg;
 /// 1.2rem 1.6rem — 작은 카드, 리스트 아이템 내부 여백
 $padding-card-compact: $spacing-sm $spacing-md;
 
-/// 2rem — 페이지 섹션 좌우 여백 (모바일 기준)
-$padding-section-x: $spacing-lg;
+/// 2.4em — 페이지 섹션 좌우 여백 (모바일 기준)
+$padding-section-x: $spacing-xl;
 
 /// 6.4rem — 페이지 섹션 상하 여백
 $padding-section-y: $spacing-xxxl;


### PR DESCRIPTION
## 📋 개요 (Summary)

홈 페이지에 첫 방문자 안내 섹션("처음 오셨나요?") 신규 구현 및 홈 전체 텍스트 링크 hover 일관성 통일.




## 💡 변경 배경 (Motivation)

**해결하려는 문제:**
- 첫 방문자가 예배 시간, 위치, 교회 정체성 등 기본 정보를 홈에서 바로 확인할 수 없음
- 홈 페이지 내 텍스트 링크(설교 전체 보기, 더 보기, 새가족부 안내 보기 등)의 hover 효과가 제각각이라 인터랙션 일관성 부재

<br/>

## 🔧 주요 변경점 (Key Changes)

**NewHere 섹션 신규 구현**
- PC: 2컬럼 그리드(좌측 교회 이미지 + 우측 FAQ 아코디언), 모바일: 단일 컬럼(이미지 숨김)
- FAQ 4개 항목: 예배 시간/위치, 교회 소개(합신 교단), 준비물, 아이 동반
- "예배안내 보기" 링크를 해당 FAQ 답변 하단에 배치, "새가족부 안내 보기" CTA 링크
- Cloudinary 서버사이드 크롭으로 원본 4:3 → 3:4 비율 변환
- `position: sticky`로 아코디언 토글/스크롤 시 이미지 shift 방지

**텍스트 링크 hover 통일**
- 홈 페이지 내 5개 텍스트 링크를 `border-color + opacity: 0.8` 패턴으로 통일
- AboutOurChurch: `a` 태그 셀렉터 → `.about_link` 클래스로 변경, 화살표(→) 추가

<br/>

## 🏗️ 설계 결정 사항 (Design Decisions)

### 레이아웃 변천

이 섹션은 여러 차례의 디자인 피드백을 거쳐 현재 형태에 도달했다.

| 단계 | 레이아웃 | 기각 사유 |
|---|---|---|
| 1차 | 2컬럼 — 다크 그라디언트 사진 오버레이 + 정보 카드 | 그라디언트가 조잡하고, 좌우 레이아웃이 달라 정보 전달 불명확 |
| 2차 | 2컬럼 — 라이트 이미지 + FeedSection 카드 패턴 | 좌우 정보 구조가 여전히 불균형, CTA가 묻힘 |
| 3차 | 단일 컬럼 — cream 배경, 이미지 제거, 정보 카드 | PC에서 좌우 여백 과다, 이미지 없이 단조로움 |
| **최종** | **2컬럼 — 좌측 이미지(PC only) + 우측 FAQ 아코디언** | 이미지로 분위기 전달 + FAQ로 정보 집중 |

### 주요 결정

| 고려한 대안 | 선택한 방법 | 선택 이유 |
|---|---|---|
| 정보 카드 나열 | FAQ 아코디언 | 카드 나열은 좌우 레이아웃 불균형 발생. 아코디언은 단일 컬럼에서 정보를 효율적으로 압축 |
| 모든 FAQ 동시 펼침 | Exclusive 아코디언 (하나만 열림) | 높이 변화 최소화로 이미지 shift 완화 |
| `max-height` 애니메이션 | `grid-template-rows: 0fr/1fr` | 정확한 높이 계산 없이 부드러운 애니메이션 가능, 콘텐츠 길이에 독립적 |
| `align-self: center` (이미지) | `align-self: start` + `position: sticky` | center는 아코디언 높이 변화마다 이미지 shift 발생. sticky는 shift 완전 제거 + 스크롤 시 자연스러운 고정 |
| FAQ 답변 내 인라인 `<Link>` | 답변 `<p>` 아래 별도 `<Link>` 블록 | 인라인 삽입 시 `<p>` → `<div>` 변환 필요하여 스타일 깨짐. 별도 블록이 안정적 |
| `$color-cream`(#f5f0e8) 배경 | `#fdfaf5` 로컬 변수 | FeedSection(white)과의 명도 차이를 줄여 dark → warm → white 자연스러운 전환 |

> ⚠️ **트레이드오프:** 모바일에서 이미지를 완전히 숨기므로 교회 분위기 전달이 텍스트에만 의존함. FAQ 콘텐츠가 하드코딩되어 있어 CMS 연동 시 별도 작업 필요.

<br/>

## 🔍 트러블슈팅 (Troubleshooting)

### 1. FAQ 아코디언 닫힘 애니메이션 끊김

**문제:** `<p>` 태그의 `padding-bottom`이 `grid-template-rows` 트랜지션과 별도로 즉시 사라져 닫힘 애니메이션이 뚝 끊어짐.

**원인:** `grid-template-rows: 0fr`은 내부 요소의 content 높이만 0으로 만들 뿐, padding/margin은 그대로 유지됨.

**해결:** `faq_answer_inner` wrapper에 `overflow: hidden`을 적용. padding이 있는 요소가 wrapper 내부에 있으므로 grid 높이가 0이 되면 padding까지 함께 클리핑됨.

```scss
.faq_answer_inner {
  overflow: hidden;  // padding 포함 전체 클리핑
}
```

### 2. 아코디언 토글 시 이미지 수직 shift

**문제:** `align-self: center`로 이미지를 수직 중앙 배치 → 아코디언 열고 닫을 때 콘텐츠 높이 변화 → 중앙 기준점 이동 → 이미지가 위아래로 shift.

**접근 과정:**

| 단계 | 시도 | 결과 |
|---|---|---|
| 1 | `align-self: start` | shift 제거되나 이미지가 상단에 붙어 허전 |
| 2 | `height: 100%`로 콘텐츠에 맞춤 | 아코디언 모두 닫히면 이미지도 축소 |
| 3 | `aspect-ratio: 3/4`로 이미지 크기 독립 | 크기는 안정적이나 center에서 여전히 shift |
| **최종** | **`align-self: start` + `position: sticky`** | shift 완전 제거 + 스크롤 시 뷰포트 고정 |

```scss
.image_area {
  @include respond-up($breakpoint-lg) {
    align-self: start;
  }
}

.image_sticky {
  position: sticky;
  top: calc($header-height + $spacing-xl);
}
```

### 3. 768~1024px 태블릿 구간 이미지 과도한 세로 길이

**문제:** 2컬럼에서 컬럼 너비가 좁아지면서 3:4 비율 이미지가 과도하게 길어짐.

| 고려한 대안 | 선택한 방법 | 선택 이유 |
|---|---|---|
| `$breakpoint-xl`부터만 표시 | 이미지 유지 + sticky 적용 | "sticky가 높이를 뷰포트 내로 제한하면서 자연스럽게 해소 |

### 4. FAQ 답변 내 인라인 Link 스타일 깨짐

**문제:** 첫 번째 FAQ 답변에 인라인 `<Link>`를 넣기 위해 `<p>` → `<div>`로 변경했더니 스타일이 깨짐.

**해결:** 인라인 삽입 포기. 데이터에 optional `link` 필드를 추가하고, 답변 `<p>` 아래에 별도 `<Link>` 블록으로 렌더링.

```tsx
const FAQ_ITEMS: { question: string; answer: string; link?: { href: string; label: string } }[] = [
  {
    question: '예배는 언제, 어디서 드리나요?',
    answer: '주일오전예배는 매주 일요일 오전 11시...',
    link: { href: '/about', label: '예배안내 보기 →' }
  },
];
```

### 5. 텍스트 링크 hover 불일치

**문제:** 홈 페이지 내 5개 텍스트 링크의 hover 효과가 모두 다름.

| 컴포넌트 | 기존 hover |
|---|---|
| AboutOurChurch | `underline + translateX(0.5rem)` |
| RecentSermons | `border-color + opacity: 0.8` |
| FeedContent | `opacity: 0.7` |
| NewHere (faq) | `opacity: 0.7` |
| NewHere (cta) | `border-color + opacity: 0.8` |

**해결:** RecentSermons `header_link` 패턴을 기준으로 전체 통일. `border-color`는 각 링크의 텍스트 색상(`$color-text-link`, `$color-gold`, `$color-feed-accent`)을 따름.

<br/>

## ✅ 검증 결과 (Verification)

**테스트 결과 / 스크린샷:**

| PC | Mobile |
|--------|-------|
| <img width="1191" height="707" alt="image" src="https://github.com/user-attachments/assets/3318c91e-c079-41c4-b1f5-a3aa03425c64" />  |  <img width="565" height="662" alt="image" src="https://github.com/user-attachments/assets/d6bf40b1-7f69-48fb-8aaa-709233f2ab72" />  |

<br/>

## 🗂️ 수정 파일 목록

| 파일 | 변경 내용 |
|---|---|
| `src/app/_component/home/NewHere.tsx` | 신규 — Client Component, FAQ 아코디언 + sticky 이미지 레이아웃 |
| `src/app/_component/home/NewHere.module.scss` | 신규 — 2컬럼 그리드, 아코디언 애니메이션, sticky, CTA 스타일 |
| `src/app/_component/home/index.ts` | NewHere barrel export 추가 |
| `src/app/page.tsx` | NewHere 섹션 배치 (RecentSermons ↔ FeedSection 사이) |
| `src/app/_component/home/AboutOurChurch.tsx` | `<Link>` className 추가, 화살표(→) 텍스트 추가 |
| `src/app/_component/home/AboutOurChurch.module.scss` | `a` → `.about_link`, hover 패턴 통일 |
| `src/app/_component/home/FeedContent.module.scss` | `.more_link` hover 패턴 통일 |
| `src/styles/globals.scss` | `letter-spacing` 제거, 빈 줄 정리 |

<br/>

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- FAQ 콘텐츠(질문/답변)는 현재 하드코딩. CMS 연동 시 `FAQ_ITEMS`를 서버 데이터로 교체 필요
- `position: sticky`는 부모에 `overflow: hidden`이 있으면 동작하지 않음. 상위 레이아웃 변경 시 주의
- 배경색 `#fdfaf5`는 디자인 토큰에 없는 로컬 변수. 다른 섹션에서 재사용 시 토큰화 검토
- AboutOurChurch의 `a` → `.about_link` 변경으로, 해당 섹션에 다른 `<a>` 태그가 추가되어도 스타일이 의도치 않게 적용되지 않음
