### PR TITLE
[Refactor] 홈페이지 컴포넌트 디자인 시스템 정합 및 유틸 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ next-env.d.ts
 
 /supabase
 .claude/settings.local.json
+
+/docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ yarn knip             # 미사용 코드 검사
 - `className` 네이밍: **snake_case** (`styles.quick_item`)
 - `className` 2개 이상: 반드시 `clsx` 사용
 - 스타일 작성: **모바일 퍼스트** — 기본값이 모바일, `respond-up($width)`으로 상위 뷰포트 확장
+- 커밋 메시지 본문은 **bullet(`-`)으로 항목 구분**
 
 ## ⚠️ Gotchas
 
@@ -41,8 +42,8 @@ yarn knip             # 미사용 코드 검사
 
 ## 상세 문서 (스킬 — 해당 작업 시 자동 로딩)
 
-| 트리거 | 스킬 |
-|---|---|
-| Supabase 클라이언트, 캐싱, revalidateTag, 인증 | `.claude/skills/supabase/` |
-| SCSS 토큰, 믹스인, 시맨틱 토큰 매핑 | `.claude/skills/styles/` |
-| 새 파일 위치, 디렉토리 구조, barrel export | `.claude/skills/file-structure/` |
+| 트리거                                         | 스킬                             |
+| ---------------------------------------------- | -------------------------------- |
+| Supabase 클라이언트, 캐싱, revalidateTag, 인증 | `.claude/skills/supabase/`       |
+| SCSS 토큰, 믹스인, 시맨틱 토큰 매핑            | `.claude/skills/styles/`         |
+| 새 파일 위치, 디렉토리 구조, barrel export     | `.claude/skills/file-structure/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ yarn knip             # 미사용 코드 검사
 - `respond($width)` (max-width)는 예외적 상황에만 — 기본은 `respond-up`
 - 한 페이지에서만 쓰이는 컴포넌트는 `src/components/`가 아닌 `app/[route]/_component/`에 배치
 - 재사용 가능성이 확인된 시점에만 `src/components/`로 이동
+- 커밋 prefix는 **Feat · Fix · Style · Refactor · Docs · Chore** 6개만 사용 — `Enhance` 등 임의 prefix 금지
 
 ## 상세 문서 (스킬 — 해당 작업 시 자동 로딩)
 

--- a/src/app/_component/home/Banner.module.scss
+++ b/src/app/_component/home/Banner.module.scss
@@ -1,23 +1,23 @@
-$btn-gold: #c4924a;
-$btn-gold-hover: #a38458;
-
 .banner {
   margin-top: calc(-1 * $header-height);
-  padding-top: calc($header-height + $spacing-96);
-  padding-bottom: $spacing-32;
+  padding-top: calc($header-height + $spacing-160);
+  padding-bottom: $spacing-64;
+  padding-left: $container-padding;
+  padding-right: $container-padding;
   position: relative;
-  width: 100%;
-  min-height: calc(48rem + $header-height);
-  max-height: calc(56rem + $header-height);
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  min-height: calc(48rem + $header-height);
+  max-height: calc(56rem + $header-height);
+  overflow: hidden;
 
   @include respond-up($breakpoint-tablet-sm) {
-    padding-top: $header-height;
-    padding-bottom: 0;
+    padding-top: calc($header-height + $spacing-80);
+    padding-bottom: $spacing-48;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -50,23 +50,29 @@ $btn-gold-hover: #a38458;
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: $content-gap-s;
+  gap: $content-gap-xs;
   max-width: $container-max;
   width: 100%;
   z-index: 1;
 
-  .scripture {
+  .label {
+    margin-bottom: $spacing-8;
     display: block;
-    @include text-label($color: $gold);
+    font-size: $font-size-13;
     letter-spacing: 0.05rem;
+    color: $gold;
   }
 
   h1 {
     font-family: $font-family-secondary;
-    font-weight: 800;
-    line-height: map-get($heading-line-heights, 'h1');
+    font-weight: 400;
     white-space: pre-line;
     color: $txt-inverse;
+
+    .title_highlight {
+      font-weight: $font-weight-bold;
+      color: $gold;
+    }
   }
 
   p {
@@ -76,7 +82,7 @@ $btn-gold-hover: #a38458;
   }
 
   .cta {
-    margin-top: $spacing-8;
+    margin-top: $spacing-20;
     display: flex;
     flex-direction: column;
     align-items: stretch;
@@ -84,14 +90,15 @@ $btn-gold-hover: #a38458;
 
     .btn_primary,
     .btn_secondary {
-      padding: $padding-control;
-      min-height: 4.2rem;
+      padding: $spacing-20;
+      min-height: 4.4rem;
+      max-height: 4.6rem;
       display: inline-flex;
       align-items: center;
       justify-content: center;
+      border-radius: $radius-xxs;
       font-size: $font-size-13;
       line-height: $line-height-reset;
-      border-radius: $radius-xs;
 
       svg {
         margin-right: $spacing-8;
@@ -102,18 +109,18 @@ $btn-gold-hover: #a38458;
     }
 
     .btn_primary {
-      background: $btn-gold;
+      background: $gold;
       font-weight: $font-weight-bold;
       transition: background 0.2s ease;
 
       &:hover {
-        background: $btn-gold-hover;
+        background: $gold-light;
       }
     }
 
     .btn_secondary {
       background: transparent;
-      border: 0.1rem solid rgba(255, 255, 255, 0.5);
+      border: 0.1rem solid $border-secondary;
       font-weight: $font-weight-medium;
       color: $txt-image-subtle;
       transition:
@@ -121,18 +128,18 @@ $btn-gold-hover: #a38458;
         background 0.2s ease;
 
       &:hover {
-        border-color: rgba(255, 255, 255, 0.7);
+        border-color: $border-primary;
         color: $txt-inverse;
       }
     }
 
-    @include respond-up($breakpoint-mobile) {
+    @include respond-up($breakpoint-mobile-lg) {
       flex-direction: row;
       align-items: center;
 
       .btn_primary,
       .btn_secondary {
-        padding: $padding-control-wide;
+        padding: $spacing-20 $spacing-32;
       }
     }
   }

--- a/src/app/_component/home/Banner.module.scss
+++ b/src/app/_component/home/Banner.module.scss
@@ -65,7 +65,7 @@
 
   h1 {
     font-family: $font-family-secondary;
-    font-weight: 400;
+    font-weight: $font-weight-regular;
     white-space: pre-line;
     color: $txt-inverse;
 

--- a/src/app/_component/home/Banner.tsx
+++ b/src/app/_component/home/Banner.tsx
@@ -1,22 +1,22 @@
 import Link from 'next/link';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
 import { getSiteSettings } from '@/apis/site-settings';
-import { revealStyle, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import { getRevealStyle } from '@/utils/reveal';
 import styles from './Banner.module.scss';
+import SettingsText from '@/components/common/SettingsText';
 
 export default async function Banner() {
-  const settings = await getSiteSettings([
-    'banner_scripture',
-    'banner_title',
-    'banner_subtitle',
-    'banner_image'
-  ]);
+  const settings =
+    (await getSiteSettings(['banner_label', 'banner_title', 'banner_subtitle', 'banner_image'])) ||
+    {};
+
+  const { banner_label, banner_title, banner_subtitle, banner_image } = settings;
 
   return (
     <section className={styles.banner}>
       <div className={styles.bg}>
         <CloudinaryImage
-          src={settings.banner_image}
+          src={banner_image}
           alt="대구동남교회 전경과 십자가 탑"
           fetchPriority="high"
           preload
@@ -26,47 +26,59 @@ export default async function Banner() {
         <div className={styles.overlay} aria-hidden="true" />
       </div>
       <div className={styles.content}>
-        <span className={styles.scripture} data-reveal style={revealStyle()}>
-          {settings.banner_scripture}
+        <span className={styles.label} data-reveal style={getRevealStyle()}>
+          {banner_label}
         </span>
-        <h1 data-reveal style={revealStyle(REVEAL_STEP_CONTENT)}>
-          {settings.banner_title}
+        <h1 data-reveal style={getRevealStyle(1)}>
+          <SettingsText value={banner_title} lineClassNames={{ 1: styles.title_highlight }} />
         </h1>
-        <p data-reveal style={revealStyle(REVEAL_STEP_CONTENT * 2)}>
-          {settings.banner_subtitle}
+        <p data-reveal style={getRevealStyle(2)}>
+          {banner_subtitle}
         </p>
-        <div className={styles.cta} data-reveal style={revealStyle(REVEAL_STEP_CONTENT * 3)}>
+        <div className={styles.cta} data-reveal style={getRevealStyle(3)}>
           <Link href="/about" className={styles.btn_primary}>
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-            >
-              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-              <circle cx="9" cy="7" r="4" />
-              <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-            </svg>
+            <UserIcon />
             처음 오셨나요?
           </Link>
           <Link href="/news/bulletin" className={styles.btn_secondary}>
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              width="16"
-              height="16"
-            >
-              <polygon points="5 3 19 12 5 21 5 3" />
-            </svg>
+            <PlayIcon />
             이번 주 말씀 보기
           </Link>
         </div>
       </div>
     </section>
+  );
+}
+
+function UserIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+    </svg>
+  );
+}
+
+function PlayIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <polygon points="5 3 19 12 5 21 5 3" />
+    </svg>
   );
 }

--- a/src/app/_component/home/FeedContent.module.scss
+++ b/src/app/_component/home/FeedContent.module.scss
@@ -1,15 +1,11 @@
 // 로컬 변수 (디자인 토큰 미포함)
 $color-feed-primary: #5c6b4f;
-$color-feed-primary-light: #eef1eb;
-$color-feed-accent: #c49352;
-$radius-list: 1.4rem;
-$radius-list-lg: 1.6rem;
 
 // ─── Tab Switcher (Mobile Only) ─────────────────────
 .tab_switcher {
   display: flex;
-  gap: $spacing-4;
-  margin-bottom: $spacing-16;
+  border-bottom: $spacing-1 solid $border-primary;
+  margin-bottom: $spacing-32;
 
   @include respond-up($breakpoint-tablet) {
     display: none;
@@ -20,25 +16,31 @@ $radius-list-lg: 1.6rem;
 .tab_inactive {
   flex: 1;
   padding: $spacing-12 0;
-  border-radius: $radius-s;
   border: none;
-  font-size: $font-size-15;
-  font-weight: $font-weight-semibold;
+  border-bottom: 0.1rem solid transparent;
+  margin-bottom: calc(-1 * $spacing-1);
+  background: none;
+  font-size: $font-size-14;
   font-family: $font-family-base;
   cursor: pointer;
   transition:
-    background $transition-duration-normal $transition-easing-default,
-    color $transition-duration-normal $transition-easing-default;
+    color $transition-duration-normal $transition-easing-default,
+    border-color $transition-duration-normal $transition-easing-default;
 }
 
 .tab_active {
-  background: $gray-900;
-  color: $white;
+  font-weight: $font-weight-semibold;
+  color: $gold;
+  border-bottom-color: $gold;
 }
 
 .tab_inactive {
-  background: $cream;
-  color: $txt-secondary;
+  font-weight: $font-weight-regular;
+  color: $txt-tertiary;
+
+  &:hover {
+    color: $txt-secondary;
+  }
 }
 
 // ─── Grid ───────────────────────────────────────────
@@ -49,7 +51,7 @@ $radius-list-lg: 1.6rem;
   @include respond-up($breakpoint-tablet) {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: $spacing-32;
+    gap: $spacing-24;
   }
 }
 
@@ -89,7 +91,7 @@ $radius-list-lg: 1.6rem;
 .color_bar_sharing {
   width: $spacing-4;
   height: 2.2rem;
-  border-radius: $spacing-2;
+  border-radius: $radius-xs;
   display: inline-block;
   flex-shrink: 0;
   transform: translateY(-0.1rem);
@@ -100,36 +102,33 @@ $radius-list-lg: 1.6rem;
 }
 
 .color_bar_sharing {
-  background: $color-feed-accent;
+  background: $gold;
 }
 
 .more_link {
-  @include text-caption;
-  font-weight: $font-weight-semibold;
-  text-decoration: none;
-  color: $color-feed-accent;
   padding-bottom: $spacing-2;
-  border-bottom: $spacing-1 solid transparent;
+  display: block;
+  width: fit-content;
+  border-bottom: $spacing-1 solid rgba($gold, 0.2);
+  font-size: $font-size-13;
+  font-weight: $font-weight-medium;
+  color: rgba($gold, 0.8);
   transition:
-    border-color $transition-duration-normal $transition-easing-default,
-    opacity $transition-duration-normal $transition-easing-default;
+    color $transition-duration-normal $transition-easing-default,
+    border-color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    border-color: $color-feed-accent;
-    opacity: 0.8;
+    color: $gold;
+    border-color: $gold;
   }
 }
 
 // ─── List Card ──────────────────────────────────────
 .list_card {
   background: $white;
-  border-radius: $radius-list;
-  border: 1px solid $border-primary;
+  border-radius: $radius-xs;
+  border: $spacing-1 solid $border-primary;
   overflow: hidden;
-
-  @include respond-up($breakpoint-tablet) {
-    border-radius: $radius-list-lg;
-  }
 }
 
 // ─── Item Row ───────────────────────────────────────
@@ -141,7 +140,7 @@ $radius-list-lg: 1.6rem;
   transition: background $transition-duration-normal $transition-easing-default;
 
   &:not(:last-child) {
-    border-bottom: 1px solid $gray-200;
+    border-bottom: $spacing-1 solid $gray-200;
   }
 
   &:hover {
@@ -156,9 +155,28 @@ $radius-list-lg: 1.6rem;
 // ─── Item Body ──────────────────────────────────────
 .item_body {
   display: flex;
+  align-items: center;
+  gap: $spacing-12;
+  min-width: 0;
+}
+
+.item_content {
+  flex: 1;
+  display: flex;
   flex-direction: column;
   gap: $spacing-4;
   min-width: 0;
+}
+
+.item_chevron {
+  flex-shrink: 0;
+  font-size: $font-size-14;
+  color: $txt-tertiary;
+  transition: color $transition-duration-normal $transition-easing-default;
+
+  .item:hover & {
+    color: $txt-secondary;
+  }
 }
 
 // ─── Item Content ───────────────────────────────────
@@ -172,15 +190,8 @@ $radius-list-lg: 1.6rem;
 
 .item_title {
   color: $txt-primary;
-  font-size: $font-size-15;
-  font-weight: $font-weight-medium;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-
-  @include respond-up($breakpoint-tablet) {
-    font-size: $font-size-16;
-  }
+  font-size: $font-size-14;
+  @include ellipsis-multi(1);
 }
 
 .item_meta {
@@ -198,6 +209,18 @@ $radius-list-lg: 1.6rem;
 }
 
 // ─── Badges ─────────────────────────────────────────
+.badge_category {
+  flex-shrink: 0;
+  padding: $spacing-4 $spacing-6;
+  font-size: $font-size-11;
+  font-weight: $font-weight-medium;
+  line-height: $line-height-reset;
+  border-radius: $radius-xxs;
+  white-space: nowrap;
+  color: $txt-secondary;
+  background: $cream;
+}
+
 .badge_new {
   color: $white;
   font-size: 0.8rem;
@@ -216,9 +239,9 @@ $radius-list-lg: 1.6rem;
 .more_button {
   display: block;
   width: 100%;
-  padding: $spacing-8 0;
-  border-radius: $radius-s;
-  border: 1px solid $border-primary;
+  padding: $spacing-12 0;
+  border-radius: $radius-xs;
+  border: $spacing-1 solid $border-primary;
   background: transparent;
   color: $txt-secondary;
   font-size: $font-size-13;
@@ -226,7 +249,8 @@ $radius-list-lg: 1.6rem;
   margin-top: $spacing-12;
   text-align: center;
   text-decoration: none;
-  transition: background $transition-duration-normal $transition-easing-default,
+  transition:
+    background $transition-duration-normal $transition-easing-default,
     color $transition-duration-normal $transition-easing-default;
 
   &:hover {

--- a/src/app/_component/home/FeedContent.module.scss
+++ b/src/app/_component/home/FeedContent.module.scss
@@ -1,6 +1,3 @@
-// 로컬 변수 (디자인 토큰 미포함)
-$color-feed-primary: #5c6b4f;
-
 // ─── Tab Switcher (Mobile Only) ─────────────────────
 .tab_switcher {
   display: flex;
@@ -98,7 +95,7 @@ $color-feed-primary: #5c6b4f;
 }
 
 .color_bar_news {
-  background: $color-feed-primary;
+  background: $gold;
 }
 
 .color_bar_sharing {

--- a/src/app/_component/home/FeedContent.tsx
+++ b/src/app/_component/home/FeedContent.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import clsx from 'clsx';
-import { revealStyle, REVEAL_STEP, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import { PiCaretRight } from 'react-icons/pi';
+import { revealStyle, REVEAL_STEP, REVEAL_STEP_CONTENT, getRevealStyle } from '@/utils/reveal';
 import { isRecent, formattedDate } from '@/utils/date';
 import type { NoticeType } from '@/types/notice';
 import styles from './FeedContent.module.scss';
@@ -42,7 +43,7 @@ export default function FeedContent({ notices }: Props) {
 
   return (
     <>
-      <div data-reveal style={revealStyle(REVEAL_STEP_CONTENT)} className={styles.tab_switcher}>
+      <div data-reveal style={getRevealStyle(1)} className={styles.tab_switcher}>
         <button
           type="button"
           className={activeTab === 'news' ? styles.tab_active : styles.tab_inactive}
@@ -62,7 +63,7 @@ export default function FeedContent({ notices }: Props) {
       <div className={styles.grid}>
         {/* 교회 소식 */}
         <div className={clsx(styles.column, activeTab !== 'news' && styles.column_hidden)}>
-          <div className={styles.column_header} data-reveal style={revealStyle()}>
+          <div className={styles.column_header} data-reveal style={getRevealStyle(1)}>
             <h3 className={styles.column_title}>
               <span className={styles.color_bar_news} />
               교회 소식
@@ -78,20 +79,22 @@ export default function FeedContent({ notices }: Props) {
                 href={`/news/notice/${notice.id}`}
                 className={styles.item}
                 data-reveal
-                style={revealStyle(i * REVEAL_STEP)}
+                style={getRevealStyle(i)}
               >
                 <div className={styles.item_body}>
-                  <span className={styles.item_title_row}>
-                    {isRecent(notice.created_at) && (
-                      <span className={styles.badge_new}>N</span>
-                    )}
-                    <span className={styles.item_title}>{notice.title}</span>
-                  </span>
-                  <span className={styles.item_meta}>
-                    <span className={styles.item_date}>
-                      {formattedDate(notice.created_at, 'YYYY.MM.DD')}
+                  <div className={styles.item_content}>
+                    <span className={styles.item_title_row}>
+                      {isRecent(notice.created_at) && <span className={styles.badge_new}>N</span>}
+                      <span className={styles.item_title}>{notice.title}</span>
                     </span>
-                  </span>
+                    <span className={styles.item_meta}>
+                      <span className={styles.badge_category}>{notice.category}</span>
+                      <span className={styles.item_date}>
+                        {formattedDate(notice.created_at, 'YYYY.MM.DD')}
+                      </span>
+                    </span>
+                  </div>
+                  <PiCaretRight className={styles.item_chevron} aria-hidden="true" />
                 </div>
               </Link>
             ))}
@@ -100,7 +103,7 @@ export default function FeedContent({ notices }: Props) {
 
         {/* 은혜 나눔 */}
         <div className={clsx(styles.column, activeTab !== 'sharing' && styles.column_hidden)}>
-          <div className={styles.column_header} data-reveal style={revealStyle()}>
+          <div className={styles.column_header} data-reveal style={getRevealStyle(1)}>
             <h3 className={styles.column_title}>
               <span className={styles.color_bar_sharing} />
               은혜 나눔
@@ -111,21 +114,18 @@ export default function FeedContent({ notices }: Props) {
           </div>
           <div className={styles.list_card}>
             {SHARING_ITEMS.map((item, i) => (
-              <div
-                key={item.id}
-                className={styles.item}
-                data-reveal
-                style={revealStyle(i * REVEAL_STEP)}
-              >
+              <div key={item.id} className={styles.item} data-reveal style={getRevealStyle(i)}>
                 <div className={styles.item_body}>
-                  <span className={styles.item_title_row}>
-                    {item.isNew && <span className={styles.badge_new}>N</span>}
-                    <span className={styles.item_title}>{item.title}</span>
-                  </span>
-                  <span className={styles.item_meta}>
-                    <span className={styles.item_author}>{item.author}</span>
-                    <span className={styles.item_date}>{item.date}</span>
-                  </span>
+                  <div className={styles.item_content}>
+                    <span className={styles.item_title_row}>
+                      {item.isNew && <span className={styles.badge_new}>N</span>}
+                      <span className={styles.item_title}>{item.title}</span>
+                    </span>
+                    <span className={styles.item_meta}>
+                      <span className={styles.item_author}>{item.author}</span>
+                      <span className={styles.item_date}>{item.date}</span>
+                    </span>
+                  </div>
                 </div>
               </div>
             ))}
@@ -137,7 +137,7 @@ export default function FeedContent({ notices }: Props) {
         href={activeTab === 'news' ? '/news/notice' : '/fellowship'}
         className={styles.more_button}
         data-reveal
-        style={revealStyle(notices.length * REVEAL_STEP)}
+        style={getRevealStyle(notices.length)}
       >
         더 보기
       </Link>

--- a/src/app/_component/home/FeedSection.module.scss
+++ b/src/app/_component/home/FeedSection.module.scss
@@ -9,11 +9,13 @@
 }
 
 .caption {
-  @include text-label($color: $gold);
-  margin-bottom: $spacing-4;
+  margin-bottom: $spacing-12;
   display: inline-block;
-  letter-spacing: 0.1rem;
+  font-size: $font-size-12;
+  font-weight: $font-weight-medium;
   text-transform: uppercase;
+  letter-spacing: $letter-spacing-wider;
+  color: $gold;
 }
 
 .header h2 {
@@ -26,7 +28,7 @@
 
   @include respond-up($breakpoint-tablet) {
     @include text-sub();
-    margin: $spacing-4 0;
+    margin-top: $spacing-8;
     display: block;
     font-size: $font-size-16;
   }

--- a/src/app/_component/home/FeedSection.tsx
+++ b/src/app/_component/home/FeedSection.tsx
@@ -1,6 +1,6 @@
 import { LayoutContainer } from '@/components/layout';
 import { getNotices } from '@/services/notice';
-import { revealStyle, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import { getRevealStyle } from '@/utils/reveal';
 import FeedContent from './FeedContent';
 import styles from './FeedSection.module.scss';
 
@@ -10,7 +10,7 @@ export default async function FeedSection() {
   return (
     <section className={styles.section}>
       <LayoutContainer>
-        <div data-reveal style={revealStyle()} className={styles.header}>
+        <div data-reveal style={getRevealStyle()} className={styles.header}>
           <span className={styles.caption}>Church Feeds</span>
           <h2>교회 소식과 은혜 나눔</h2>
           <p className={styles.subtitle}>

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -49,8 +49,8 @@ $divider-height: 0.2rem;
 
 .year_badge {
   position: absolute;
-  bottom: -$spacing-16;
-  right: -$spacing-16;
+  bottom: calc(-1 * $spacing-16);
+  right: calc(-1 * $spacing-16);
   padding: $spacing-20 $spacing-24;
   background: $navy;
   border-radius: $radius-xs;
@@ -81,29 +81,33 @@ $divider-height: 0.2rem;
   flex-direction: column;
 
   @include respond-up($breakpoint-tablet) {
-    align-self: center;
+    align-self: flex-start;
+  }
+
+  @include respond-up($breakpoint-tablet-lg) {
+    padding-top: $spacing-20;
   }
 }
 
 // ─── 헤더 ───────────────────────────────────────────
 .header {
-  margin-bottom: $spacing-16;
+  margin-bottom: $spacing-12;
 }
 
 .caption {
-  @include text-label($color: $gold);
-  display: inline-block;
-  letter-spacing: 0.25rem;
-  text-transform: uppercase;
   margin-bottom: $spacing-12;
+  display: inline-block;
+  font-size: $font-size-12;
+  font-weight: $font-weight-medium;
+  text-transform: uppercase;
+  letter-spacing: $letter-spacing-wider;
+  color: $gold;
 }
 
 .title {
   @include text-page-title();
   font-family: $font-family-secondary;
   font-weight: $font-weight-regular;
-  line-height: 1.25;
-  letter-spacing: $letter-spacing-heading;
 
   strong {
     font-family: inherit;
@@ -115,7 +119,7 @@ $divider-height: 0.2rem;
   width: $divider-width;
   height: $divider-height;
   background: $gold;
-  margin: $spacing-20 0;
+  margin: $spacing-16 0;
 }
 
 .desc {
@@ -130,7 +134,7 @@ $divider-height: 0.2rem;
 }
 
 .faq_item {
-  border-bottom: 1px solid $border-primary;
+  border-bottom: 1px solid $border-warm;
 }
 
 .faq_question {
@@ -149,9 +153,18 @@ $divider-height: 0.2rem;
   font-weight: $font-weight-medium;
   color: $txt-primary;
   line-height: $line-height-base;
+  transition: color $transition-duration-normal $transition-easing-default;
+
+  &:hover {
+    color: $gold;
+  }
 
   @include respond-up($breakpoint-tablet) {
     font-size: $font-size-15;
+  }
+
+  .faq_open & {
+    font-weight: $font-weight-semibold;
   }
 }
 
@@ -214,7 +227,7 @@ $divider-height: 0.2rem;
   align-items: center;
   gap: $spacing-8;
   width: fit-content;
-  font-size: $font-size-14;
+  font-size: $font-size-13;
   font-weight: $font-weight-semibold;
   color: $gold;
   text-decoration: none;

--- a/src/app/_component/home/NewHere.tsx
+++ b/src/app/_component/home/NewHere.tsx
@@ -2,10 +2,11 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { PiArrowRight } from 'react-icons/pi';
 import clsx from 'clsx';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
 import { LayoutContainer } from '@/components/layout';
-import { revealStyle, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import { getRevealStyle } from '@/utils/reveal';
 import styles from './NewHere.module.scss';
 
 const FOUNDING_YEAR = 1958;
@@ -46,7 +47,7 @@ export default function NewHere() {
       <LayoutContainer>
         <div className={styles.inner}>
           {/* 좌측: 교회 이미지 (PC only) */}
-          <div className={styles.image_area} data-reveal style={revealStyle()}>
+          <div className={styles.image_area} data-reveal style={getRevealStyle()}>
             <div className={styles.image_sticky}>
               <div className={styles.image_frame}>
                 <CloudinaryImage
@@ -69,7 +70,7 @@ export default function NewHere() {
           </div>
 
           {/* 우측: 텍스트 + FAQ */}
-          <div className={styles.content} data-reveal style={revealStyle(REVEAL_STEP_CONTENT)}>
+          <div className={styles.content} data-reveal style={getRevealStyle()}>
             <div className={styles.header}>
               <span className={styles.caption}>Welcome</span>
               <h2 className={styles.title}>
@@ -90,6 +91,8 @@ export default function NewHere() {
                 <div
                   key={item.question}
                   className={clsx(styles.faq_item, openIndex === index && styles.faq_open)}
+                  data-reveal
+                  style={getRevealStyle(index)}
                 >
                   <button
                     type="button"
@@ -116,8 +119,14 @@ export default function NewHere() {
               ))}
             </div>
 
-            <Link href="/newcomer" className={styles.cta_link}>
-              새가족부 안내 보기 →
+            <Link
+              href="/newcomer"
+              className={styles.cta_link}
+              data-reveal
+              style={getRevealStyle(FAQ_ITEMS.length)}
+            >
+              새가족부 안내 보기
+              <PiArrowRight aria-hidden="true" />
             </Link>
           </div>
         </div>

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -1,44 +1,57 @@
-$icon_box_pc_size: 4.4rem;
-$icon_box_mobile_size: 4.2rem;
-$icon_box_radius: 0.8rem;
+$icon_box_size: 4.2rem;
 
-.quick_wap {
-  background: $white;
+.quick_wrap {
+  background: $cream-deep;
+}
 
-  .quick_container {
-    padding: 0;
+.quick_container {
+  padding: 0;
+
+  @include respond-up($breakpoint-tablet) {
+    padding: 0 calc($container-padding / 4);
   }
 }
 
 .quick_access {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   border-bottom: $spacing-1 solid $border-primary;
   display: grid;
   grid-template-columns: 1fr;
 
+  li:last-child .item {
+    border-bottom: none;
+  }
+
   @include respond-up($breakpoint-tablet) {
     grid-template-columns: repeat(3, 1fr);
+
+    li:last-child .item {
+      border-right: none;
+    }
   }
 }
 
 .item {
   display: flex;
   align-items: center;
-  gap: $content-gap-s;
-  padding: $spacing-20 $spacing-24;
-  border-bottom: $spacing-1 solid $border-primary;
+  padding: $spacing-24;
+  border-bottom: $spacing-1 solid $border-warm;
   transition: background $transition-duration-normal $transition-easing-default;
 
-  &:last-child {
-    border-bottom: none;
+  @include respond-up($breakpoint-mobile) {
+    padding: $spacing-20 $spacing-24;
   }
 
   @include respond-up($breakpoint-tablet) {
+    padding: $spacing-20 $spacing-24;
     border-bottom: none;
     border-right: $spacing-1 solid $border-primary;
+  }
 
-    &:last-child {
-      border-right: none;
-    }
+  @include respond-up($breakpoint-pc) {
+    padding: $spacing-24 $spacing-32;
   }
 
   &:hover {
@@ -46,30 +59,33 @@ $icon_box_radius: 0.8rem;
 
     .arrow {
       opacity: 1;
-      transform: translateX(0);
+      transform: translateX(0.8rem);
     }
   }
 }
 
 .icon_box {
-  flex-shrink: 0;
+  margin-right: $spacing-20;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: $icon_box_mobile_size;
-  height: $icon_box_mobile_size;
+  flex-shrink: 0;
+  width: $icon_box_size;
+  height: $icon_box_size;
   background: $navy;
-  border-radius: $icon_box_radius;
-  font-size: calc($icon_box_mobile_size / 1.6);
+  border-radius: $radius-xs;
+  font-size: calc($icon_box_size / 1.8);
   color: $gold;
 
   @include respond-up($breakpoint-tablet) {
-    width: $icon_box_pc_size;
-    height: $icon_box_pc_size;
-    font-size: calc($icon_box_pc_size / 1.6);
+    margin-right: $spacing-16;
+    width: $icon_box_size;
+    height: $icon_box_size;
+    font-size: calc($icon_box_size / 1.8);
   }
 
   svg {
+    display: block;
     transform: translateX(0.05rem);
   }
 }
@@ -78,28 +94,26 @@ $icon_box_radius: 0.8rem;
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: $spacing-4;
 }
 
 .label {
   font-family: $font-family-secondary;
-  font-size: $font-size-14;
+  font-size: $font-size-15;
   font-weight: $font-weight-semibold;
   color: $txt-primary;
-  line-height: $line-height-reset;
 }
 
 .desc {
-  @include text-caption;
+  display: block;
   font-size: $font-size-12;
-  line-height: 1.4;
+  color: $txt-tertiary;
 }
 
 .arrow {
   flex-shrink: 0;
   font-size: $font-size-14;
-  color: $navy;
-  opacity: 0.4;
+  color: $gold;
+  opacity: 0;
   transition:
     opacity 0.2s ease,
     transform 0.2s ease;

--- a/src/app/_component/home/QuickAccess.tsx
+++ b/src/app/_component/home/QuickAccess.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link';
-import { PiCalendarLight, PiBookOpenLight, PiMapPinLight } from 'react-icons/pi';
-import styles from './QuickAccess.module.scss';
+import { PiCalendarLight, PiBookOpenLight, PiMapPinLight, PiArrowRight } from 'react-icons/pi';
 import { LayoutContainer } from '@/components/layout';
 import IconWrap from '@/components/common/IconWrap';
-import { revealStyle, REVEAL_STEP, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import { getRevealStyle } from '@/utils/reveal';
+import styles from './QuickAccess.module.scss';
 
 const ITEMS = [
   {
@@ -15,7 +15,7 @@ const ITEMS = [
   {
     href: '/about',
     label: '담임목사 인사말',
-    desc: '담임목사님의 말씀을 전합니다',
+    desc: '2026년 말씀 메시지 ',
     Icon: PiBookOpenLight
   },
   {
@@ -28,27 +28,23 @@ const ITEMS = [
 
 export default function QuickAccess() {
   return (
-    <section className={styles.quick_wap}>
+    <section className={styles.quick_wrap}>
       <LayoutContainer className={styles.quick_container}>
-        <nav className={styles.quick_access} aria-label="퀵 액세스">
-          {ITEMS.map(({ href, label, desc, Icon }, i) => (
-            <Link
-              key={label}
-              href={href}
-              className={styles.item}
-              data-reveal
-              style={revealStyle(i * REVEAL_STEP)}
-            >
-              <IconWrap Icon={Icon} className={styles.icon_box} aria-hidden="true" />
-              <span className={styles.text}>
-                <span className={styles.label}>{label}</span>
-                <span className={styles.desc}>{desc}</span>
-              </span>
-              <span className={styles.arrow} aria-hidden="true">
-                →
-              </span>
-            </Link>
-          ))}
+        <nav aria-label="퀵 액세스">
+          <ul className={styles.quick_access}>
+            {ITEMS.map(({ href, label, desc, Icon }, i) => (
+              <li key={href}>
+                <Link href={href} className={styles.item} data-reveal style={getRevealStyle(i)}>
+                  <IconWrap Icon={Icon} className={styles.icon_box} aria-hidden="true" />
+                  <div className={styles.text}>
+                    <span className={styles.label}>{label}</span>
+                    <span className={styles.desc}>{desc}</span>
+                  </div>
+                  <IconWrap Icon={PiArrowRight} className={styles.arrow} aria-hidden="true" />
+                </Link>
+              </li>
+            ))}
+          </ul>
         </nav>
       </LayoutContainer>
     </section>

--- a/src/app/_component/home/RecentSermons.module.scss
+++ b/src/app/_component/home/RecentSermons.module.scss
@@ -1,6 +1,6 @@
 // ─── Section ────────────────────────────────────────
 .section {
-  padding: $section-padding-64 0;
+  padding: $section-padding-80 0;
   background: $bg-dark;
 }
 
@@ -8,7 +8,7 @@
 .header {
   display: flex;
   flex-direction: column;
-  gap: $content-gap-s;
+  gap: $content-gap-m;
   margin-bottom: $content-gap-l;
 
   @include respond-up($breakpoint-mobile-lg) {
@@ -21,36 +21,39 @@
 .header_left {
   display: flex;
   flex-direction: column;
-  gap: $spacing-4;
 }
 
 .caption {
-  @include text-label($color: $gold);
-  letter-spacing: 0.1rem;
+  margin-bottom: $spacing-12;
+  display: inline-block;
+  font-size: $font-size-12;
+  font-weight: $font-weight-medium;
   text-transform: uppercase;
+  letter-spacing: $letter-spacing-wider;
+  color: $gold;
 }
 
 .header h2 {
-  color: $white;
-  @include text-page-title();
   font-family: $font-family-secondary;
+  font-weight: $font-weight-medium;
+  color: $white;
 }
 
 .header_link {
-  @include text-sub($color: $gold);
   padding-bottom: $spacing-2;
-  display: inline-block;
+  display: block;
   width: fit-content;
-  border-bottom: $spacing-1 solid transparent;
-  text-decoration: none;
-  white-space: nowrap;
+  border-bottom: $spacing-1 solid rgba($gold, 0.2);
+  font-size: $font-size-13;
+  font-weight: $font-weight-medium;
+  color: rgba($gold, 0.7);
   transition:
-    opacity 0.2s ease,
-    border 0.2s ease;
+    color $transition-duration-normal $transition-easing-default,
+    border-color $transition-duration-normal $transition-easing-default;
 
   &:hover {
+    color: $gold;
     border-color: $gold;
-    opacity: 0.8;
   }
 }
 

--- a/src/app/_component/home/RecentSermons.tsx
+++ b/src/app/_component/home/RecentSermons.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { LayoutContainer } from '@/components/layout';
 import SermonCard from '@/app/_component/home/SermonCard';
 import { getRecentSermons } from '@/apis/sermons';
-import { revealStyle, REVEAL_STEP, REVEAL_STEP_CONTENT } from '@/utils/reveal';
+import { getRevealStyle } from '@/utils/reveal';
 import styles from './RecentSermons.module.scss';
 
 export default async function RecentSermons() {
@@ -15,25 +15,20 @@ export default async function RecentSermons() {
   return (
     <section className={styles.section}>
       <LayoutContainer>
-        <div data-reveal style={revealStyle()} className={styles.header}>
+        <div data-reveal style={getRevealStyle()} className={styles.header}>
           <div className={styles.header_left}>
             <span className={styles.caption}>the Message</span>
-            <h2>말씀 다시보기</h2>
+            <h2>지난 설교 다시보기</h2>
           </div>
           <Link href="/sermons" className={styles.header_link}>
             설교 전체 보기 →
           </Link>
         </div>
         <div className={styles.grid}>
-          <SermonCard sermon={featured} isLatest delay={REVEAL_STEP} />
+          <SermonCard sermon={featured} isLatest index={0} />
           <div className={styles.sub_list}>
             {rest.map((sermon, i) => (
-              <SermonCard
-                key={sermon.id}
-                sermon={sermon}
-                delay={(i + 1) * REVEAL_STEP}
-                isSub
-              />
+              <SermonCard key={sermon.id} sermon={sermon} index={i + 1} isSub />
             ))}
           </div>
         </div>

--- a/src/app/_component/home/SermonCard.tsx
+++ b/src/app/_component/home/SermonCard.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import clsx from 'clsx';
 import { formattedDate } from '@/utils/date';
-import { revealStyle } from '@/utils/reveal';
+import { getRevealStyle } from '@/utils/reveal';
 import type { RecentSermon } from '@/apis/sermons';
 import styles from './SermonCard.module.scss';
 
@@ -11,25 +11,11 @@ const YT_WATCH = 'https://www.youtube.com/watch?v=';
 type SermonCardProps = {
   sermon: RecentSermon;
   isLatest?: boolean;
-  delay?: number;
+  index?: number;
   isSub?: boolean;
 };
 
-function PlayIcon({ className }: { className?: string }) {
-  return (
-    <span className={className} aria-hidden="true">
-      <svg viewBox="0 0 12 14" fill="currentColor">
-        <path d="M0 0v14l12-7z" />
-      </svg>
-    </span>
-  );
-}
-
-function sermonAlt(sermon: Pick<RecentSermon, 'title' | 'preacher' | 'sermon_date'>) {
-  return `${sermon.title} - ${sermon.preacher} (${formattedDate(sermon.sermon_date, 'YYYY.MM.DD')})`;
-}
-
-export default function SermonCard({ sermon, isLatest, delay, isSub }: SermonCardProps) {
+export default function SermonCard({ sermon, isLatest, index, isSub }: SermonCardProps) {
   return (
     <Link
       href={sermon.youtube_id ? `${YT_WATCH}${sermon.youtube_id}` : `/sermons/${sermon.id}`}
@@ -38,9 +24,10 @@ export default function SermonCard({ sermon, isLatest, delay, isSub }: SermonCar
       rel="noopener noreferrer"
       aria-label={`${sermon.title} 설교 영상 재생 - ${sermon.preacher}`}
       data-reveal
-      style={revealStyle(delay)}
+      style={getRevealStyle(index)}
     >
       <div className={styles.card_thumb}>
+        {/* TODO: Cloudinary 최적화 */}
         {sermon.youtube_id && (
           <img
             src={`${YT_THUMB}/${sermon.youtube_id}/maxresdefault.jpg`}
@@ -68,4 +55,18 @@ export default function SermonCard({ sermon, isLatest, delay, isSub }: SermonCar
       </div>
     </Link>
   );
+}
+
+function PlayIcon({ className }: { className?: string }) {
+  return (
+    <span className={className} aria-hidden="true">
+      <svg viewBox="0 0 12 14" fill="currentColor">
+        <path d="M0 0v14l12-7z" />
+      </svg>
+    </span>
+  );
+}
+
+function sermonAlt(sermon: Pick<RecentSermon, 'title' | 'preacher' | 'sermon_date'>) {
+  return `${sermon.title} - ${sermon.preacher} (${formattedDate(sermon.sermon_date, 'YYYY.MM.DD')})`;
 }

--- a/src/components/common/SettingsText.tsx
+++ b/src/components/common/SettingsText.tsx
@@ -1,17 +1,18 @@
 type Props = {
   value: string | undefined;
   fallback?: string;
+  lineClassNames?: Record<number, string>;
 };
 
-export default function SettingsText({ value, fallback = '' }: Props) {
+export default function SettingsText({ value, fallback = '', lineClassNames }: Props) {
   const lines = (value ?? fallback).split('\n');
 
-  if (lines.length === 1) return <>{lines[0]}</>;
+  if (lines.length === 1 && !lineClassNames) return <>{lines[0]}</>;
 
   return (
     <>
       {lines.map((line, i) => (
-        <span key={i} style={{ display: 'block', fontFamily: 'inherit', color: 'inherit' }}>
+        <span key={i} className={lineClassNames?.[i]} style={{ display: 'block' }}>
           {line}
         </span>
       ))}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -20,12 +20,15 @@
   }
 }
 
-@mixin set-heading-fonts($sizes-map, $line-heights-map: null) {
+@mixin set-heading-fonts($sizes-map, $line-heights-map: null, $letter-spacings-map: null) {
   @each $heading, $size in $sizes-map {
     #{$heading} {
       font-size: $size;
       @if $line-heights-map {
         line-height: map-get($line-heights-map, $heading);
+      }
+      @if $letter-spacings-map {
+        letter-spacing: map-get($letter-spacings-map, $heading);
       }
     }
   }
@@ -53,7 +56,6 @@
   -webkit-user-select: none;
   -ms-user-select: none;
 }
-
 
 @mixin ellipsis-multi($lines: 2) {
   display: -webkit-box;
@@ -86,7 +88,9 @@
   font-weight: $weight;
   line-height: map-get($heading-line-heights, 'h1');
   letter-spacing: $letter-spacing-heading;
-  @if $color { color: $color; }
+  @if $color {
+    color: $color;
+  }
 
   @include respond-up($breakpoint-tablet) {
     font-size: $font-size-42;
@@ -99,7 +103,9 @@
   font-weight: $weight;
   line-height: map-get($heading-line-heights, 'h2');
   letter-spacing: $letter-spacing-heading;
-  @if $color { color: $color; }
+  @if $color {
+    color: $color;
+  }
 
   @include respond-up($breakpoint-tablet) {
     font-size: $font-size-34;
@@ -112,7 +118,9 @@
   font-weight: $weight;
   line-height: map-get($heading-line-heights, 'h3');
   letter-spacing: $letter-spacing-tight;
-  @if $color { color: $color; }
+  @if $color {
+    color: $color;
+  }
 
   @include respond-up($breakpoint-tablet) {
     font-size: $font-size-28;
@@ -125,7 +133,9 @@
   font-weight: $weight;
   line-height: map-get($heading-line-heights, 'h4');
   letter-spacing: $letter-spacing-tight;
-  @if $color { color: $color; }
+  @if $color {
+    color: $color;
+  }
 
   @include respond-up($breakpoint-tablet) {
     font-size: $font-size-24;
@@ -137,7 +147,9 @@
   font-size: $font-size-18;
   font-weight: $weight;
   line-height: map-get($heading-line-heights, 'h5');
-  @if $color { color: $color; }
+  @if $color {
+    color: $color;
+  }
 
   @include respond-up($breakpoint-tablet) {
     font-size: $font-size-20;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -18,7 +18,9 @@
   --spacing-48: 4rem;
   --spacing-64: 5.2rem;
   --spacing-80: 6.4rem;
-  --spacing-96: 8rem;
+  --spacing-120: 8rem;
+  --spacing-160: 12rem;
+  --spacing-200: 16rem;
 
   // radius-2 ~ radius-6: 모든 해상도 동일
   --radius-2: 0.2rem;
@@ -51,7 +53,7 @@
   --screensize-h-min: 81.2rem;
 }
 
-@include respond-up($breakpoint-tablet-sm) {
+@include respond-up($breakpoint-tablet) {
   :root {
     // ── Spacing — Desktop 값 ──
     --spacing-8: 0.8rem;
@@ -65,7 +67,9 @@
     --spacing-48: 4.8rem;
     --spacing-64: 6.4rem;
     --spacing-80: 8rem;
-    --spacing-96: 9.6rem;
+    --spacing-120: 12rem;
+    --spacing-160: 16rem;
+    --spacing-200: 20rem;
 
     --radius-8: 0.8rem;
     --radius-10: 1rem;
@@ -117,6 +121,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: $line-height-base;
+  letter-spacing: $letter-spacing-body;
   color: $txt-primary;
   overflow-x: hidden;
   -webkit-text-size-adjust: none;
@@ -131,14 +136,6 @@ body {
   font-family: inherit;
   color: inherit;
   box-sizing: border-box;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5 {
-  letter-spacing: $letter-spacing-heading;
 }
 
 input,
@@ -224,7 +221,7 @@ header:has(#gnb:hover):not([data-nav-locked]) {
   @include respond-fonts($width, $vw-value);
 }
 
-@include set-heading-fonts($heading-sizes-mobile, $heading-line-heights);
+@include set-heading-fonts($heading-sizes-mobile, $heading-line-heights, $heading-letter-spacings);
 @include respond-up($breakpoint-tablet) {
   @include set-heading-fonts($heading-sizes);
 }

--- a/src/styles/tokens/_color.scss
+++ b/src/styles/tokens/_color.scss
@@ -18,10 +18,19 @@ $white: #faf9f6;
 // ══════════════════════════════════════════
 
 /// 교회 네이비. 다크 배경, 헤더/푸터, 강한 브랜드 표현
-$navy: #1b2d4e;
+$navy: #1c2b3a;
+
+/// 네이비 중간 톤. 서브 배경, 구분선, 보조 요소
+$navy-mid: #2c3e50;
+
+/// 네이비 연한 톤. hover 상태, 보조 UI 요소
+$navy-light: #3d5166;
 
 /// 포인트 컬러. CTA 강조, 브랜드 액센트
-$gold: #b8976a;
+$gold: #c4924a;
+
+/// 골드 연한 톤. hover 상태, 보조 강조
+$gold-light: #d9a96a;
 
 /// 섹션/카드 배경. 따뜻한 톤의 배경
 $cream: #f5f0e6;
@@ -120,7 +129,10 @@ $border-primary: $gray-300;
 $border-secondary: $gray-500;
 
 /// 반전 경계선. 다크 배경 위
-$border-inverse: $gray-200;
+$border-inverse: $white;
+
+/// 따뜻한 경계선. cream 배경 위 구분선
+$border-warm: #64503226;
 
 // ══════════════════════════════════════════
 // SEMANTIC: Primary Action

--- a/src/styles/tokens/_layout.scss
+++ b/src/styles/tokens/_layout.scss
@@ -12,7 +12,7 @@ $container-min: var(--container-min);
 /// 컨테이너 최대 너비 (PC·Tablet 120rem / Mobile 76.8rem)
 $container-max: var(--container-max);
 
-/// 최소 화면 높이 (PC 80rem / Tablet 102.4rem / Mobile 81.2rem)
+/// 최소 화면 높이 (PC 80rem / Tablet 102.4rem / Mobile 81.2rem), 한 화면에 콘텐츠를 모두 노출해야 하는 경우
 $screensize-h-min: var(--screensize-h-min);
 
 // ══════════════════════════════════════════

--- a/src/styles/tokens/_semantic.scss
+++ b/src/styles/tokens/_semantic.scss
@@ -71,6 +71,9 @@ $radius-s: var(--radius-12);
 /// XS (Desktop 0.8rem / Mobile 0.6rem) — label, tag, button 등 가장 작은 컴포넌트
 $radius-xs: var(--radius-8);
 
+/// XXS (Desktop 0.4rem / Mobile 0.4rem)
+$radius-xxs: var(--radius-4);
+
 /// Circle (9999px) — 원형 표현이 필요한 경우, 높이 또는 너비 값의 50%를 기준으로 사용
 $radius-circle: var(--radius-999);
 

--- a/src/styles/tokens/_spacing.scss
+++ b/src/styles/tokens/_spacing.scss
@@ -22,4 +22,6 @@ $spacing-40: var(--spacing-40);
 $spacing-48: var(--spacing-48);
 $spacing-64: var(--spacing-64);
 $spacing-80: var(--spacing-80);
-$spacing-96: var(--spacing-96);
+$spacing-120: var(--spacing-120);
+$spacing-160: var(--spacing-160);
+$spacing-200: var(--spacing-200);

--- a/src/styles/tokens/_typography.scss
+++ b/src/styles/tokens/_typography.scss
@@ -45,11 +45,20 @@ $font-weight-bold: 700;
 // LETTER SPACING
 // ══════════════════════════════════════════
 
+/// -0.03rem — 본문 기본값. body 기본 letter-spacing
+$letter-spacing-body: -0.03rem;
+
 /// -0.15rem — 대형 헤딩(h1~h2)에서 글자 간 간격 축소
 $letter-spacing-heading: -0.15rem;
 
 /// -0.1rem — 중형 헤딩(h3~h5)
 $letter-spacing-tight: -0.1rem;
+
+/// 0.05rem — 라벨, 캡션 등 소형 텍스트의 가독성 향상                  │
+$letter-spacing-wide: 0.1rem;
+
+/// 0.2rem — 영문 대문자, 뱃지, 섹션 제목 등 강한 트래킹
+$letter-spacing-wider: 0.2rem;
 
 // ══════════════════════════════════════════
 // FONT SIZE — 숫자 기반 네이밍
@@ -124,9 +133,17 @@ $heading-sizes-mobile: (
 );
 
 $heading-line-heights: (
-  'h1': 1.25,
-  'h2': 1.35,
+  'h1': 1.3,
+  'h2': 1.3,
   'h3': 1.4,
-  'h4': 1.5,
+  'h4': 1.4,
   'h5': 1.5
+);
+
+$heading-letter-spacings: (
+  'h1': -0.1rem,
+  'h2': -0.05rem,
+  'h3': -0.03rem,
+  'h4': -0.03rem,
+  'h5': -0.03rem,
 );

--- a/src/utils/reveal.ts
+++ b/src/utils/reveal.ts
@@ -15,3 +15,5 @@ export const revealStyle = (delay?: number): CSSProperties => ({
   transition: `opacity ${REVEAL_DURATION} ease, transform ${REVEAL_DURATION} ease`,
   ...(delay ? { transitionDelay: `${delay}s` } : {})
 });
+
+export const getRevealStyle = (step: number = 0) => revealStyle(REVEAL_STEP_CONTENT * step);

--- a/src/utils/reveal.ts
+++ b/src/utils/reveal.ts
@@ -16,4 +16,4 @@ export const revealStyle = (delay?: number): CSSProperties => ({
   ...(delay ? { transitionDelay: `${delay}s` } : {})
 });
 
-export const getRevealStyle = (step: number = 0) => revealStyle(REVEAL_STEP_CONTENT * step);
+export const getRevealStyle = (step: number = 0, interval: number = REVEAL_STEP_CONTENT) => revealStyle(interval * step);


### PR DESCRIPTION
## 📋 개요 (Summary)

홈페이지 섹션(Banner, QuickAccess, NewHere, FeedContent/FeedSection) 전반에 산재한
하드코딩 값·로컬 변수를 디자인 토큰으로 교체하고, reveal 유틸 및 공통 컴포넌트 개선.

<br>

## 💡 리팩토링 배경 (Motivation)

**개선하려는 문제:**

- 토큰 파일을 매번 열어 값을 확인해야 하는 탐색 비용 — 기존 토큰은 `$radius-xs`, `$radius-s`처럼 상대 크기 명칭을 사용해, 실제 값과 적용 맥락을 파악하려면 토큰 파일을 항상 참조해야 했음
- 용도 기반 네이밍으로 인한 의사결정 비용 — "이 컴포넌트에 xs가 맞나, s가 맞나"를 판단하기 위해 각 토큰의 실제 값과 용도를 재확인해야 했고, 섹션마다 다른 판단이 내려져 스타일 불일치 발생
- 하드코딩으로 누적된 기술 부채 — 토큰 탐색 비용을 피하기 위해 `$btn-gold: #c4924a`, `$radius-list: 1.4rem` 등 로컬 변수와 HEX 직접 사용이 반복되어 전역 토큰과 중복 정의 누적
- `revealStyle(i * REVEAL_STEP_CONTENT)` 패턴의 분산 — 각 컴포넌트가 delay 계산식을 직접 작성해, 수정 시 모든 호출부를 일일이 변경해야 하는 유지보수 부담

**해결 방향 — Codeit 디자인 시스템 레퍼런스 적용:**

Codeit의 Primitive Token + Semantic Token 2계층 구조를 참고해 토큰 체계 재정비.

- **Primitive Token** — `$spacing-8`, `$font-size-14`, `$radius-xxs`처럼 숫자 단위로 값을 직접 표현. 파일을 열지 않아도 토큰명만으로 크기 유추 가능, 의사결정 비용 절감
- **Semantic Token** — `$txt-secondary`, `$border-warm`, `$gold`처럼 용도·역할 기반으로 명시. HEX 직접 사용 없이 의미 단위로 적용 가능

이번 리팩토링에서는 각 컴포넌트에 산재한 하드코딩 값과 로컬 변수를 이 토큰 체계로 교체하여,
이후 스타일 수정 시 파일 탐색 없이 토큰명만으로 빠르게 판단·적용 가능한 기반 마련.


<br>

## 🔧 주요 변경점 (Key Changes)

- `reveal.ts`에 `getRevealStyle(step)` 헬퍼 추가 — `revealStyle(i * REVEAL_STEP_CONTENT)` 반복 호출을 `getRevealStyle(i)`로 일원화
- `SettingsText`에 `lineClassNames` prop 추가 — 줄별 className 지정 가능, Banner 2번째 줄 bold+gold 스타일 적용에 활용
- Banner 인라인 SVG를 `UserIcon` / `PlayIcon` 서브컴포넌트로 분리
- QuickAccess를 `nav > ul > li > a` 시맨틱 구조로 변경, 텍스트 화살표(`→`)를 `PiArrowRight` 아이콘으로 교체
- 하드코딩 색상·수치 제거
  - `$btn-gold`, `$color-feed-accent`, `$radius-list`, `$radius-list-lg`, `$color-feed-primary-light` → 글로벌 토큰(`$gold`, `$radius-xs`, `$radius-xxs` 등)으로 교체
- 각 섹션 caption/label 스타일을 `text-label()` 믹스인 대신 토큰 직접 적용 방식으로 통일
  - `$letter-spacing-wider`, `$font-size-12`, `$font-weight-medium` 적용으로 섹션 간 불일치 해소
- `year_badge` CSS 음수값 표기 수정 — `-$spacing-16` → `calc(-1 * $spacing-16)`
- `.gitignore`에 `/docs` 디렉토리 추가, `CLAUDE.md` 커밋 규칙 및 테이블 포맷 정리

<br>

## 🏗️ 설계 변경 사항 (Design Changes)

**변경 전 구조:**

- 각 컴포넌트가 `REVEAL_STEP`, `REVEAL_STEP_CONTENT`를 직접 import해 delay 계산을 각자 수행
- 하드코딩 로컬 변수와 글로벌 디자인 토큰 혼재
- `text-label()`, `text-caption()` 믹스인 의존으로 섹션 간 caption 스타일 불일치

**변경 후 구조:**

- `getRevealStyle(step)` 단일 헬퍼로 delay 계산을 추상화, 컴포넌트는 step 숫자만 전달
- 모든 색상·radius·spacing이 글로벌 토큰으로 통일
- 토큰 직접 적용으로 믹스인 내부 구현에 대한 의존 제거

> ⚠️ **주의사항:**
> - `SettingsText`에서 `lineClassNames`가 있으면 단일 줄이어도 `<span>` 래핑 강제 — 기존 단순 텍스트 렌더링과 다른 DOM 구조 생성 가능
> - `getRevealStyle`의 step 단위는 `REVEAL_STEP_CONTENT` 기준 고정 — 섹션별로 다른 stagger 간격이 필요한 경우 기존 `revealStyle()` 직접 호출 방식 유지 필요

<br>

## 📊 개선 지표 (Improvement Metrics)

| 항목 | Before | After |
|------|--------|-------|
| 하드코딩 로컬 색상 변수 | 5개 (`$btn-gold`, `$color-feed-accent`, `$radius-list` 등) | 0개 |
| reveal delay 계산 패턴 | 각 컴포넌트에서 `i * REVEAL_STEP_CONTENT` 직접 계산 | `getRevealStyle(i)` 단일 헬퍼로 일원화 |
| Banner 인라인 SVG | 2개 (각 15줄+, JSX 내부 직접 작성) | 0개 (서브컴포넌트 분리) |
| QuickAccess 시맨틱 구조 | `nav > a` (list 없음) | `nav > ul > li > a` |
| caption 스타일 일관성 | 섹션별 믹스인·하드코딩 혼재 | 토큰 직접 적용으로 통일 |

<br>

## ✅ 검증 결과 (Verification)

**회귀 테스트 (Regression Test):**
- [ ] 기존 테스트 전체 통과 여부
- [ ] 새로 추가한 테스트 통과 여부
- [x] 수동 테스트로 주요 시나리오 동작 확인

**수행한 테스트:**
- [ ] 단위 테스트 (Unit Test)
- [ ] 통합 테스트 (Integration Test)
- [x] 수동 테스트 (Manual Test) — Banner, QuickAccess, NewHere, FeedContent 각 섹션 모바일/PC 렌더링 확인


**테스트 결과 / 스크린샷:**

| Before - PC | After - PC|
|--------|-------|
| <img width="1342" height="3077" alt="image" src="https://github.com/user-attachments/assets/7f57fb28-77c2-4d65-893d-36b98ca3903f" />  | <img width="1342" height="3077" alt="image" src="https://github.com/user-attachments/assets/7f57fb28-77c2-4d65-893d-36b98ca3903f" /> |

| Before - Mobile | After - Mobile |
|--------|-------|
| <img width="590" height="3661" alt="image" src="https://github.com/user-attachments/assets/c4a3c9b8-b116-457b-a6d7-6e25b0ed2e05" />  |  <img width="590" height="3700" alt="image" src="https://github.com/user-attachments/assets/baf027b3-e244-44f5-8f2d-5de39e26e29e" /> |

<br>

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**리팩토링 완성도**
- [x] 외부 동작(기능, API 인터페이스) 변경 없음 확인
- [ ] 기존 테스트 전체 통과 여부
- [x] 성능 저하 없음 확인

**코드 품질**
- [x] 변수명·함수명의 의도 명확성
- [x] 복잡한 로직 설명 주석 추가 여부
- [x] 불필요한 코드·디버그 로그 제거 여부
- [x] 불필요한 기능 변경 미포함 확인 (리팩토링과 기능 개발 분리)

**테스트 및 문서화**
- [x] 구조 변경에 따른 README·주석 업데이트 여부 (`CLAUDE.md` 업데이트)
- [x] Conventional Commits 규격 준수 여부 (`refactor`)

<br>

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- `getRevealStyle`은 현재 `REVEAL_STEP_CONTENT` 고정값 기반 — 향후 섹션마다 다른 stagger 속도가 필요해지면 `speed` 파라미터 추가 방향으로 확장 가능
- caption 스타일 통일 방식(믹스인 → 토큰 직접 적용)은 믹스인 내부 구현에 의존하지 않아 명시적이나, 향후 caption 디자인 변경 시 여러 파일 수정 필요 — 공통 caption 믹스인 재정의 고려 가능
- QuickAccess `ul > li` 도입으로 CSS 선택자가 `.item` → `li:last-child .item` 방식으로 변경 — 추가 스타일 작업 시 구조 확인 필요