### PR TITLE
[Fix] 헤더 깜빡임 및 홈 fadeUp 애니메이션 오작동 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dnchurch",
-  "version": "0.1.0",
+  "version": "0.3.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dnchurch",
-      "version": "0.1.0",
+      "version": "0.3.1-beta.1",
       "dependencies": {
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.86.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dnchurch",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.1-beta.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,35 +33,36 @@ const myeongjo = Nanum_Myeongjo({
 const SCROLL_REVEAL_OBSERVER_SCRIPT = `
 (function(){
   var STAGGER=0.1;
+  var SECTION_GAP=200;
   var pending=[];
   var rafId=null;
-  var revealed={};
-
-  function isRevealed(){return !!revealed[location.pathname]}
-
-  function markRevealed(){revealed[location.pathname]=true}
 
   function revealImmediate(el){
     el.style.transition='none';
     el.style.opacity='1';
     el.style.transform='translateY(0)';
+    el.setAttribute('data-revealed','');
   }
 
   function processBatch(){
     if(!pending.length)return;
     pending.sort(function(a,b){return a.top-b.top});
     var running=0;
+    var prevTop=pending[0].top;
     for(var i=0;i<pending.length;i++){
-      var el=pending[i].el;
+      var item=pending[i];
+      if(item.top-prevTop>SECTION_GAP){running=0}
+      prevTop=item.top;
+      var el=item.el;
       var base=parseFloat(el.style.transitionDelay)||0;
       var eff=Math.max(base,running);
       el.style.transitionDelay=eff+'s';
       el.style.opacity='1';
       el.style.transform='translateY(0)';
+      el.setAttribute('data-revealed','');
       running=eff+STAGGER;
     }
     pending=[];
-    markRevealed();
   }
 
   var observer=new IntersectionObserver(function(entries){
@@ -77,9 +78,7 @@ const SCROLL_REVEAL_OBSERVER_SCRIPT = `
   },{threshold:0,rootMargin:'0px 0px 80px 0px'});
 
   function processElement(el){
-    if(isRevealed()){
-      revealImmediate(el);
-    } else if(el.getBoundingClientRect().bottom<0){
+    if(el.hasAttribute('data-revealed')||el.getBoundingClientRect().bottom<0){
       revealImmediate(el);
     } else {
       observer.observe(el);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -36,12 +36,21 @@ const SCROLL_REVEAL_OBSERVER_SCRIPT = `
   var SECTION_GAP=200;
   var pending=[];
   var rafId=null;
+  var revealed={};
+
+  function isRevealed(){return !!revealed[location.pathname]}
+  function markRevealed(){revealed[location.pathname]=true}
+
+  var _push=history.pushState.bind(history);
+  history.pushState=function(state,unused,url){
+    markRevealed();
+    return _push(state,unused,url);
+  };
 
   function revealImmediate(el){
     el.style.transition='none';
     el.style.opacity='1';
     el.style.transform='translateY(0)';
-    el.setAttribute('data-revealed','');
   }
 
   function processBatch(){
@@ -59,7 +68,6 @@ const SCROLL_REVEAL_OBSERVER_SCRIPT = `
       el.style.transitionDelay=eff+'s';
       el.style.opacity='1';
       el.style.transform='translateY(0)';
-      el.setAttribute('data-revealed','');
       running=eff+STAGGER;
     }
     pending=[];
@@ -78,7 +86,7 @@ const SCROLL_REVEAL_OBSERVER_SCRIPT = `
   },{threshold:0,rootMargin:'0px 0px 80px 0px'});
 
   function processElement(el){
-    if(el.hasAttribute('data-revealed')||el.getBoundingClientRect().bottom<0){
+    if(isRevealed()||el.getBoundingClientRect().bottom<0){
       revealImmediate(el);
     } else {
       observer.observe(el);

--- a/src/components/layout/header/DesktopNav.tsx
+++ b/src/components/layout/header/DesktopNav.tsx
@@ -19,7 +19,6 @@ export default function DesktopNav() {
   const lockNav = (el: HTMLElement) => {
     el.classList.add(styles.no_hover);
     el.closest('header')?.setAttribute('data-nav-locked', '');
-    el.closest('header')?.removeAttribute('data-nav-hover');
   };
 
   const unlockNav = (el: HTMLElement) => {
@@ -29,17 +28,12 @@ export default function DesktopNav() {
 
   const handleNavEnter = () => {
     isHoveredRef.current = true;
-    if (!navRef.current?.classList.contains(styles.no_hover)) {
-      navRef.current?.closest('header')?.setAttribute('data-nav-hover', '');
-    }
   };
 
   const handleNavLeave = () => {
     isHoveredRef.current = false;
     hoveredItemRef.current = null;
     lockedItemRef.current = null;
-    const header = navRef.current?.closest('header');
-    header?.removeAttribute('data-nav-hover');
     if (navRef.current) unlockNav(navRef.current);
   };
 
@@ -51,7 +45,6 @@ export default function DesktopNav() {
     if (lockedItemRef.current !== path) {
       lockedItemRef.current = null;
       unlockNav(el);
-      el.closest('header')?.setAttribute('data-nav-hover', '');
     }
   };
 

--- a/src/components/layout/header/Header.module.scss
+++ b/src/components/layout/header/Header.module.scss
@@ -12,36 +12,12 @@
     background-color $transition-duration-normal $transition-easing-default,
     color $transition-duration-normal $transition-easing-default,
     box-shadow $transition-duration-normal $transition-easing-default;
-
-  @supports (animation-timeline: scroll()) {
-    animation: header-scroll steps(1) both;
-    animation-timeline: scroll(root);
-    animation-range: 0px 41px;
-  }
 }
 
-// @supports 미지원 브라우저를 위한 JS 폴백
 .scrolled {
   background: $white;
   color: $txt-primary;
   box-shadow: 0 0.1rem 0 0 $gray-200;
-}
-
-.header[data-nav-hover] {
-  background: $white !important;
-  color: $txt-primary !important;
-  box-shadow: 0 0.1rem 0 0 #e7e7e7 !important;
-}
-
-@keyframes header-scroll {
-  from {
-    background: transparent;
-    box-shadow: 0 0.1rem 0 0 rgba(255, 255, 255, 0.2);
-  }
-  to {
-    background: $white;
-    box-shadow: 0 0.1rem 0 0 #e7e7e7;
-  }
 }
 
 .header_wrap {

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -111,7 +111,6 @@ html {
   height: 100%;
   font-size: 2.777778vw;
   scrollbar-gutter: stable;
-  scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
## 📋 개요 (Summary)

헤더 깜빡임 현상 및 홈 페이지 fadeUp 스크롤 애니메이션의 누락·지연·재애니메이션 문제를 수정한다.

<br/>

## 🐛 버그 리포트 (Bug Report)

### Bug 1 — 헤더 깜빡임 (FAQ 아코디언 / GNB 드롭다운)

**재현 조건:**

- 환경: 모든 브라우저 (Chrome 기준 확인)
- 재현 절차:
  1.  NewHere 섹션으로 이동
  2.  FAQ 아코디언 항목을 열고 닫는다
  3.  또는 GNB 드롭다운을 열었다가 마우스를 벗어난다
- 기대 동작: 헤더 스타일이 현재 스크롤 상태를 유지
- 실제 동작: 헤더 배경/색상/그림자가 순간 깜빡임

**근본 원인 (Root Cause):**

- `animation-timeline: scroll(root)` — 문서 높이 변경 시 progress 재계산으로 헤더 animation 값이 순간 변동
- CSS `@keyframes` animation이 CSS `transition`을 override(CSS Cascade Level 4)하여 드롭다운 해제 시 transition 없이 animation 값으로 snap

<br/>

### Bug 2 — fadeUp 애니메이션 누락 및 과도한 지연

**재현 조건:**

- 환경: 홈 페이지 최상단
- 재현 절차:
  1.  홈 페이지 최상단에서 아래로 스크롤
- 기대 동작: 각 섹션 진입 시 즉시 fadeUp 발동, 섹션별 독립적 stagger
- 실제 동작 1: 뷰포트에 진입했지만 애니메이션 미발생 (opacity:1 즉시 표시)
- 실제 동작 2: Banner 다음 QuickAccess 섹션 진입 시 0.6s 이상 지연

**근본 원인 (Root Cause):**

- `markRevealed()` 조기 호출: 첫 번째 배치(Banner) 처리 직후 `revealed['/'] = true` 설정 → React 18 스트리밍 SSR로 이후 도착하는 RecentSermons/FeedSection 요소들이 `revealImmediate()` 처리됨
- stagger 누산: `running` 변수가 배치 내 전체 요소에 걸쳐 누적 → 다른 섹션 요소에 0.6~0.8s 과도한 delay 부여

<br/>

### Bug 3 — 홈 복귀 시 fadeUp 재애니메이션

**재현 조건:**

- 재현 절차:
  1.  홈 → 다른 페이지로 이동
  2.  홈으로 복귀 (Link 또는 브라우저 뒤로가기)
- 기대 동작: 이미 방문한 페이지이므로 즉시 표시
- 실제 동작: fadeUp 애니메이션 재발생

**근본 원인 (Root Cause):**

- Next.js SPA 네비게이션 시 `#main` 자식 DOM이 교체됨 → 새 노드에는 방문 이력 없음 → MutationObserver가 모든 요소를 observer에 등록

<br/>

## 🔧 수정 내용 (Fix Details)

### 헤더 스타일 제어 단순화

- `animation-timeline: scroll()` 및 관련 `@keyframes` 제거 (버그 1·2 공통 원인)
- `DesktopNav.tsx`의 `data-nav-hover` 속성 set/remove 코드 제거 — `header:has(#gnb:hover):not([data-nav-locked])` CSS 규칙으로 대체 (이미 존재)
- JS scroll listener → `.scrolled` 클래스 방식 단독 유지

### fadeUp 스크롤 애니메이션 개선

- `markRevealed()` 호출 시점을 `history.pushState` 인터셉터로 이동 — URL 변경 직전(`location.pathname` = 이전 경로)에 기록, 스트리밍 SSR 요소 누락 방지 및 복귀 시 재애니메이션 방지 동시 해결
- `SECTION_GAP=200px` 경계 감지 추가 — 섹션 간 수직 거리가 200px 초과 시 `running` 리셋, 섹션별 독립적 stagger 보장
- `replaceState` 인터셉트 제외 — 스크롤 복원·쿼리스트링 갱신 등 비내비게이션 목적 호출 보호

### 모바일 스크롤 슬라이딩 제거

- `html { scroll-behavior: smooth }` 전역 제거
- 브라우저의 스크롤 복원(scroll restoration)에도 smooth가 적용되어, 페이지 이동 및 뒤로가기 시 모바일에서 슬라이딩 현상 발생
- 앵커 이동 등 smooth 효과가 필요한 경우 해당 요소에서 `window.scrollTo({ behavior: 'smooth' })` 로 선택 적용

<br/>

## ⚠️ 영향 범위 (Impact)

**변경된 동작:**

- 헤더: CSS animation → JS `.scrolled` 클래스 단독 제어로 전환
- fadeUp: 페이지 방문 중 `markRevealed()` 미호출 → 스트리밍 요소 모두 정상 관찰
- fadeUp: 페이지 이탈 시 `revealed[pathname]=true` → 복귀 시 즉시 표시

**영향받는 컴포넌트·모듈:**

- `src/app/layout.tsx` — `SCROLL_REVEAL_OBSERVER_SCRIPT`
- `src/components/layout/header/Header.module.scss`
- `src/components/layout/header/DesktopNav.tsx`

**사이드 이펙트 가능성:**

> `animation-timeline` 미지원 브라우저에서는 변경 없음 (기존 JS fallback 유지)
> `history.pushState` 인터셉터는 `replaceState` 를 제외하므로 Next.js 내부 상태 관리에 영향 없음.

<br/>

## ✅ 검증 결과 (Verification)

**재현 확인:**

- [x] 수정 전 버그 재현 확인
- [x] 수정 후 버그 미발생 확인
- [ ] 회귀 테스트(Regression Test) 수행 여부

**수행한 테스트:**

- [ ] 단위 테스트 (Unit Test)
- [ ] 통합 테스트 (Integration Test)
- [x] 수동 테스트 (Manual Test)

**테스트 시나리오:**

- [x] 홈 최상단 → 천천히 스크롤 → 각 섹션 진입 시 즉시 fadeUp 발동
- [x] 홈 최상단 → 빠르게 스크롤 → 섹션별 stagger 독립 적용
- [x] 중간 스크롤 위치에서 새로고침 → 뷰포트 위 요소 즉시 표시, 뷰포트 내 요소 정상 fadeUp
- [x] 홈 → 다른 페이지 이동 → 홈 복귀 → fadeUp 없이 즉시 표시
- [x] 홈 → 다른 페이지 → 브라우저 뒤로가기 → 즉시 표시
- [x] FAQ 아코디언 토글 → 헤더 깜빡임 없음
- [x] GNB 드롭다운 열고 마우스 이탈 → 헤더 snap 없음

<br/>

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**버그 수정 완성도**

- [x] 근본 원인(Root Cause) 해결 여부
- [x] 동일 패턴의 잠재적 버그 추가 점검 여부
- [x] 수정 범위가 버그와 무관한 코드를 포함하지 않는지 확인

**코드 품질**

- [x] 불필요한 코드·디버그 로그 제거 여부

**테스트 및 문서화**

- [x] CHANGELOG 또는 관련 문서 반영 여부 (`docs/` 트러블슈팅 문서 추가)
- [x] Conventional Commits 규격 준수 여부 (`fix`)

<br/>

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- `history.pushState` 인터셉터의 핵심은 **URL이 바뀌기 전** `location.pathname`이 아직 이전 경로를 가리킨다는 점
- `replaceState`는 동일 pathname에서의 부수 업데이트이므로 인터셉트하면 안 됨
- `animation-timeline: scroll()`은 문서 높이가 동적으로 변하는 페이지(아코디언, 무한 스크롤 등)에서 progress 재계산 부작용이 있음. 이 프로젝트에서는 JS 스크롤 리스너로 대체
