### PR TITLE
[Feat] 설교 어드민 레이아웃 및 등록/수정 폼 UI 구현

### DIFF
--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,11 @@
+import PageHeader from '@/components/admin/layout/PageHeader';
+
+export default function AdminDashboardPage() {
+  return (
+    <PageHeader
+      eyebrow="홈"
+      title="대시보드"
+      description="어서 오세요. 오늘의 주요 지표를 확인하세요."
+    />
+  );
+}

--- a/src/app/(admin)/admin/sermons/[slug]/edit/page.tsx
+++ b/src/app/(admin)/admin/sermons/[slug]/edit/page.tsx
@@ -1,17 +1,17 @@
 import PageHeader from '@/components/admin/layout/PageHeader';
 import SermonForm from '@/components/admin/sermons/SermonForm';
 
-export default function SermonNewPage() {
+export default function SermonEditPage() {
   return (
     <>
       <PageHeader
         eyebrow="설교 관리"
-        badge="새 설교 등록"
-        title="새 설교 등록"
-        description="영상, 본문, 자료를 입력하고 발행하세요"
+        badge="수정"
+        title="설교 제목 자리"
+        description="영상, 본문, 자료를 수정하고 저장하세요"
         actions={[
           { label: '임시저장', variant: 'outline' },
-          { label: '발행', variant: 'pri' }
+          { label: '수정 저장', variant: 'pri' }
         ]}
       />
       <SermonForm />

--- a/src/app/(admin)/admin/sermons/new/page.tsx
+++ b/src/app/(admin)/admin/sermons/new/page.tsx
@@ -1,0 +1,3 @@
+export default function SermonNewPage() {
+  return <div>page</div>;
+}

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,0 +1,6 @@
+import { PropsWithChildren } from 'react';
+import AdminLayout from '@/components/admin/layout/AdminLayout';
+
+export default function Layout({ children }: PropsWithChildren) {
+  return <AdminLayout>{children}</AdminLayout>;
+}

--- a/src/app/(content)/layout.tsx
+++ b/src/app/(content)/layout.tsx
@@ -1,5 +1,115 @@
+import Script from 'next/script';
 import { PropsWithChildren } from 'react';
+import { Header, Hero, Footer, BottomNav } from '@/components/layout';
+import KakaoScript from '@/components/lib/KakaoScript';
+import { SCROLL_THRESHOLD } from '@/constants';
 
-export default function Layout({ children }: PropsWithChildren) {
-  return <>{children}</>;
+const SCROLL_REVEAL_OBSERVER_SCRIPT = `
+(function(){
+  var STAGGER=0.1;
+  var SECTION_GAP=200;
+  var pending=[];
+  var rafId=null;
+  var revealed={};
+
+  function isRevealed(){return !!revealed[location.pathname]}
+  function markRevealed(){revealed[location.pathname]=true}
+
+  var _push=history.pushState.bind(history);
+  history.pushState=function(state,unused,url){
+    markRevealed();
+    return _push(state,unused,url);
+  };
+
+  function revealImmediate(el){
+    el.style.transition='none';
+    el.style.opacity='1';
+    el.style.transform='translateY(0)';
+  }
+
+  function processBatch(){
+    if(!pending.length)return;
+    pending.sort(function(a,b){return a.top-b.top});
+    var running=0;
+    var prevTop=pending[0].top;
+    for(var i=0;i<pending.length;i++){
+      var item=pending[i];
+      if(item.top-prevTop>SECTION_GAP){running=0}
+      prevTop=item.top;
+      var el=item.el;
+      var base=parseFloat(el.style.transitionDelay)||0;
+      var eff=Math.max(base,running);
+      el.style.transitionDelay=eff+'s';
+      el.style.opacity='1';
+      el.style.transform='translateY(0)';
+      running=eff+STAGGER;
+    }
+    pending=[];
+  }
+
+  var observer=new IntersectionObserver(function(entries){
+    for(var i=0;i<entries.length;i++){
+      if(entries[i].isIntersecting){
+        pending.push({el:entries[i].target,top:entries[i].boundingClientRect.top});
+        observer.unobserve(entries[i].target);
+      }
+    }
+    if(pending.length&&!rafId){
+      rafId=requestAnimationFrame(function(){processBatch();rafId=null});
+    }
+  },{threshold:0,rootMargin:'0px 0px 80px 0px'});
+
+  function processElement(el){
+    if(isRevealed()||el.getBoundingClientRect().bottom<0){
+      revealImmediate(el);
+    } else {
+      observer.observe(el);
+    }
+  }
+
+  function observeAll(root){
+    root.querySelectorAll('[data-reveal]').forEach(processElement);
+  }
+
+  observeAll(document);
+
+  new MutationObserver(function(mutations){
+    for(var i=0;i<mutations.length;i++){
+      var nodes=mutations[i].addedNodes;
+      for(var j=0;j<nodes.length;j++){
+        if(nodes[j].nodeType!==1)continue;
+        if(nodes[j].hasAttribute('data-reveal'))processElement(nodes[j]);
+        observeAll(nodes[j]);
+      }
+    }
+  }).observe(document.getElementById('root'),{childList:true,subtree:true});
+})();
+`;
+
+const API_KEY = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
+
+export default function ContentLayout({ children }: PropsWithChildren) {
+  return (
+    <>
+      <Script src={API_KEY} strategy="afterInteractive" />
+      <KakaoScript />
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `if(window.scrollY>${SCROLL_THRESHOLD})document.documentElement.setAttribute('data-scrolled','');`
+        }}
+      />
+      <Header />
+      <main id="main">
+        <Hero />
+        {children}
+      </main>
+      <Footer />
+      <BottomNav />
+      <Script
+        id="scroll-reveal-observer"
+        strategy="afterInteractive"
+        dangerouslySetInnerHTML={{ __html: SCROLL_REVEAL_OBSERVER_SCRIPT }}
+      />
+    </>
+  );
 }

--- a/src/app/(content)/page.tsx
+++ b/src/app/(content)/page.tsx
@@ -1,4 +1,4 @@
-import { Banner, QuickAccess, RecentSermons, NewHere, FeedSection } from './_component/home';
+import { Banner, QuickAccess, RecentSermons, NewHere, FeedSection } from '../_component/home';
 
 export default async function Home() {
   return (

--- a/src/app/(content)/sermons/_component/AdvancedFilterSheet/AdvancedFilterSheet.module.scss
+++ b/src/app/(content)/sermons/_component/AdvancedFilterSheet/AdvancedFilterSheet.module.scss
@@ -50,9 +50,9 @@
 }
 
 .footer {
+  margin-top: $content-gap-l;
   display: flex;
   gap: $spacing-12;
-  margin-top: $content-gap-l;
   padding-top: $spacing-16;
   border-top: 1px solid $border-primary;
 }
@@ -60,7 +60,7 @@
 .btn_reset,
 .btn_apply {
   flex: 1;
-  padding: $padding-control;
+  padding: $spacing-12 $spacing-16;
   font-size: $font-size-14;
   font-weight: $font-weight-semibold;
   border-radius: $radius-s;

--- a/src/app/(content)/sermons/_component/GridCard/GridCard.module.scss
+++ b/src/app/(content)/sermons/_component/GridCard/GridCard.module.scss
@@ -110,6 +110,7 @@
   overflow: hidden;
   font-size: $font-size-16;
   font-weight: $font-weight-semibold;
+  font-family: $font-family-secondary;
   line-height: $line-height-heading;
   color: $txt-primary;
 }
@@ -123,8 +124,8 @@
 }
 
 .dot {
-  width: 0.3rem;
-  height: 0.3rem;
+  width: 0.2rem;
+  height: 0.2rem;
   background: $txt-tertiary;
   border-radius: $radius-circle;
 }

--- a/src/app/(content)/sermons/_component/SeriesEpisodeList/SeriesEpisodeList.module.scss
+++ b/src/app/(content)/sermons/_component/SeriesEpisodeList/SeriesEpisodeList.module.scss
@@ -110,8 +110,8 @@
 }
 
 .dot {
-  width: 0.3rem;
-  height: 0.3rem;
+  width: 0.2rem;
+  height: 0.2rem;
   background: $txt-tertiary;
   border-radius: $radius-circle;
 }

--- a/src/app/(content)/sermons/_component/SermonCard/SermonCard.module.scss
+++ b/src/app/(content)/sermons/_component/SermonCard/SermonCard.module.scss
@@ -140,6 +140,7 @@
 .title {
   font-size: $font-size-20;
   font-weight: $font-weight-bold;
+  font-family: $font-family-secondary;
   line-height: $line-height-heading;
   color: $txt-primary;
 
@@ -157,8 +158,8 @@
 }
 
 .dot {
-  width: 0.3rem;
-  height: 0.3rem;
+  width: 0.2rem;
+  height: 0.2rem;
   background: $txt-tertiary;
   border-radius: $radius-circle;
 }

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
@@ -5,40 +5,25 @@
 .layout {
   display: flex;
   flex-direction: column;
-  gap: $content-gap-l;
+  gap: $content-gap-m;
   padding: 0 0 $section-padding-80;
 
   @include respond-up($breakpoint-tablet) {
     padding-top: $section-padding-40;
   }
+
+  @include respond-up($breakpoint-pc-sm) {
+    gap: $content-gap-l;
+  }
 }
 
-.main {
+.video_section {
   display: flex;
   flex-direction: column;
   gap: $content-gap-m;
 }
 
-.mobile_info {
-  display: flex;
-  flex-direction: column;
-  gap: $content-gap-m;
-
-  @include respond-up($breakpoint-pc-sm) {
-    display: none;
-  }
-}
-
-.side {
-  display: none;
-
-  @include respond-up($breakpoint-pc-sm) {
-    display: block;
-    width: 100%;
-  }
-}
-
-.side_inner {
+.info_section {
   display: flex;
   flex-direction: column;
   gap: $content-gap-m;
@@ -82,8 +67,8 @@
 }
 
 .dot {
-  width: 0.3rem;
-  height: 0.3rem;
+  width: 0.2rem;
+  height: 0.2rem;
   background: $txt-tertiary;
   border-radius: $radius-circle;
 }

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -59,67 +59,38 @@ export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
   return (
     <LayoutContainer>
       <div className={styles.layout}>
-        {/* ── Main column ── */}
-        <div className={styles.main}>
+        <div className={styles.video_section}>
           <SermonVideoPlayer
             videoId={sermon.video_id}
             videoProvider={sermon.video_provider as 'youtube' | 'vimeo'}
             title={sermon.title}
           />
           <SermonVideoTools sermonId={sermon.id} onToast={showToast} />
-
-          {/* Mobile-only info */}
-          <div className={styles.mobile_info}>
-            <SermonMeta
-              seriesTitle={seriesTitle}
-              seriesOrder={sermon.series_order}
-              title={sermon.title}
-              date={sermon.sermon_date}
-              preacher={preacherLabel}
-              scripture={sermon.scripture}
-              duration={duration}
-              serviceType={sermon.service_type}
-            />
-            <SermonTabs activeTab={activeTab} onTabChange={setActiveTab} tabs={TABS} />
-            <TabContent activeTab={activeTab} sermon={sermon} resources={activeResources} />
-            {hasSeriesEpisodes && (
-              <SeriesEpisodeList
-                currentSermonId={sermon.id}
-                sermons={seriesEpisodes}
-                seriesTitle={seriesTitle ?? '시리즈'}
-                onSelect={handleEpisodeSelect}
-                onViewAll={handleViewAllSeries}
-              />
-            )}
-          </div>
         </div>
 
-        {/* ── Side panel (PC only) ── */}
-        <aside className={styles.side}>
-          <div className={styles.side_inner}>
-            <SermonMeta
-              seriesTitle={seriesTitle}
-              seriesOrder={sermon.series_order}
-              title={sermon.title}
-              date={sermon.sermon_date}
-              preacher={preacherLabel}
-              scripture={sermon.scripture}
-              duration={duration}
-              serviceType={sermon.service_type}
+        <div className={styles.info_section}>
+          <SermonMeta
+            seriesTitle={seriesTitle}
+            seriesOrder={sermon.series_order}
+            title={sermon.title}
+            date={sermon.sermon_date}
+            preacher={preacherLabel}
+            scripture={sermon.scripture}
+            duration={duration}
+            serviceType={sermon.service_type}
+          />
+          <SermonTabs activeTab={activeTab} onTabChange={setActiveTab} tabs={TABS} />
+          <TabContent activeTab={activeTab} sermon={sermon} resources={activeResources} />
+          {hasSeriesEpisodes && (
+            <SeriesEpisodeList
+              currentSermonId={sermon.id}
+              sermons={seriesEpisodes}
+              seriesTitle={seriesTitle ?? '시리즈'}
+              onSelect={handleEpisodeSelect}
+              onViewAll={handleViewAllSeries}
             />
-            <SermonTabs activeTab={activeTab} onTabChange={setActiveTab} tabs={TABS} />
-            <TabContent activeTab={activeTab} sermon={sermon} resources={activeResources} />
-            {hasSeriesEpisodes && (
-              <SeriesEpisodeList
-                currentSermonId={sermon.id}
-                sermons={seriesEpisodes}
-                seriesTitle={seriesTitle ?? '시리즈'}
-                onSelect={handleEpisodeSelect}
-                onViewAll={handleViewAllSeries}
-              />
-            )}
-          </div>
-        </aside>
+          )}
+        </div>
       </div>
 
       <Toast message={toast.message} show={toast.show} />
@@ -157,7 +128,7 @@ function SermonMeta({
       </span>
       <h1 className={styles.sermon_title}>{title}</h1>
       <div className={styles.meta_row}>
-        <span>{formattedDate(date, 'YYYY.MM.DD')}</span>
+        <span>{formattedDate(date, 'YYYY년 MM월 DD일')}</span>
         <Dot />
         <span>{preacher}</span>
         <Dot />

--- a/src/app/(content)/sermons/_component/SermonListPage/SermonListPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonListPage/SermonListPage.module.scss
@@ -208,7 +208,7 @@
   align-items: center;
   justify-content: center;
   gap: $spacing-4;
-  min-width: 4.4rem;
+  min-width: 4.2rem;
   padding: 0 $spacing-12;
   font-size: $font-size-13;
   font-weight: $font-weight-medium;
@@ -259,7 +259,7 @@
 // ── Series Chips (Mobile) ──
 
 .chips {
-  margin-bottom: $content-gap-m;
+  margin-bottom: $content-gap-l;
 
   @include respond-up($breakpoint-pc-sm) {
     display: none;
@@ -282,8 +282,8 @@
 
 .chip {
   flex-shrink: 0;
-  padding: $spacing-10 $spacing-16;
-  font-size: $font-size-14;
+  padding: $spacing-8 $spacing-16;
+  font-size: $font-size-13;
   font-weight: $font-weight-medium;
   color: $txt-secondary;
   background: $primary-subtle;
@@ -307,8 +307,8 @@
   display: inline-flex;
   align-items: center;
   gap: $spacing-4;
-  padding: $spacing-10 $spacing-16;
-  font-size: $font-size-14;
+  padding: $spacing-8 $spacing-16;
+  font-size: $font-size-13;
   font-weight: $font-weight-medium;
   color: $primary;
   background: $primary-subtle;
@@ -439,7 +439,7 @@
 // ── Content sections ──
 
 .featured {
-  margin-bottom: $content-gap-xl;
+  margin-bottom: $section-padding-40;
 }
 
 .year_section {

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -94,8 +94,8 @@ $thumb-sub-w: 14rem;
 }
 
 .dot {
-  width: 0.3rem;
-  height: 0.3rem;
+  width: 0.2rem;
+  height: 0.2rem;
   border-radius: $radius-circle;
   background: rgba(255, 255, 255, 0.25);
   flex-shrink: 0;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,7 @@
-import Script from 'next/script';
 import type { Metadata } from 'next';
 import { Noto_Serif_KR } from 'next/font/google';
 import ScrollToTop from '@/components/common/ScrollToTop';
-import { Header, Hero, Footer, BottomNav } from '@/components/layout';
 import SessionContextProvider from '@/context/SessionContextProvider';
-import KakaoScript from '@/components/lib/KakaoScript';
-import { SCROLL_THRESHOLD } from '@/constants';
 import '@/styles/globals.scss';
 import 'photoswipe/dist/photoswipe.css';
 
@@ -30,90 +26,6 @@ const notoserifKR = Noto_Serif_KR({
   display: 'swap'
 });
 
-const SCROLL_REVEAL_OBSERVER_SCRIPT = `
-(function(){
-  var STAGGER=0.1;
-  var SECTION_GAP=200;
-  var pending=[];
-  var rafId=null;
-  var revealed={};
-
-  function isRevealed(){return !!revealed[location.pathname]}
-  function markRevealed(){revealed[location.pathname]=true}
-
-  var _push=history.pushState.bind(history);
-  history.pushState=function(state,unused,url){
-    markRevealed();
-    return _push(state,unused,url);
-  };
-
-  function revealImmediate(el){
-    el.style.transition='none';
-    el.style.opacity='1';
-    el.style.transform='translateY(0)';
-  }
-
-  function processBatch(){
-    if(!pending.length)return;
-    pending.sort(function(a,b){return a.top-b.top});
-    var running=0;
-    var prevTop=pending[0].top;
-    for(var i=0;i<pending.length;i++){
-      var item=pending[i];
-      if(item.top-prevTop>SECTION_GAP){running=0}
-      prevTop=item.top;
-      var el=item.el;
-      var base=parseFloat(el.style.transitionDelay)||0;
-      var eff=Math.max(base,running);
-      el.style.transitionDelay=eff+'s';
-      el.style.opacity='1';
-      el.style.transform='translateY(0)';
-      running=eff+STAGGER;
-    }
-    pending=[];
-  }
-
-  var observer=new IntersectionObserver(function(entries){
-    for(var i=0;i<entries.length;i++){
-      if(entries[i].isIntersecting){
-        pending.push({el:entries[i].target,top:entries[i].boundingClientRect.top});
-        observer.unobserve(entries[i].target);
-      }
-    }
-    if(pending.length&&!rafId){
-      rafId=requestAnimationFrame(function(){processBatch();rafId=null});
-    }
-  },{threshold:0,rootMargin:'0px 0px 80px 0px'});
-
-  function processElement(el){
-    if(isRevealed()||el.getBoundingClientRect().bottom<0){
-      revealImmediate(el);
-    } else {
-      observer.observe(el);
-    }
-  }
-
-  function observeAll(root){
-    root.querySelectorAll('[data-reveal]').forEach(processElement);
-  }
-
-  observeAll(document);
-
-  new MutationObserver(function(mutations){
-    for(var i=0;i<mutations.length;i++){
-      var nodes=mutations[i].addedNodes;
-      for(var j=0;j<nodes.length;j++){
-        if(nodes[j].nodeType!==1)continue;
-        if(nodes[j].hasAttribute('data-reveal'))processElement(nodes[j]);
-        observeAll(nodes[j]);
-      }
-    }
-  }).observe(document.getElementById('root'),{childList:true,subtree:true});
-})();
-`;
-
-const API_KEY = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
-
 export default async function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="ko" className={`${notoserifKR.variable}`}>
@@ -122,33 +34,15 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
           rel="stylesheet"
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
         />
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `if(window.scrollY>${SCROLL_THRESHOLD})document.documentElement.setAttribute('data-scrolled','');`
-          }}
-        />
       </head>
       <body>
-        <Script src={API_KEY} strategy="afterInteractive" />
-        <KakaoScript />
         <div id="root">
           <SessionContextProvider>
             <ScrollToTop />
-            <Header />
-            <main id="main">
-              <Hero />
-              {children}
-            </main>
-            <Footer />
-            <BottomNav />
+            {children}
           </SessionContextProvider>
         </div>
         <div id="modal-root"></div>
-        <Script
-          id="scroll-reveal-observer"
-          strategy="afterInteractive"
-          dangerouslySetInnerHTML={{ __html: SCROLL_REVEAL_OBSERVER_SCRIPT }}
-        />
       </body>
     </html>
   );

--- a/src/components/admin/layout/AdminHeader/index.module.scss
+++ b/src/components/admin/layout/AdminHeader/index.module.scss
@@ -1,0 +1,160 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: var(--header-h);
+  padding: 0 24px;
+  background: var(--admin-bg-card);
+  border-bottom: 1px solid var(--admin-bd);
+}
+
+.menu_btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--admin-t2);
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--admin-bg-hover);
+  }
+
+  @media (max-width: 1023px) {
+    display: flex;
+  }
+}
+
+.crumbs {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  font-size: 13px;
+}
+
+.crumbs_list {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.separator {
+  color: var(--admin-t3);
+  font-size: 12px;
+}
+
+.crumb {
+  color: var(--admin-t3);
+  cursor: pointer;
+  transition: color 0.15s;
+
+  &:hover {
+    color: var(--admin-t1);
+  }
+
+  &.current {
+    color: var(--admin-t1);
+    font-weight: 600;
+    cursor: default;
+  }
+}
+
+.search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 300px;
+  padding: 7px 12px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  background: var(--admin-bg);
+  color: var(--admin-t3);
+  font-size: 13px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+
+  &:hover,
+  &:focus-visible {
+    border-color: var(--admin-t3);
+    color: var(--admin-t2);
+    outline: none;
+  }
+
+  @media (max-width: 767px) {
+    display: none;
+  }
+}
+
+.search_icon {
+  flex-shrink: 0;
+  font-size: 16px;
+}
+
+.search_text {
+  flex: 1;
+}
+
+.kbd {
+  padding: 2px 6px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 4px;
+  background: var(--admin-bg-card);
+  color: var(--admin-t3);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.bell {
+  position: relative;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--admin-t2);
+  font-size: 20px;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--admin-bg-hover);
+  }
+}
+
+.dot {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+  width: 8px;
+  height: 8px;
+  border: 2px solid var(--admin-bg-card);
+  border-radius: 50%;
+  background: #ef4444;
+  box-sizing: content-box;
+}

--- a/src/components/admin/layout/AdminHeader/index.module.scss
+++ b/src/components/admin/layout/AdminHeader/index.module.scss
@@ -29,7 +29,7 @@
     background: var(--admin-bg-hover);
   }
 
-  @media (max-width: 1023px) {
+  @media (max-width: 1024px) {
     display: flex;
   }
 }

--- a/src/components/admin/layout/AdminHeader/index.tsx
+++ b/src/components/admin/layout/AdminHeader/index.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import clsx from 'clsx';
+import { HiOutlineBell, HiOutlineMenu, HiOutlineSearch } from 'react-icons/hi';
+import styles from './index.module.scss';
+
+interface AdminHeaderProps {
+  crumbs: string[];
+  onMobileMenuClick: () => void;
+}
+
+export default function AdminHeader({ crumbs, onMobileMenuClick }: AdminHeaderProps) {
+  return (
+    <header className={styles.header}>
+      <button
+        type="button"
+        className={styles.menu_btn}
+        onClick={onMobileMenuClick}
+        aria-label="메뉴 열기"
+      >
+        <HiOutlineMenu />
+      </button>
+
+      <nav className={styles.crumbs} aria-label="경로">
+        <ol className={styles.crumbs_list}>
+          {crumbs.map((crumb, index) => {
+            const last = index === crumbs.length - 1;
+            return (
+              <li key={`${crumb}-${index}`} className={styles.group}>
+                {index > 0 && (
+                  <span className={styles.separator} aria-hidden>
+                    /
+                  </span>
+                )}
+                <span
+                  className={clsx(styles.crumb, last && styles.current)}
+                  aria-current={last ? 'page' : undefined}
+                >
+                  {crumb}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      <div className={styles.search} role="button" tabIndex={0}>
+        <HiOutlineSearch className={styles.search_icon} />
+        <span className={styles.search_text}>검색</span>
+        <kbd className={styles.kbd}>⌘K</kbd>
+      </div>
+
+      <button type="button" className={styles.bell} aria-label="알림">
+        <HiOutlineBell />
+        <span className={styles.dot} aria-hidden />
+      </button>
+    </header>
+  );
+}

--- a/src/components/admin/layout/AdminLayout/index.module.scss
+++ b/src/components/admin/layout/AdminLayout/index.module.scss
@@ -1,0 +1,70 @@
+.shell {
+  --admin-bg: #f7f8fa;
+  --admin-bg-card: #fff;
+  --admin-bg-hover: #eef0f4;
+  --admin-t1: #1a1d23;
+  --admin-t2: #4b5563;
+  --admin-t3: #8a94a3;
+  --admin-bd: #e5e8ed;
+  --admin-accent: #5b6ba5;
+  --admin-accent-bg: rgba(91, 107, 165, 0.08);
+  --admin-pri: #2e3440;
+  --admin-sidebar-bg: #1f2329;
+  --admin-sidebar-t1: #e6e8ec;
+  --admin-sidebar-t2: #9ba2ae;
+  --admin-sidebar-t3: #6b7280;
+  --admin-sidebar-hover: #2a2f36;
+  --admin-sidebar-active: #3b434d;
+  --admin-sidebar-border: #2a2f36;
+  --header-h: 56px;
+  --sidebar-w: 240px;
+  --sidebar-w-collapsed: 64px;
+  --admin-ease: cubic-bezier(0.4, 0, 0.2, 1);
+
+  position: relative;
+  min-height: 100vh;
+  background: var(--admin-bg);
+  color: var(--admin-t1);
+  font-family: 'Pretendard', sans-serif;
+
+  @media (min-width: 1024px) {
+    display: flex;
+    align-items: flex-start;
+  }
+}
+
+.main_area {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-width: 0;
+
+  @media (min-width: 1024px) {
+    flex: 1;
+  }
+}
+
+.content {
+  flex: 1;
+  padding: 24px;
+}
+
+.overlay {
+  display: none;
+
+  @media (max-width: 1023px) {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    background: rgba(15, 20, 30, 0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.18s var(--admin-ease);
+
+    &.open {
+      opacity: 1;
+      pointer-events: auto;
+    }
+  }
+}

--- a/src/components/admin/layout/AdminLayout/index.module.scss
+++ b/src/components/admin/layout/AdminLayout/index.module.scss
@@ -2,6 +2,14 @@
   --admin-bg: #f7f8fa;
   --admin-bg-card: #fff;
   --admin-bg-hover: #eef0f4;
+  --admin-bg-w: #f1f3f6;
+  --admin-bd-s: #d1d6de;
+  --admin-sh-s: 0 1px 2px rgba(15, 20, 30, 0.06);
+  --admin-warn: #d97706;
+  --admin-warn-bg: rgba(217, 119, 6, 0.08);
+  --admin-ok: #2e7d5b;
+  --admin-ok-bg: rgba(46, 125, 91, 0.08);
+  --admin-err: #c0392b;
   --admin-t1: #1a1d23;
   --admin-t2: #4b5563;
   --admin-t3: #8a94a3;
@@ -47,12 +55,17 @@
 .content {
   flex: 1;
   padding: 24px;
+  padding-bottom: 100px; // 모바일 하단 액션 바 공간 확보
+
+  @media (min-width: 1024px) {
+    padding-bottom: 48px;
+  }
 }
 
 .overlay {
   display: none;
 
-  @media (max-width: 1023px) {
+  @media (max-width: 1024px) {
     display: block;
     position: fixed;
     inset: 0;

--- a/src/components/admin/layout/AdminLayout/index.tsx
+++ b/src/components/admin/layout/AdminLayout/index.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { PropsWithChildren, useState } from 'react';
+import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
+import { resolveAdminBreadcrumbs } from '@/config/adminNavigation';
 import AdminHeader from '../AdminHeader';
 import AdminSidebar from '../AdminSidebar';
 import styles from './index.module.scss';
@@ -9,6 +11,8 @@ import styles from './index.module.scss';
 export default function AdminLayout({ children }: PropsWithChildren) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const pathname = usePathname();
+  const crumbs = resolveAdminBreadcrumbs(pathname);
 
   return (
     <div className={styles.shell}>
@@ -25,7 +29,7 @@ export default function AdminLayout({ children }: PropsWithChildren) {
       />
       <div className={styles.main_area}>
         <AdminHeader
-          crumbs={['관리자', '대시보드']}
+          crumbs={crumbs}
           onMobileMenuClick={() => setMobileSidebarOpen(true)}
         />
         <main className={styles.content}>{children}</main>

--- a/src/components/admin/layout/AdminLayout/index.tsx
+++ b/src/components/admin/layout/AdminLayout/index.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { PropsWithChildren, useState } from 'react';
+import clsx from 'clsx';
+import AdminHeader from '../AdminHeader';
+import AdminSidebar from '../AdminSidebar';
+import styles from './index.module.scss';
+
+export default function AdminLayout({ children }: PropsWithChildren) {
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
+  return (
+    <div className={styles.shell}>
+      <AdminSidebar
+        collapsed={sidebarCollapsed}
+        onToggle={() => setSidebarCollapsed((value) => !value)}
+        mobileOpen={mobileSidebarOpen}
+        onMobileClose={() => setMobileSidebarOpen(false)}
+      />
+      <div
+        className={clsx(styles.overlay, mobileSidebarOpen && styles.open)}
+        onClick={() => setMobileSidebarOpen(false)}
+        aria-hidden
+      />
+      <div className={styles.main_area}>
+        <AdminHeader
+          crumbs={['관리자', '대시보드']}
+          onMobileMenuClick={() => setMobileSidebarOpen(true)}
+        />
+        <main className={styles.content}>{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/layout/AdminSidebar/index.module.scss
+++ b/src/components/admin/layout/AdminSidebar/index.module.scss
@@ -38,7 +38,7 @@
     }
   }
 
-  @media (max-width: 1023px) {
+  @media (max-width: 1024px) {
     position: fixed;
     inset: 0 auto 0 0;
     z-index: 50;
@@ -132,6 +132,7 @@
   color: var(--admin-sidebar-t2);
   font-size: 13px;
   font-weight: 500;
+  text-decoration: none;
   cursor: pointer;
   transition:
     background 0.15s,

--- a/src/components/admin/layout/AdminSidebar/index.module.scss
+++ b/src/components/admin/layout/AdminSidebar/index.module.scss
@@ -1,0 +1,255 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: var(--sidebar-w);
+  background: var(--admin-sidebar-bg);
+  color: var(--admin-sidebar-t1);
+
+  @media (min-width: 1024px) {
+    position: sticky;
+    top: 0;
+    align-self: stretch;
+    height: 100vh;
+    flex-shrink: 0;
+    transition: width 0.18s var(--admin-ease);
+
+    &.collapsed {
+      width: var(--sidebar-w-collapsed);
+
+      .title,
+      .label,
+      .badge,
+      .section_title,
+      .info,
+      .toggle_label {
+        display: none;
+      }
+
+      .item,
+      .brand,
+      .user,
+      .toggle {
+        justify-content: center;
+      }
+
+      .brand {
+        padding: 0;
+      }
+    }
+  }
+
+  @media (max-width: 1023px) {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 50;
+    transform: translateX(-100%);
+    transition: transform 0.18s var(--admin-ease);
+
+    &.mobile_open {
+      transform: translateX(0);
+    }
+
+    .toggle {
+      display: none;
+    }
+  }
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: var(--header-h);
+  padding: 0 16px;
+  border-bottom: 1px solid var(--admin-sidebar-border);
+}
+
+.logo {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--admin-accent);
+  color: #fff;
+  font-size: 18px;
+}
+
+.title {
+  overflow: hidden;
+  white-space: nowrap;
+  font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--admin-sidebar-t1);
+}
+
+.nav {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 10px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.section_title {
+  margin: 0;
+  padding: 4px 10px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--admin-sidebar-t3);
+}
+
+.items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--admin-sidebar-t2);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  &:hover {
+    background: var(--admin-sidebar-hover);
+    color: var(--admin-sidebar-t1);
+  }
+
+  &.on {
+    background: var(--admin-sidebar-active);
+    color: var(--admin-sidebar-t1);
+    font-weight: 600;
+  }
+}
+
+.icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  font-size: 18px;
+}
+
+.label {
+  flex: 1;
+  overflow: hidden;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.badge {
+  padding: 2px 7px;
+  border-radius: 100px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--admin-sidebar-t2);
+  font-size: 10px;
+  font-weight: 600;
+
+  .item.on & {
+    background: rgba(255, 255, 255, 0.14);
+    color: var(--admin-sidebar-t1);
+  }
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--admin-sidebar-border);
+}
+
+.user {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+}
+
+.avatar {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--admin-sidebar-active);
+  color: var(--admin-sidebar-t1);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.name {
+  line-height: 1.2;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--admin-sidebar-t1);
+}
+
+.email {
+  line-height: 1.2;
+  font-size: 10px;
+  color: var(--admin-sidebar-t3);
+}
+
+.toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border: 0;
+  border-top: 1px solid var(--admin-sidebar-border);
+  background: transparent;
+  color: var(--admin-sidebar-t2);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--admin-sidebar-hover);
+    color: var(--admin-sidebar-t1);
+  }
+}
+
+.toggle_icon {
+  display: flex;
+  align-items: center;
+  font-size: 16px;
+}
+
+.toggle_label {
+  overflow: hidden;
+  white-space: nowrap;
+}

--- a/src/components/admin/layout/AdminSidebar/index.tsx
+++ b/src/components/admin/layout/AdminSidebar/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { ReactNode } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import {
   HiCheck,
@@ -13,42 +15,21 @@ import {
   HiOutlineUser,
   HiOutlineUsers
 } from 'react-icons/hi';
+import {
+  ADMIN_NAV_SECTIONS,
+  AdminIconName,
+  isActiveAdminNav
+} from '@/config/adminNavigation';
 import styles from './index.module.scss';
 
-interface SidebarItem {
-  label: string;
-  icon: ReactNode;
-  active?: boolean;
-  badge?: string;
-}
-
-interface SidebarSection {
-  title: string;
-  items: SidebarItem[];
-}
-
-const SECTIONS: SidebarSection[] = [
-  {
-    title: '메인',
-    items: [{ label: '대시보드', icon: <HiOutlineHome /> }]
-  },
-  {
-    title: '설교',
-    items: [
-      { label: '설교 관리', icon: <HiOutlinePlay />, active: true, badge: '128' },
-      { label: '시리즈 관리', icon: <HiOutlineFolder />, badge: '24' },
-      { label: '설교자 관리', icon: <HiOutlineUser /> }
-    ]
-  },
-  {
-    title: '멤버',
-    items: [{ label: '멤버 관리', icon: <HiOutlineUsers /> }]
-  },
-  {
-    title: '시스템',
-    items: [{ label: '설정', icon: <HiOutlineCog /> }]
-  }
-];
+const ICONS: Record<AdminIconName, ReactNode> = {
+  home: <HiOutlineHome />,
+  play: <HiOutlinePlay />,
+  folder: <HiOutlineFolder />,
+  user: <HiOutlineUser />,
+  users: <HiOutlineUsers />,
+  cog: <HiOutlineCog />
+};
 
 interface AdminSidebarProps {
   collapsed: boolean;
@@ -63,6 +44,8 @@ export default function AdminSidebar({
   mobileOpen,
   onMobileClose
 }: AdminSidebarProps) {
+  const pathname = usePathname();
+
   return (
     <aside
       className={clsx(
@@ -79,23 +62,27 @@ export default function AdminSidebar({
       </div>
 
       <nav className={styles.nav} aria-label="관리자 메뉴">
-        {SECTIONS.map((section) => (
+        {ADMIN_NAV_SECTIONS.map((section) => (
           <div key={section.title} className={styles.section}>
             <h3 className={styles.section_title}>{section.title}</h3>
             <ul className={styles.items}>
-              {section.items.map((item) => (
-                <li key={item.label}>
-                  <button
-                    type="button"
-                    className={clsx(styles.item, item.active && styles.on)}
-                    onClick={onMobileClose}
-                  >
-                    <span className={styles.icon}>{item.icon}</span>
-                    <span className={styles.label}>{item.label}</span>
-                    {item.badge && <span className={styles.badge}>{item.badge}</span>}
-                  </button>
-                </li>
-              ))}
+              {section.items.map((item) => {
+                const active = isActiveAdminNav(pathname, item.href);
+                return (
+                  <li key={item.href}>
+                    <Link
+                      href={item.href}
+                      className={clsx(styles.item, active && styles.on)}
+                      onClick={onMobileClose}
+                      aria-current={active ? 'page' : undefined}
+                    >
+                      <span className={styles.icon}>{ICONS[item.icon]}</span>
+                      <span className={styles.label}>{item.label}</span>
+                      {item.badge && <span className={styles.badge}>{item.badge}</span>}
+                    </Link>
+                  </li>
+                );
+              })}
             </ul>
           </div>
         ))}

--- a/src/components/admin/layout/AdminSidebar/index.tsx
+++ b/src/components/admin/layout/AdminSidebar/index.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+import {
+  HiCheck,
+  HiChevronLeft,
+  HiChevronRight,
+  HiOutlineCog,
+  HiOutlineFolder,
+  HiOutlineHome,
+  HiOutlinePlay,
+  HiOutlineUser,
+  HiOutlineUsers
+} from 'react-icons/hi';
+import styles from './index.module.scss';
+
+interface SidebarItem {
+  label: string;
+  icon: ReactNode;
+  active?: boolean;
+  badge?: string;
+}
+
+interface SidebarSection {
+  title: string;
+  items: SidebarItem[];
+}
+
+const SECTIONS: SidebarSection[] = [
+  {
+    title: '메인',
+    items: [{ label: '대시보드', icon: <HiOutlineHome /> }]
+  },
+  {
+    title: '설교',
+    items: [
+      { label: '설교 관리', icon: <HiOutlinePlay />, active: true, badge: '128' },
+      { label: '시리즈 관리', icon: <HiOutlineFolder />, badge: '24' },
+      { label: '설교자 관리', icon: <HiOutlineUser /> }
+    ]
+  },
+  {
+    title: '멤버',
+    items: [{ label: '멤버 관리', icon: <HiOutlineUsers /> }]
+  },
+  {
+    title: '시스템',
+    items: [{ label: '설정', icon: <HiOutlineCog /> }]
+  }
+];
+
+interface AdminSidebarProps {
+  collapsed: boolean;
+  onToggle: () => void;
+  mobileOpen: boolean;
+  onMobileClose: () => void;
+}
+
+export default function AdminSidebar({
+  collapsed,
+  onToggle,
+  mobileOpen,
+  onMobileClose
+}: AdminSidebarProps) {
+  return (
+    <aside
+      className={clsx(
+        styles.sidebar,
+        collapsed && styles.collapsed,
+        mobileOpen && styles.mobile_open
+      )}
+    >
+      <div className={styles.brand}>
+        <div className={styles.logo}>
+          <HiCheck />
+        </div>
+        <span className={styles.title}>대구동남교회</span>
+      </div>
+
+      <nav className={styles.nav} aria-label="관리자 메뉴">
+        {SECTIONS.map((section) => (
+          <div key={section.title} className={styles.section}>
+            <h3 className={styles.section_title}>{section.title}</h3>
+            <ul className={styles.items}>
+              {section.items.map((item) => (
+                <li key={item.label}>
+                  <button
+                    type="button"
+                    className={clsx(styles.item, item.active && styles.on)}
+                    onClick={onMobileClose}
+                  >
+                    <span className={styles.icon}>{item.icon}</span>
+                    <span className={styles.label}>{item.label}</span>
+                    {item.badge && <span className={styles.badge}>{item.badge}</span>}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </nav>
+
+      <div className={styles.footer}>
+        <div className={styles.user}>
+          <div className={styles.avatar}>관</div>
+          <div className={styles.info}>
+            <span className={styles.name}>관리자</span>
+            <span className={styles.email}>admin@church.kr</span>
+          </div>
+        </div>
+        <button type="button" className={styles.toggle} onClick={onToggle}>
+          <span className={styles.toggle_icon}>
+            {collapsed ? <HiChevronRight /> : <HiChevronLeft />}
+          </span>
+          <span className={styles.toggle_label}>접기</span>
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/admin/layout/PageHeader/index.module.scss
+++ b/src/components/admin/layout/PageHeader/index.module.scss
@@ -100,6 +100,12 @@
       border-color: var(--admin-t3);
       color: var(--admin-t1);
     }
+
+    // 640px 이하에서는 outline 액션을 숨기고 primary만 노출.
+    // 숨긴 기능(임시저장)은 추후 모바일 하단 액션 바에서 복원한다.
+    @media (max-width: 640px) {
+      display: none;
+    }
   }
 
   &.pri {

--- a/src/components/admin/layout/PageHeader/index.module.scss
+++ b/src/components/admin/layout/PageHeader/index.module.scss
@@ -1,0 +1,121 @@
+.wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 20px 24px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 10px;
+  background: var(--admin-bg-card);
+
+  @media (max-width: 767px) {
+    flex-direction: column;
+    padding: 16px;
+  }
+}
+
+.head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--admin-t3);
+}
+
+.title_row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1.25;
+  color: var(--admin-t1);
+
+  @media (max-width: 767px) {
+    font-size: 19px;
+  }
+}
+
+.badge {
+  padding: 2px 8px;
+  border-radius: 100px;
+  background: var(--admin-accent-bg);
+  color: var(--admin-accent);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.description {
+  margin: 0;
+  font-size: 13px;
+  color: var(--admin-t2);
+}
+
+.actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 8px;
+
+  @media (max-width: 767px) {
+    align-self: stretch;
+
+    .btn {
+      flex: 1;
+    }
+  }
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  height: 36px;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+
+  &.outline {
+    border: 1px solid var(--admin-bd);
+    background: var(--admin-bg-card);
+    color: var(--admin-t2);
+
+    &:hover {
+      border-color: var(--admin-t3);
+      color: var(--admin-t1);
+    }
+  }
+
+  &.pri {
+    border: 0;
+    background: var(--admin-pri);
+    color: #fff;
+
+    &:hover {
+      background: color-mix(in srgb, var(--admin-pri), #fff 8%);
+    }
+  }
+}
+
+.btn_icon {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 6px;
+  font-size: 16px;
+}

--- a/src/components/admin/layout/PageHeader/index.tsx
+++ b/src/components/admin/layout/PageHeader/index.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+import styles from './index.module.scss';
+
+interface PageHeaderAction {
+  label: string;
+  variant?: 'outline' | 'pri';
+  icon?: ReactNode;
+  onClick?: () => void;
+}
+
+interface PageHeaderProps {
+  eyebrow?: string;
+  badge?: string;
+  title: string;
+  description?: string;
+  actions?: PageHeaderAction[];
+}
+
+export default function PageHeader({
+  eyebrow,
+  badge,
+  title,
+  description,
+  actions
+}: PageHeaderProps) {
+  return (
+    <header className={styles.wrapper}>
+      <div className={styles.head}>
+        {eyebrow && <span className={styles.eyebrow}>{eyebrow}</span>}
+        <div className={styles.title_row}>
+          <h1 className={styles.title}>{title}</h1>
+          {badge && <span className={styles.badge}>{badge}</span>}
+        </div>
+        {description && <p className={styles.description}>{description}</p>}
+      </div>
+      {actions && actions.length > 0 && (
+        <div className={styles.actions}>
+          {actions.map((action) => (
+            <button
+              key={action.label}
+              type="button"
+              className={clsx(styles.btn, styles[action.variant ?? 'outline'])}
+              onClick={action.onClick}
+            >
+              {action.icon && <span className={styles.btn_icon}>{action.icon}</span>}
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
@@ -1,0 +1,61 @@
+import clsx from 'clsx';
+import { HiCheck } from 'react-icons/hi';
+import parent from '../index.module.scss';
+import styles from './preview.module.scss';
+
+type Status = 'empty' | 'err' | 'ok';
+
+interface ChecklistItem {
+  label: string;
+  required?: boolean;
+  status: Status;
+}
+
+const ITEMS: ChecklistItem[] = [
+  { label: '설교 제목', required: true, status: 'err' },
+  { label: '설교 날짜', required: true, status: 'err' },
+  { label: '설교자 선택', required: true, status: 'err' },
+  { label: '영상 연결 (YouTube/Vimeo)', status: 'empty' },
+  { label: '성경 본문', status: 'empty' },
+  { label: '설교 요약', status: 'empty' },
+  { label: '썸네일 업로드', status: 'empty' }
+];
+
+const STATUS_CLASS: Record<Status, string> = {
+  empty: styles.cl_empty,
+  err: styles.cl_err,
+  ok: styles.cl_ok
+};
+
+export default function Checklist() {
+  const completed = ITEMS.filter((item) => item.status === 'ok').length;
+
+  return (
+    <section className={parent.card}>
+      <header className={styles.cl_head}>
+        <span className={styles.cl_title}>발행 준비 상태</span>
+        <span className={styles.cl_progress}>
+          {completed}/{ITEMS.length}
+        </span>
+      </header>
+      <ul className={styles.cl_items}>
+        {ITEMS.map((item) => (
+          <li key={item.label} className={styles.cl_item}>
+            <span className={clsx(styles.cl_badge, STATUS_CLASS[item.status])}>
+              {item.status === 'ok' && <HiCheck />}
+              {item.status === 'err' && '!'}
+            </span>
+            <span className={styles.cl_label}>
+              {item.label}
+              {item.required && (
+                <span className={styles.cl_required} aria-hidden>
+                  *
+                </span>
+              )}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
@@ -22,9 +22,9 @@ const ITEMS: ChecklistItem[] = [
 ];
 
 const STATUS_CLASS: Record<Status, string> = {
-  empty: styles.cl_empty,
-  err: styles.cl_err,
-  ok: styles.cl_ok
+  empty: styles.checklist_empty,
+  err: styles.checklist_err,
+  ok: styles.checklist_ok
 };
 
 export default function Checklist() {
@@ -32,23 +32,23 @@ export default function Checklist() {
 
   return (
     <section className={parent.card}>
-      <header className={styles.cl_head}>
-        <span className={styles.cl_title}>발행 준비 상태</span>
-        <span className={styles.cl_progress}>
+      <header className={styles.checklist_head}>
+        <span className={styles.checklist_title}>발행 준비 상태</span>
+        <span className={styles.checklist_progress}>
           {completed}/{ITEMS.length}
         </span>
       </header>
-      <ul className={styles.cl_items}>
+      <ul className={styles.checklist_items}>
         {ITEMS.map((item) => (
-          <li key={item.label} className={styles.cl_item}>
-            <span className={clsx(styles.cl_badge, STATUS_CLASS[item.status])}>
+          <li key={item.label} className={styles.checklist_item}>
+            <span className={clsx(styles.checklist_badge, STATUS_CLASS[item.status])}>
               {item.status === 'ok' && <HiCheck />}
               {item.status === 'err' && '!'}
             </span>
-            <span className={styles.cl_label}>
+            <span className={styles.checklist_label}>
               {item.label}
               {item.required && (
-                <span className={styles.cl_required} aria-hidden>
+                <span className={styles.checklist_required} aria-hidden>
                   *
                 </span>
               )}

--- a/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
@@ -1,25 +1,16 @@
 import clsx from 'clsx';
 import { HiCheck } from 'react-icons/hi';
+import type { SermonFormData } from '@/types/sermon-form';
 import parent from '../index.module.scss';
 import styles from './preview.module.scss';
 
 type Status = 'empty' | 'err' | 'ok';
 
-interface ChecklistItem {
+interface ChecklistEntry {
   label: string;
   required?: boolean;
   status: Status;
 }
-
-const ITEMS: ChecklistItem[] = [
-  { label: '설교 제목', required: true, status: 'err' },
-  { label: '설교 날짜', required: true, status: 'err' },
-  { label: '설교자 선택', required: true, status: 'err' },
-  { label: '영상 연결 (YouTube/Vimeo)', status: 'empty' },
-  { label: '성경 본문', status: 'empty' },
-  { label: '설교 요약', status: 'empty' },
-  { label: '썸네일 업로드', status: 'empty' }
-];
 
 const STATUS_CLASS: Record<Status, string> = {
   empty: styles.checklist_empty,
@@ -27,19 +18,35 @@ const STATUS_CLASS: Record<Status, string> = {
   ok: styles.checklist_ok
 };
 
-export default function Checklist() {
-  const completed = ITEMS.filter((item) => item.status === 'ok').length;
+const requiredStatus = (filled: boolean): Status => (filled ? 'ok' : 'err');
+const optionalStatus = (filled: boolean): Status => (filled ? 'ok' : 'empty');
+
+interface ChecklistProps {
+  data: SermonFormData;
+}
+
+export default function Checklist({ data }: ChecklistProps) {
+  const items: ChecklistEntry[] = [
+    { label: '설교 제목', required: true, status: requiredStatus(data.title.trim() !== '') },
+    { label: '설교 날짜', required: true, status: requiredStatus(data.sermonDate !== '') },
+    { label: '설교자 선택', required: true, status: requiredStatus(data.preacherId !== '') },
+    { label: '영상 연결 (YouTube/Vimeo)', status: optionalStatus(Boolean(data.videoId)) },
+    { label: '성경 본문', status: optionalStatus(data.scripture.trim() !== '') },
+    { label: '설교 요약', status: optionalStatus(data.summary.trim() !== '') },
+    { label: '썸네일 업로드', status: optionalStatus(Boolean(data.thumbnailUrl)) }
+  ];
+  const completed = items.filter((item) => item.status === 'ok').length;
 
   return (
     <section className={parent.card}>
       <header className={styles.checklist_head}>
         <span className={styles.checklist_title}>발행 준비 상태</span>
         <span className={styles.checklist_progress}>
-          {completed}/{ITEMS.length}
+          {completed}/{items.length}
         </span>
       </header>
       <ul className={styles.checklist_items}>
-        {ITEMS.map((item) => (
+        {items.map((item) => (
           <li key={item.label} className={styles.checklist_item}>
             <span className={clsx(styles.checklist_badge, STATUS_CLASS[item.status])}>
               {item.status === 'ok' && <HiCheck />}

--- a/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/Checklist.tsx
@@ -30,6 +30,7 @@ export default function Checklist({ data }: ChecklistProps) {
     { label: '설교 제목', required: true, status: requiredStatus(data.title.trim() !== '') },
     { label: '설교 날짜', required: true, status: requiredStatus(data.sermonDate !== '') },
     { label: '설교자 선택', required: true, status: requiredStatus(data.preacherId !== '') },
+    { label: '예배 종류', required: true, status: requiredStatus(data.serviceType !== '') },
     { label: '영상 연결 (YouTube/Vimeo)', status: optionalStatus(Boolean(data.videoId)) },
     { label: '성경 본문', status: optionalStatus(data.scripture.trim() !== '') },
     { label: '설교 요약', status: optionalStatus(data.summary.trim() !== '') },

--- a/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
@@ -1,0 +1,31 @@
+import clsx from 'clsx';
+import { HiOutlineEye, HiOutlinePhotograph } from 'react-icons/hi';
+import parent from '../index.module.scss';
+import styles from './preview.module.scss';
+
+export default function PreviewCard() {
+  return (
+    <section className={parent.card}>
+      <header className={styles.pv_head}>
+        <HiOutlineEye />
+        <span>실시간 미리보기</span>
+      </header>
+      <div className={styles.pv_body}>
+        <div className={styles.pv_thumb}>
+          <div className={styles.pv_thumb_empty}>
+            <HiOutlinePhotograph />
+            <span>썸네일 없음</span>
+          </div>
+          <span className={styles.pv_thumb_tag}>단독 설교</span>
+        </div>
+        <p className={styles.pv_meta}>2026년 3월 29일 (일) · 김은혜 목사</p>
+        <h4 className={clsx(styles.pv_title, styles.pv_title_empty)}>
+          설교 제목을 입력하세요
+        </h4>
+        <div className={styles.pv_summary_block}>
+          <p className={styles.pv_summary}>설교 요약이 여기에 표시됩니다</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
@@ -1,9 +1,27 @@
 import clsx from 'clsx';
 import { HiOutlineEye, HiOutlinePhotograph } from 'react-icons/hi';
+import type { SermonFormData } from '@/types/sermon-form';
 import parent from '../index.module.scss';
 import styles from './preview.module.scss';
 
-export default function PreviewCard() {
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+function formatSermonDate(iso: string): string {
+  if (!iso) return '';
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return '';
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 (${WEEKDAYS[date.getDay()]})`;
+}
+
+interface PreviewCardProps {
+  data: SermonFormData;
+}
+
+export default function PreviewCard({ data }: PreviewCardProps) {
+  const { title, sermonDate, preacherId, seriesId, summary, thumbnailUrl } = data;
+  const metaParts = [formatSermonDate(sermonDate), preacherId].filter(Boolean);
+  const seriesLabel = seriesId || '단독 설교';
+
   return (
     <section className={parent.card}>
       <header className={styles.preview_head}>
@@ -12,18 +30,26 @@ export default function PreviewCard() {
       </header>
       <div className={styles.preview_body}>
         <div className={styles.preview_thumb}>
-          <div className={styles.preview_thumb_empty}>
-            <HiOutlinePhotograph />
-            <span>썸네일 없음</span>
-          </div>
-          <span className={styles.preview_thumb_tag}>단독 설교</span>
+          {thumbnailUrl ? (
+            <img src={thumbnailUrl} alt="" />
+          ) : (
+            <div className={styles.preview_thumb_empty}>
+              <HiOutlinePhotograph />
+              <span>썸네일 없음</span>
+            </div>
+          )}
+          <span className={styles.preview_thumb_tag}>{seriesLabel}</span>
         </div>
-        <p className={styles.preview_meta}>2026년 3월 29일 (일) · 김은혜 목사</p>
-        <h4 className={clsx(styles.preview_title, styles.preview_title_empty)}>
-          설교 제목을 입력하세요
+        {metaParts.length > 0 && (
+          <p className={styles.preview_meta}>{metaParts.join(' · ')}</p>
+        )}
+        <h4 className={clsx(styles.preview_title, !title && styles.preview_title_empty)}>
+          {title || '설교 제목을 입력하세요'}
         </h4>
         <div className={styles.preview_summary_block}>
-          <p className={styles.preview_summary}>설교 요약이 여기에 표시됩니다</p>
+          <p className={styles.preview_summary}>
+            {summary || '설교 요약이 여기에 표시됩니다'}
+          </p>
         </div>
       </div>
     </section>

--- a/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
@@ -1,17 +1,9 @@
 import clsx from 'clsx';
 import { HiOutlineEye, HiOutlinePhotograph } from 'react-icons/hi';
+import { formattedDate } from '@/utils/date';
 import type { SermonFormData } from '@/types/sermon-form';
 import parent from '../index.module.scss';
 import styles from './preview.module.scss';
-
-const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
-
-function formatSermonDate(iso: string): string {
-  if (!iso) return '';
-  const date = new Date(iso);
-  if (isNaN(date.getTime())) return '';
-  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일 (${WEEKDAYS[date.getDay()]})`;
-}
 
 interface PreviewCardProps {
   data: SermonFormData;
@@ -19,7 +11,10 @@ interface PreviewCardProps {
 
 export default function PreviewCard({ data }: PreviewCardProps) {
   const { title, sermonDate, preacherId, seriesId, summary, thumbnailUrl } = data;
-  const metaParts = [formatSermonDate(sermonDate), preacherId].filter(Boolean);
+  const metaParts = [
+    sermonDate ? formattedDate(sermonDate, 'YYYY년 M월 D일') : '',
+    preacherId
+  ].filter(Boolean);
   const seriesLabel = seriesId || '단독 설교';
 
   return (

--- a/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
@@ -6,24 +6,24 @@ import styles from './preview.module.scss';
 export default function PreviewCard() {
   return (
     <section className={parent.card}>
-      <header className={styles.pv_head}>
+      <header className={styles.preview_head}>
         <HiOutlineEye />
         <span>실시간 미리보기</span>
       </header>
-      <div className={styles.pv_body}>
-        <div className={styles.pv_thumb}>
-          <div className={styles.pv_thumb_empty}>
+      <div className={styles.preview_body}>
+        <div className={styles.preview_thumb}>
+          <div className={styles.preview_thumb_empty}>
             <HiOutlinePhotograph />
             <span>썸네일 없음</span>
           </div>
-          <span className={styles.pv_thumb_tag}>단독 설교</span>
+          <span className={styles.preview_thumb_tag}>단독 설교</span>
         </div>
-        <p className={styles.pv_meta}>2026년 3월 29일 (일) · 김은혜 목사</p>
-        <h4 className={clsx(styles.pv_title, styles.pv_title_empty)}>
+        <p className={styles.preview_meta}>2026년 3월 29일 (일) · 김은혜 목사</p>
+        <h4 className={clsx(styles.preview_title, styles.preview_title_empty)}>
           설교 제목을 입력하세요
         </h4>
-        <div className={styles.pv_summary_block}>
-          <p className={styles.pv_summary}>설교 요약이 여기에 표시됩니다</p>
+        <div className={styles.preview_summary_block}>
+          <p className={styles.preview_summary}>설교 요약이 여기에 표시됩니다</p>
         </div>
       </div>
     </section>

--- a/src/components/admin/sermons/SermonForm/Preview/preview.module.scss
+++ b/src/components/admin/sermons/SermonForm/Preview/preview.module.scss
@@ -1,9 +1,9 @@
 // PreviewCard + Checklist 공유 모듈.
-// 단일 파일 + prefix 네이밍(pv_*, cl_*)으로 sprawl 방지.
+// 단일 파일 + prefix 네이밍(preview_*, checklist_*)으로 sprawl 방지.
 
 // ── PreviewCard ──
 
-.pv_head {
+.preview_head {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -16,14 +16,14 @@
   letter-spacing: 0.04em;
 }
 
-.pv_body {
+.preview_body {
   display: flex;
   flex-direction: column;
   gap: 10px;
   padding: 12px 16px 16px;
 }
 
-.pv_thumb {
+.preview_thumb {
   position: relative;
   overflow: hidden;
   aspect-ratio: 16 / 9;
@@ -31,7 +31,7 @@
   background: var(--admin-bg);
 }
 
-.pv_thumb_empty {
+.preview_thumb_empty {
   position: absolute;
   inset: 0;
   display: flex;
@@ -47,7 +47,7 @@
   }
 }
 
-.pv_thumb_tag {
+.preview_thumb_tag {
   position: absolute;
   top: 8px;
   left: 8px;
@@ -59,13 +59,13 @@
   font-weight: 600;
 }
 
-.pv_meta {
+.preview_meta {
   margin: 0;
   color: var(--admin-t3);
   font-size: 11px;
 }
 
-.pv_title {
+.preview_title {
   margin: 0;
   font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
   font-size: 15px;
@@ -74,18 +74,18 @@
   color: var(--admin-t1);
 }
 
-.pv_title_empty {
+.preview_title_empty {
   color: var(--admin-t3);
   font-style: italic;
 }
 
-.pv_summary_block {
+.preview_summary_block {
   margin-top: 4px;
   padding-top: 10px;
   border-top: 1px solid var(--admin-bd);
 }
 
-.pv_summary {
+.preview_summary {
   display: -webkit-box;
   overflow: hidden;
   margin: 0;
@@ -99,7 +99,7 @@
 
 // ── Checklist ──
 
-.cl_head {
+.checklist_head {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -107,7 +107,7 @@
   border-bottom: 1px solid var(--admin-bd);
 }
 
-.cl_title {
+.checklist_title {
   color: var(--admin-t2);
   font-size: 12px;
   font-weight: 700;
@@ -115,13 +115,13 @@
   letter-spacing: 0.04em;
 }
 
-.cl_progress {
+.checklist_progress {
   color: var(--admin-t3);
   font-size: 11px;
   font-variant-numeric: tabular-nums;
 }
 
-.cl_items {
+.checklist_items {
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -130,13 +130,13 @@
   list-style: none;
 }
 
-.cl_item {
+.checklist_item {
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
-.cl_badge {
+.checklist_badge {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
@@ -148,27 +148,27 @@
   font-weight: 700;
 }
 
-.cl_empty {
+.checklist_empty {
   background: var(--admin-bg);
   color: var(--admin-t3);
 }
 
-.cl_err {
+.checklist_err {
   background: rgba(192, 57, 43, 0.12);
   color: var(--admin-err);
 }
 
-.cl_ok {
+.checklist_ok {
   background: rgba(46, 125, 91, 0.12);
   color: var(--admin-ok);
 }
 
-.cl_label {
+.checklist_label {
   color: var(--admin-t1);
   font-size: 12px;
 }
 
-.cl_required {
+.checklist_required {
   margin-left: 2px;
   color: #ef4444;
 }

--- a/src/components/admin/sermons/SermonForm/Preview/preview.module.scss
+++ b/src/components/admin/sermons/SermonForm/Preview/preview.module.scss
@@ -29,6 +29,12 @@
   aspect-ratio: 16 / 9;
   border-radius: 6px;
   background: var(--admin-bg);
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 .preview_thumb_empty {

--- a/src/components/admin/sermons/SermonForm/Preview/preview.module.scss
+++ b/src/components/admin/sermons/SermonForm/Preview/preview.module.scss
@@ -1,0 +1,174 @@
+// PreviewCard + Checklist 공유 모듈.
+// 단일 파일 + prefix 네이밍(pv_*, cl_*)으로 sprawl 방지.
+
+// ── PreviewCard ──
+
+.pv_head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--admin-bd);
+  color: var(--admin-t2);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pv_body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 16px 16px;
+}
+
+.pv_thumb {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  border-radius: 6px;
+  background: var(--admin-bg);
+}
+
+.pv_thumb_empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--admin-t3);
+  font-size: 12px;
+
+  svg {
+    font-size: 24px;
+  }
+}
+
+.pv_thumb_tag {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 8px;
+  border-radius: 100px;
+  background: rgba(15, 20, 30, 0.72);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.pv_meta {
+  margin: 0;
+  color: var(--admin-t3);
+  font-size: 11px;
+}
+
+.pv_title {
+  margin: 0;
+  font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.4;
+  color: var(--admin-t1);
+}
+
+.pv_title_empty {
+  color: var(--admin-t3);
+  font-style: italic;
+}
+
+.pv_summary_block {
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--admin-bd);
+}
+
+.pv_summary {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 0;
+  color: var(--admin-t3);
+  font-size: 12px;
+  font-style: italic;
+  line-height: 1.5;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+}
+
+// ── Checklist ──
+
+.cl_head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--admin-bd);
+}
+
+.cl_title {
+  color: var(--admin-t2);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cl_progress {
+  color: var(--admin-t3);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.cl_items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 10px 16px 14px;
+  list-style: none;
+}
+
+.cl_item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.cl_badge {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.cl_empty {
+  background: var(--admin-bg);
+  color: var(--admin-t3);
+}
+
+.cl_err {
+  background: rgba(192, 57, 43, 0.12);
+  color: var(--admin-err);
+}
+
+.cl_ok {
+  background: rgba(46, 125, 91, 0.12);
+  color: var(--admin-ok);
+}
+
+.cl_label {
+  color: var(--admin-t1);
+  font-size: 12px;
+}
+
+.cl_required {
+  margin-left: 2px;
+  color: #ef4444;
+}

--- a/src/components/admin/sermons/SermonForm/index.module.scss
+++ b/src/components/admin/sermons/SermonForm/index.module.scss
@@ -1,0 +1,468 @@
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  max-width: 1400px;
+  margin: 16px auto 0;
+
+  @media (min-width: 1280px) {
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    align-items: start;
+  }
+}
+
+.form_col {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.pv_col {
+  display: none;
+
+  @media (min-width: 1280px) {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    position: sticky;
+    top: calc(var(--header-h) + 24px);
+  }
+}
+
+// Section Card — 5개 섹션 카드가 공유하는 공통 쉘.
+// sections/*.tsx 에서 ../index.module.scss 경유로 소비.
+.card {
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 10px;
+}
+
+.card_h {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--admin-bd);
+}
+
+.card_num {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--admin-bg-w);
+  color: var(--admin-t2);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.card_ht {
+  margin: 0;
+  font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--admin-t1);
+}
+
+.card_hd {
+  margin: 3px 0 0;
+  font-size: 12px;
+  color: var(--admin-t3);
+}
+
+.card_b {
+  padding: 18px 20px 20px;
+  color: var(--admin-t3);
+  font-size: 13px;
+}
+
+// 카드 본문 내부에서 필드들을 세로 스택할 때 사용.
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+// 한 줄에 여러 Field를 가로로 배치. 모바일에서는 세로.
+.field_row {
+  display: flex;
+  gap: 12px;
+
+  > * {
+    flex: 1;
+    min-width: 0;
+  }
+
+  > .f2 {
+    flex: 2;
+  }
+
+  @media (max-width: 767px) {
+    flex-direction: column;
+  }
+}
+
+// 폭을 제한한 단일 필드 (예: 재생 시간). 모바일에서는 전폭.
+.field_short {
+  max-width: 220px;
+
+  @media (max-width: 767px) {
+    max-width: none;
+  }
+}
+
+// 이미지/파일 업로드 빈 상태 영역. VideoCard 썸네일, ResourcesCard 공용.
+.upload {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 22px 18px;
+  border: 1.5px dashed var(--admin-bd-s);
+  border-radius: 10px;
+  background: var(--admin-bg);
+  font-family: inherit;
+  text-align: center;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+
+  &:hover {
+    border-color: var(--admin-accent);
+    background: var(--admin-accent-bg);
+  }
+}
+
+.upload_ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--admin-bg-card);
+  color: var(--admin-accent);
+  font-size: 20px;
+}
+
+.upload_t {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--admin-t2);
+}
+
+.upload_accent {
+  color: var(--admin-accent);
+}
+
+.upload_d {
+  font-size: 11px;
+  color: var(--admin-t3);
+}
+
+// 파일 추가 dashed 버튼 (ResourcesCard — 파일 있을 때 표시).
+.add_btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px dashed var(--admin-bd-s);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--admin-t2);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+
+  &:hover {
+    border-color: var(--admin-accent);
+    color: var(--admin-accent);
+  }
+}
+
+// VideoCard — YouTube / Vimeo provider 탭.
+.prov_tabs {
+  display: flex;
+  gap: 6px;
+}
+
+.prov_tab {
+  padding: 7px 14px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  background: var(--admin-bg-card);
+  color: var(--admin-t2);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+
+  &:hover {
+    border-color: var(--admin-t3);
+    color: var(--admin-t1);
+  }
+
+  &.on {
+    border-color: var(--admin-accent);
+    background: var(--admin-accent-bg);
+    color: var(--admin-accent);
+    font-weight: 600;
+  }
+}
+
+// PublishCard — 공개 상태 토글 (초안 / 발행 세그먼티드 컨트롤).
+.toggle_row {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--admin-bg-w);
+}
+
+.toggle {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 10px 14px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--admin-t2);
+  font-family: inherit;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s,
+    box-shadow 0.15s;
+
+  &.on {
+    background: var(--admin-bg-card);
+    box-shadow: var(--admin-sh-s);
+    color: var(--admin-t1);
+
+    .main {
+      font-weight: 600;
+    }
+  }
+}
+
+.main {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.sub {
+  font-size: 11px;
+  color: var(--admin-t3);
+}
+
+// 안내 박스 — PublishCard 발행 조건 안내 등.
+.warn_box {
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--admin-warn);
+  border-radius: 6px;
+  background: var(--admin-warn-bg);
+  color: var(--admin-warn);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.ok_box {
+  margin-top: 14px;
+  padding: 10px 12px;
+  border: 1px solid var(--admin-ok);
+  border-radius: 6px;
+  background: var(--admin-ok-bg);
+  color: var(--admin-ok);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+// ── 모바일 하단 액션 바 ──
+// PC에서는 PageHeader 액션(임시저장/발행)을 우측에 두고, 모바일(<640px)에서 outline은 숨긴다.
+// 본 바는 숨겨진 임시저장을 복원하고 미리보기 시트 토글 버튼을 제공한다.
+.mb_bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: flex;
+  gap: 6px;
+  padding: 10px 16px;
+  background: var(--admin-bg-card);
+  border-top: 1px solid var(--admin-bd);
+
+  @media (min-width: 1024px) {
+    display: none;
+  }
+}
+
+.mb_pv_btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  background: var(--admin-bg-card);
+  color: var(--admin-t2);
+  font-size: 18px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
+
+  &:hover {
+    border-color: var(--admin-t3);
+    color: var(--admin-t1);
+  }
+}
+
+.mb_btn {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 42px;
+  padding: 0 14px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+
+  &.outline {
+    border: 1px solid var(--admin-bd);
+    background: var(--admin-bg-card);
+    color: var(--admin-t2);
+
+    &:hover {
+      border-color: var(--admin-t3);
+      color: var(--admin-t1);
+    }
+  }
+
+  &.pri {
+    border: 0;
+    background: var(--admin-pri);
+    color: #fff;
+
+    &:hover {
+      background: color-mix(in srgb, var(--admin-pri), #fff 8%);
+    }
+  }
+}
+
+// ── 미리보기 바텀시트 ──
+// PC(1024px+)에서는 우측 PreviewCard가 역할을 하므로 시트 자체가 불필요.
+.pv_ov {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: none;
+  align-items: flex-end;
+  justify-content: center;
+  background: rgba(15, 20, 30, 0.5);
+
+  &.open {
+    display: flex;
+  }
+
+  @media (min-width: 1024px) {
+    display: none;
+  }
+}
+
+.pv_sh {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: 90vh;
+  border-radius: 14px 14px 0 0;
+  background: var(--admin-bg);
+}
+
+.pv_sh_bar {
+  flex-shrink: 0;
+  width: 32px;
+  height: 3px;
+  margin: 8px auto 0;
+  border-radius: 999px;
+  background: var(--admin-bd-s);
+}
+
+.pv_sh_h {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px 10px;
+  border-bottom: 1px solid var(--admin-bd);
+}
+
+.pv_sh_title {
+  margin: 0;
+  font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--admin-t1);
+}
+
+.pv_sh_close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--admin-t2);
+  font-size: 18px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  &:hover {
+    background: var(--admin-bg-hover);
+    color: var(--admin-t1);
+  }
+}
+
+.pv_sh_b {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+}
+

--- a/src/components/admin/sermons/SermonForm/index.module.scss
+++ b/src/components/admin/sermons/SermonForm/index.module.scss
@@ -18,7 +18,7 @@
   gap: 14px;
 }
 
-.pv_col {
+.preview_col {
   display: none;
 
   @media (min-width: 1280px) {
@@ -38,7 +38,7 @@
   border-radius: 10px;
 }
 
-.card_h {
+.card_header {
   display: flex;
   align-items: flex-start;
   gap: 12px;
@@ -46,7 +46,7 @@
   border-bottom: 1px solid var(--admin-bd);
 }
 
-.card_num {
+.card_number {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
@@ -60,7 +60,7 @@
   font-weight: 700;
 }
 
-.card_ht {
+.card_heading_title {
   margin: 0;
   font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
   font-size: 14px;
@@ -68,13 +68,13 @@
   color: var(--admin-t1);
 }
 
-.card_hd {
+.card_heading_desc {
   margin: 3px 0 0;
   font-size: 12px;
   color: var(--admin-t3);
 }
 
-.card_b {
+.card_body {
   padding: 18px 20px 20px;
   color: var(--admin-t3);
   font-size: 13px;
@@ -97,7 +97,7 @@
     min-width: 0;
   }
 
-  > .f2 {
+  > .flex_2 {
     flex: 2;
   }
 
@@ -139,7 +139,7 @@
   }
 }
 
-.upload_ic {
+.upload_icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -151,7 +151,7 @@
   font-size: 20px;
 }
 
-.upload_t {
+.upload_text {
   font-size: 13px;
   font-weight: 600;
   color: var(--admin-t2);
@@ -161,13 +161,13 @@
   color: var(--admin-accent);
 }
 
-.upload_d {
+.upload_desc {
   font-size: 11px;
   color: var(--admin-t3);
 }
 
 // 파일 추가 dashed 버튼 (ResourcesCard — 파일 있을 때 표시).
-.add_btn {
+.add_button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -194,12 +194,12 @@
 }
 
 // VideoCard — YouTube / Vimeo provider 탭.
-.prov_tabs {
+.provider_tabs {
   display: flex;
   gap: 6px;
 }
 
-.prov_tab {
+.provider_tab {
   padding: 7px 14px;
   border: 1px solid var(--admin-bd);
   border-radius: 6px;
@@ -301,7 +301,7 @@
 // ── 모바일 하단 액션 바 ──
 // PC에서는 PageHeader 액션(임시저장/발행)을 우측에 두고, 모바일(<640px)에서 outline은 숨긴다.
 // 본 바는 숨겨진 임시저장을 복원하고 미리보기 시트 토글 버튼을 제공한다.
-.mb_bar {
+.mobile_bar {
   position: fixed;
   bottom: 0;
   left: 0;
@@ -318,7 +318,7 @@
   }
 }
 
-.mb_pv_btn {
+.mobile_preview_button {
   flex-shrink: 0;
   display: inline-flex;
   align-items: center;
@@ -341,7 +341,7 @@
   }
 }
 
-.mb_btn {
+.mobile_button {
   flex: 1;
   display: inline-flex;
   align-items: center;
@@ -369,7 +369,7 @@
     }
   }
 
-  &.pri {
+  &.primary {
     border: 0;
     background: var(--admin-pri);
     color: #fff;
@@ -382,8 +382,8 @@
 
 // ── 미리보기 바텀시트 ──
 // PC(1024px+)에서는 우측 PreviewCard가 역할을 하므로 시트 자체가 불필요.
-.pv_ov {
-  position: fixed;
+.preview_overlay {
+  // position: fixed;  TODO: 모바일에서 바텀시트로 구현할 때 활성화
   inset: 0;
   z-index: 300;
   display: none;
@@ -400,7 +400,7 @@
   }
 }
 
-.pv_sh {
+.preview_sheet {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -409,7 +409,7 @@
   background: var(--admin-bg);
 }
 
-.pv_sh_bar {
+.preview_sheet_bar {
   flex-shrink: 0;
   width: 32px;
   height: 3px;
@@ -418,7 +418,7 @@
   background: var(--admin-bd-s);
 }
 
-.pv_sh_h {
+.preview_sheet_header {
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -427,7 +427,7 @@
   border-bottom: 1px solid var(--admin-bd);
 }
 
-.pv_sh_title {
+.preview_sheet_title {
   margin: 0;
   font-family: var(--font-notoserifKR), 'Noto Serif KR', serif;
   font-size: 14px;
@@ -435,7 +435,7 @@
   color: var(--admin-t1);
 }
 
-.pv_sh_close {
+.preview_sheet_close {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -457,7 +457,7 @@
   }
 }
 
-.pv_sh_b {
+.preview_sheet_body {
   flex: 1;
   overflow-y: auto;
   display: flex;
@@ -465,4 +465,3 @@
   gap: 14px;
   padding: 18px;
 }
-

--- a/src/components/admin/sermons/SermonForm/index.module.scss
+++ b/src/components/admin/sermons/SermonForm/index.module.scss
@@ -166,6 +166,125 @@
   color: var(--admin-t3);
 }
 
+// 썸네일 자동 미리보기 (YouTube)
+.thumb_preview {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--admin-bd);
+  border-radius: 8px;
+  background: var(--admin-bg);
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.thumb_badge {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  padding: 3px 8px;
+  border-radius: 100px;
+  background: rgba(15, 20, 30, 0.72);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+}
+
+// ResourcesCard — 업로드된 파일 목록.
+.resource_list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.resource_item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 8px;
+  background: var(--admin-bg);
+}
+
+.resource_icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+  background: var(--admin-bg-card);
+  color: var(--admin-t3);
+  font-size: 16px;
+}
+
+.resource_info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.resource_name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--admin-t1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.resource_meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--admin-t3);
+}
+
+.resource_badge {
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: var(--admin-bg-w);
+  color: var(--admin-t2);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.resource_remove {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--admin-t3);
+  font-size: 16px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+
+  &:hover {
+    background: var(--admin-bg-hover);
+    color: var(--admin-warn);
+  }
+}
+
 // 파일 추가 dashed 버튼 (ResourcesCard — 파일 있을 때 표시).
 .add_button {
   display: flex;
@@ -383,7 +502,7 @@
 // ── 미리보기 바텀시트 ──
 // PC(1024px+)에서는 우측 PreviewCard가 역할을 하므로 시트 자체가 불필요.
 .preview_overlay {
-  // position: fixed;  TODO: 모바일에서 바텀시트로 구현할 때 활성화
+  position: fixed;
   inset: 0;
   z-index: 300;
   display: none;

--- a/src/components/admin/sermons/SermonForm/index.module.scss
+++ b/src/components/admin/sermons/SermonForm/index.module.scss
@@ -285,6 +285,26 @@
   }
 }
 
+// 업로드 거부 파일 경고 (ResourcesCard — 크기 초과·미지원 확장자).
+.resource_rejected {
+  margin: 10px 0 0;
+  padding: 10px 12px;
+  list-style: none;
+  border: 1px solid var(--admin-warn);
+  border-radius: 6px;
+  background: var(--admin-warn-bg);
+  color: var(--admin-warn);
+  font-size: 12px;
+
+  li + li {
+    margin-top: 4px;
+  }
+
+  strong {
+    font-weight: 600;
+  }
+}
+
 // 파일 추가 dashed 버튼 (ResourcesCard — 파일 있을 때 표시).
 .add_button {
   display: flex;

--- a/src/components/admin/sermons/SermonForm/index.tsx
+++ b/src/components/admin/sermons/SermonForm/index.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useState } from 'react';
 import clsx from 'clsx';
 import { HiOutlineEye, HiOutlineX } from 'react-icons/hi';
 import BasicInfoCard from './sections/BasicInfoCard';
@@ -7,48 +10,51 @@ import ResourcesCard from './sections/ResourcesCard';
 import PublishCard from './sections/PublishCard';
 import PreviewCard from './Preview/PreviewCard';
 import Checklist from './Preview/Checklist';
+import { INITIAL_SERMON_FORM_DATA, type SermonFormData } from '@/types/sermon-form';
 import styles from './index.module.scss';
 
 export default function SermonForm() {
+  const [data, setData] = useState<SermonFormData>(INITIAL_SERMON_FORM_DATA);
+
   return (
     <>
       <form className={styles.wrap}>
         <div className={styles.form_col}>
-          <BasicInfoCard />
-          <VideoCard />
-          <ScriptureCard />
-          <ResourcesCard />
-          <PublishCard />
+          <BasicInfoCard data={data} setData={setData} />
+          <VideoCard data={data} setData={setData} />
+          <ScriptureCard data={data} setData={setData} />
+          <ResourcesCard data={data} setData={setData} />
+          <PublishCard data={data} setData={setData} />
         </div>
-        <aside className={styles.pv_col} aria-label="미리보기">
+        <aside className={styles.preview_col} aria-label="미리보기">
           <PreviewCard />
           <Checklist />
         </aside>
       </form>
 
-      <div className={styles.mb_bar}>
-        <button type="button" className={styles.mb_pv_btn} aria-label="미리보기 열기">
+      <div className={styles.mobile_bar}>
+        <button type="button" className={styles.mobile_preview_button} aria-label="미리보기 열기">
           <HiOutlineEye />
         </button>
-        <button type="button" className={clsx(styles.mb_btn, styles.outline)}>
+        <button type="button" className={clsx(styles.mobile_button, styles.outline)}>
           임시저장
         </button>
-        <button type="button" className={clsx(styles.mb_btn, styles.pri)}>
+        <button type="button" className={clsx(styles.mobile_button, styles.primary)}>
           발행
         </button>
       </div>
 
       {/* 1-10: 스타일 확인용으로 open 기본. 다음 단계에서 state로 교체. */}
-      <div className={clsx(styles.pv_ov, styles.open)}>
-        <div className={styles.pv_sh}>
-          <div className={styles.pv_sh_bar} aria-hidden />
-          <header className={styles.pv_sh_h}>
-            <h2 className={styles.pv_sh_title}>미리보기</h2>
-            <button type="button" className={styles.pv_sh_close} aria-label="닫기">
+      <div className={clsx(styles.preview_overlay, styles.open)}>
+        <div className={styles.preview_sheet}>
+          <div className={styles.preview_sheet_bar} aria-hidden />
+          <header className={styles.preview_sheet_header}>
+            <h2 className={styles.preview_sheet_title}>미리보기</h2>
+            <button type="button" className={styles.preview_sheet_close} aria-label="닫기">
               <HiOutlineX />
             </button>
           </header>
-          <div className={styles.pv_sh_b}>
+          <div className={styles.preview_sheet_body}>
             <PreviewCard />
             <Checklist />
           </div>

--- a/src/components/admin/sermons/SermonForm/index.tsx
+++ b/src/components/admin/sermons/SermonForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import clsx from 'clsx';
 import { HiOutlineEye, HiOutlineX } from 'react-icons/hi';
 import BasicInfoCard from './sections/BasicInfoCard';
@@ -10,30 +10,105 @@ import ResourcesCard from './sections/ResourcesCard';
 import PublishCard from './sections/PublishCard';
 import PreviewCard from './Preview/PreviewCard';
 import Checklist from './Preview/Checklist';
-import { INITIAL_SERMON_FORM_DATA, type SermonFormData } from '@/types/sermon-form';
+import {
+  INITIAL_SERMON_FORM_DATA,
+  type SermonFormData,
+  type SermonFormPatch,
+  type SermonResourceInput
+} from '@/types/sermon-form';
+import { parseVideoId } from '@/lib/video-url';
+import { inferResourceType } from '@/lib/sermon-resource';
 import styles from './index.module.scss';
 
-export default function SermonForm() {
-  const [data, setData] = useState<SermonFormData>(INITIAL_SERMON_FORM_DATA);
+const MAX_RESOURCE_BYTES = 50 * 1024 * 1024;
+
+interface SermonFormProps {
+  initialData?: SermonFormData;
+}
+
+export default function SermonForm({ initialData }: SermonFormProps = {}) {
+  const [data, setData] = useState<SermonFormData>(initialData ?? INITIAL_SERMON_FORM_DATA);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const handlePatch = useCallback((patch: SermonFormPatch) => {
+    setData((d) => {
+      const next = { ...d, ...patch };
+      const videoChanged =
+        patch.videoUrl !== undefined || patch.videoProvider !== undefined;
+      if (videoChanged) {
+        next.videoId = parseVideoId(next.videoUrl, next.videoProvider);
+      }
+      if (videoChanged && !d.thumbnailManual) {
+        next.thumbnailUrl =
+          next.videoProvider === 'youtube' && next.videoId
+            ? `https://img.youtube.com/vi/${next.videoId}/hqdefault.jpg`
+            : '';
+      }
+      return next;
+    });
+  }, []);
+
+  const handleAddResources = useCallback((files: FileList) => {
+    const additions: SermonResourceInput[] = [];
+    for (const file of Array.from(files)) {
+      if (file.size > MAX_RESOURCE_BYTES) continue;
+      additions.push({
+        id: crypto.randomUUID(),
+        name: file.name,
+        size: file.size,
+        fileType: inferResourceType(file.name),
+        file
+      });
+    }
+    if (additions.length === 0) return;
+    setData((d) => ({ ...d, resources: [...d.resources, ...additions] }));
+  }, []);
+
+  const handleRemoveResource = useCallback((id: string) => {
+    setData((d) => ({ ...d, resources: d.resources.filter((r) => r.id !== id) }));
+  }, []);
 
   return (
     <>
       <form className={styles.wrap}>
         <div className={styles.form_col}>
-          <BasicInfoCard data={data} setData={setData} />
-          <VideoCard data={data} setData={setData} />
+          <BasicInfoCard
+            title={data.title}
+            sermonDate={data.sermonDate}
+            preacherId={data.preacherId}
+            seriesId={data.seriesId}
+            onChange={handlePatch}
+          />
+          <VideoCard
+            videoProvider={data.videoProvider}
+            videoUrl={data.videoUrl}
+            videoId={data.videoId}
+            duration={data.duration}
+            thumbnailUrl={data.thumbnailUrl}
+            onChange={handlePatch}
+          />
           <ScriptureCard data={data} setData={setData} />
-          <ResourcesCard data={data} setData={setData} />
+          <ResourcesCard
+            resources={data.resources}
+            onAdd={handleAddResources}
+            onRemove={handleRemoveResource}
+          />
           <PublishCard data={data} setData={setData} />
         </div>
         <aside className={styles.preview_col} aria-label="미리보기">
-          <PreviewCard />
-          <Checklist />
+          <PreviewCard data={data} />
+          <Checklist data={data} />
         </aside>
       </form>
 
       <div className={styles.mobile_bar}>
-        <button type="button" className={styles.mobile_preview_button} aria-label="미리보기 열기">
+        <button
+          type="button"
+          className={styles.mobile_preview_button}
+          aria-label="미리보기 열기"
+          aria-expanded={previewOpen}
+          onClick={() => setPreviewOpen(true)}
+        >
           <HiOutlineEye />
         </button>
         <button type="button" className={clsx(styles.mobile_button, styles.outline)}>
@@ -44,19 +119,32 @@ export default function SermonForm() {
         </button>
       </div>
 
-      {/* 1-10: 스타일 확인용으로 open 기본. 다음 단계에서 state로 교체. */}
-      <div className={clsx(styles.preview_overlay, styles.open)}>
-        <div className={styles.preview_sheet}>
+      <div
+        className={clsx(styles.preview_overlay, previewOpen && styles.open)}
+        onClick={() => setPreviewOpen(false)}
+        aria-hidden={!previewOpen}
+      >
+        <div
+          className={styles.preview_sheet}
+          role="dialog"
+          aria-label="미리보기"
+          onClick={(e) => e.stopPropagation()}
+        >
           <div className={styles.preview_sheet_bar} aria-hidden />
           <header className={styles.preview_sheet_header}>
             <h2 className={styles.preview_sheet_title}>미리보기</h2>
-            <button type="button" className={styles.preview_sheet_close} aria-label="닫기">
+            <button
+              type="button"
+              className={styles.preview_sheet_close}
+              aria-label="닫기"
+              onClick={() => setPreviewOpen(false)}
+            >
               <HiOutlineX />
             </button>
           </header>
           <div className={styles.preview_sheet_body}>
-            <PreviewCard />
-            <Checklist />
+            <PreviewCard data={data} />
+            <Checklist data={data} />
           </div>
         </div>
       </div>

--- a/src/components/admin/sermons/SermonForm/index.tsx
+++ b/src/components/admin/sermons/SermonForm/index.tsx
@@ -1,0 +1,59 @@
+import clsx from 'clsx';
+import { HiOutlineEye, HiOutlineX } from 'react-icons/hi';
+import BasicInfoCard from './sections/BasicInfoCard';
+import VideoCard from './sections/VideoCard';
+import ScriptureCard from './sections/ScriptureCard';
+import ResourcesCard from './sections/ResourcesCard';
+import PublishCard from './sections/PublishCard';
+import PreviewCard from './Preview/PreviewCard';
+import Checklist from './Preview/Checklist';
+import styles from './index.module.scss';
+
+export default function SermonForm() {
+  return (
+    <>
+      <form className={styles.wrap}>
+        <div className={styles.form_col}>
+          <BasicInfoCard />
+          <VideoCard />
+          <ScriptureCard />
+          <ResourcesCard />
+          <PublishCard />
+        </div>
+        <aside className={styles.pv_col} aria-label="미리보기">
+          <PreviewCard />
+          <Checklist />
+        </aside>
+      </form>
+
+      <div className={styles.mb_bar}>
+        <button type="button" className={styles.mb_pv_btn} aria-label="미리보기 열기">
+          <HiOutlineEye />
+        </button>
+        <button type="button" className={clsx(styles.mb_btn, styles.outline)}>
+          임시저장
+        </button>
+        <button type="button" className={clsx(styles.mb_btn, styles.pri)}>
+          발행
+        </button>
+      </div>
+
+      {/* 1-10: 스타일 확인용으로 open 기본. 다음 단계에서 state로 교체. */}
+      <div className={clsx(styles.pv_ov, styles.open)}>
+        <div className={styles.pv_sh}>
+          <div className={styles.pv_sh_bar} aria-hidden />
+          <header className={styles.pv_sh_h}>
+            <h2 className={styles.pv_sh_title}>미리보기</h2>
+            <button type="button" className={styles.pv_sh_close} aria-label="닫기">
+              <HiOutlineX />
+            </button>
+          </header>
+          <div className={styles.pv_sh_b}>
+            <PreviewCard />
+            <Checklist />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/index.tsx
+++ b/src/components/admin/sermons/SermonForm/index.tsx
@@ -16,6 +16,7 @@ import {
   type SermonFormPatch,
   type SermonResourceInput
 } from '@/types/sermon-form';
+
 import { applyPatch } from '@/lib/sermon-form';
 import styles from './index.module.scss';
 
@@ -59,13 +60,18 @@ export default function SermonForm({ initialData }: SermonFormProps = {}) {
             thumbnailUrl={data.thumbnailUrl}
             onChange={handlePatch}
           />
-          <ScriptureCard data={data} setData={setData} />
+          <ScriptureCard
+            scripture={data.scripture}
+            scriptureText={data.scriptureText}
+            summary={data.summary}
+            onChange={handlePatch}
+          />
           <ResourcesCard
             resources={data.resources}
             onAdd={handleAddResources}
             onRemove={handleRemoveResource}
           />
-          <PublishCard data={data} setData={setData} />
+          <PublishCard isPublished={data.isPublished} onChange={handlePatch} />
         </div>
         <aside className={styles.preview_col} aria-label="미리보기">
           <PreviewCard data={data} />

--- a/src/components/admin/sermons/SermonForm/index.tsx
+++ b/src/components/admin/sermons/SermonForm/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import clsx from 'clsx';
 import { HiOutlineEye, HiOutlineX } from 'react-icons/hi';
 import BasicInfoCard from './sections/BasicInfoCard';
@@ -16,11 +16,8 @@ import {
   type SermonFormPatch,
   type SermonResourceInput
 } from '@/types/sermon-form';
-import { parseVideoId } from '@/lib/video-url';
-import { inferResourceType } from '@/lib/sermon-resource';
+import { applyPatch } from '@/lib/sermon-form';
 import styles from './index.module.scss';
-
-const MAX_RESOURCE_BYTES = 50 * 1024 * 1024;
 
 interface SermonFormProps {
   initialData?: SermonFormData;
@@ -30,43 +27,17 @@ export default function SermonForm({ initialData }: SermonFormProps = {}) {
   const [data, setData] = useState<SermonFormData>(initialData ?? INITIAL_SERMON_FORM_DATA);
   const [previewOpen, setPreviewOpen] = useState(false);
 
-  const handlePatch = useCallback((patch: SermonFormPatch) => {
-    setData((d) => {
-      const next = { ...d, ...patch };
-      const videoChanged =
-        patch.videoUrl !== undefined || patch.videoProvider !== undefined;
-      if (videoChanged) {
-        next.videoId = parseVideoId(next.videoUrl, next.videoProvider);
-      }
-      if (videoChanged && !d.thumbnailManual) {
-        next.thumbnailUrl =
-          next.videoProvider === 'youtube' && next.videoId
-            ? `https://img.youtube.com/vi/${next.videoId}/hqdefault.jpg`
-            : '';
-      }
-      return next;
-    });
-  }, []);
+  const handlePatch = (patch: SermonFormPatch) => {
+    setData((d) => applyPatch(d, patch));
+  };
 
-  const handleAddResources = useCallback((files: FileList) => {
-    const additions: SermonResourceInput[] = [];
-    for (const file of Array.from(files)) {
-      if (file.size > MAX_RESOURCE_BYTES) continue;
-      additions.push({
-        id: crypto.randomUUID(),
-        name: file.name,
-        size: file.size,
-        fileType: inferResourceType(file.name),
-        file
-      });
-    }
-    if (additions.length === 0) return;
-    setData((d) => ({ ...d, resources: [...d.resources, ...additions] }));
-  }, []);
+  const handleAddResources = (inputs: SermonResourceInput[]) => {
+    setData((d) => ({ ...d, resources: [...d.resources, ...inputs] }));
+  };
 
-  const handleRemoveResource = useCallback((id: string) => {
+  const handleRemoveResource = (id: string) => {
     setData((d) => ({ ...d, resources: d.resources.filter((r) => r.id !== id) }));
-  }, []);
+  };
 
   return (
     <>
@@ -77,6 +48,7 @@ export default function SermonForm({ initialData }: SermonFormProps = {}) {
             sermonDate={data.sermonDate}
             preacherId={data.preacherId}
             seriesId={data.seriesId}
+            serviceType={data.serviceType}
             onChange={handlePatch}
           />
           <VideoCard

--- a/src/components/admin/sermons/SermonForm/primitives/Field.module.scss
+++ b/src/components/admin/sermons/SermonForm/primitives/Field.module.scss
@@ -1,0 +1,49 @@
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.label_row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--admin-t1);
+}
+
+.required {
+  margin-left: 2px;
+  color: #ef4444;
+}
+
+.optional {
+  padding: 1px 6px;
+  border-radius: 100px;
+  background: var(--admin-bg-w);
+  color: var(--admin-t3);
+  font-size: 10px;
+  font-weight: 600;
+}
+
+.foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--admin-t3);
+}
+
+.counter {
+  margin-left: auto;
+  color: var(--admin-t3);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/components/admin/sermons/SermonForm/primitives/Field.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Field.tsx
@@ -1,0 +1,46 @@
+import { ReactNode } from 'react';
+import styles from './Field.module.scss';
+
+interface FieldProps {
+  label: string;
+  required?: boolean;
+  /** `true` → "선택" 뱃지, 문자열 → 해당 문자열 뱃지 (예: "자동 생성") */
+  optional?: boolean | string;
+  hint?: string;
+  counter?: string;
+  children: ReactNode;
+}
+
+export default function Field({
+  label,
+  required,
+  optional,
+  hint,
+  counter,
+  children
+}: FieldProps) {
+  const optionalLabel = typeof optional === 'string' ? optional : optional ? '선택' : null;
+
+  return (
+    <div className={styles.field}>
+      <div className={styles.label_row}>
+        <span className={styles.label}>
+          {label}
+          {required && (
+            <span className={styles.required} aria-hidden>
+              *
+            </span>
+          )}
+        </span>
+        {optionalLabel && <span className={styles.optional}>{optionalLabel}</span>}
+      </div>
+      {children}
+      {(hint || counter) && (
+        <div className={styles.foot}>
+          {hint && <span className={styles.hint}>{hint}</span>}
+          {counter && <span className={styles.counter}>{counter}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/primitives/Input.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Input.tsx
@@ -1,0 +1,9 @@
+import { InputHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './primitives.module.scss';
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export default function Input({ className, ...rest }: InputProps) {
+  return <input className={clsx(styles.control, className)} {...rest} />;
+}

--- a/src/components/admin/sermons/SermonForm/primitives/InputGroup.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/InputGroup.tsx
@@ -1,7 +1,7 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
 import styles from './primitives.module.scss';
 
-interface InputGroupProps extends InputHTMLAttributes<HTMLInputElement> {
+interface InputGroupProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
   prefix: ReactNode;
 }
 

--- a/src/components/admin/sermons/SermonForm/primitives/InputGroup.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/InputGroup.tsx
@@ -1,0 +1,15 @@
+import { InputHTMLAttributes, ReactNode } from 'react';
+import styles from './primitives.module.scss';
+
+interface InputGroupProps extends InputHTMLAttributes<HTMLInputElement> {
+  prefix: ReactNode;
+}
+
+export default function InputGroup({ prefix, ...rest }: InputGroupProps) {
+  return (
+    <div className={styles.group}>
+      <span className={styles.prefix}>{prefix}</span>
+      <input className={styles.control} {...rest} />
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/primitives/Select.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Select.tsx
@@ -1,0 +1,13 @@
+import { SelectHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './primitives.module.scss';
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
+
+export default function Select({ className, children, ...rest }: SelectProps) {
+  return (
+    <select className={clsx(styles.control, styles.select, className)} {...rest}>
+      {children}
+    </select>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/primitives/Textarea.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Textarea.tsx
@@ -1,0 +1,16 @@
+import { TextareaHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './primitives.module.scss';
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  tall?: boolean;
+}
+
+export default function Textarea({ tall, className, ...rest }: TextareaProps) {
+  return (
+    <textarea
+      className={clsx(styles.control, styles.textarea, tall && styles.tall, className)}
+      {...rest}
+    />
+  );
+}

--- a/src/components/admin/sermons/SermonForm/primitives/primitives.module.scss
+++ b/src/components/admin/sermons/SermonForm/primitives/primitives.module.scss
@@ -1,0 +1,94 @@
+// Input / Textarea / Select / InputGroup 가 공유하는 컨트롤 기본 스타일.
+
+.control {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  background: var(--admin-bg-card);
+  color: var(--admin-t1);
+  font-family: inherit;
+  font-size: 13px;
+  outline: none;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  &::placeholder {
+    color: var(--admin-t3);
+  }
+
+  &:focus-visible {
+    border-color: var(--admin-accent);
+    box-shadow: 0 0 0 3px rgba(91, 107, 165, 0.08);
+  }
+
+  &:disabled {
+    background: var(--admin-bg);
+    color: var(--admin-t3);
+    cursor: not-allowed;
+  }
+}
+
+.textarea {
+  height: auto;
+  min-height: 100px;
+  padding: 10px 12px;
+  line-height: 1.5;
+  resize: vertical;
+
+  &.tall {
+    min-height: 160px;
+  }
+}
+
+.select {
+  appearance: none;
+  padding-right: 36px;
+  background-image: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'><path fill='none' stroke='%238A94A3' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1.5l5 5 5-5'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  cursor: pointer;
+}
+
+.group {
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+  height: 38px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  background: var(--admin-bg-card);
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+
+  &:focus-within {
+    border-color: var(--admin-accent);
+    box-shadow: 0 0 0 3px rgba(91, 107, 165, 0.08);
+  }
+
+  .control {
+    flex: 1;
+    height: auto;
+    border: 0;
+    background: transparent;
+
+    &:focus-visible {
+      border-color: transparent;
+      box-shadow: none;
+    }
+  }
+}
+
+.prefix {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-right: 1px solid var(--admin-bd);
+  background: var(--admin-bg-w);
+  color: var(--admin-t3);
+  font-size: 13px;
+  white-space: nowrap;
+}

--- a/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
@@ -2,22 +2,28 @@ import Field from '../primitives/Field';
 import Input from '../primitives/Input';
 import InputGroup from '../primitives/InputGroup';
 import Select from '../primitives/Select';
+import type { SermonCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function BasicInfoCard() {
+export default function BasicInfoCard({ data, setData }: SermonCardProps) {
   return (
     <section className={styles.card}>
-      <header className={styles.card_h}>
-        <span className={styles.card_num}>1</span>
+      <header className={styles.card_header}>
+        <span className={styles.card_number}>1</span>
         <div>
-          <h3 className={styles.card_ht}>기본 정보</h3>
-          <p className={styles.card_hd}>설교 제목·날짜·설교자를 입력합니다</p>
+          <h3 className={styles.card_heading_title}>기본 정보</h3>
+          <p className={styles.card_heading_desc}>설교 제목·날짜·설교자를 입력합니다</p>
         </div>
       </header>
-      <div className={styles.card_b}>
+      <div className={styles.card_body}>
         <div className={styles.fields}>
-          <Field label="설교 제목" required counter="0/80">
-            <Input placeholder="예: 두려움을 넘어 믿음으로" maxLength={80} />
+          <Field label="설교 제목" required counter={`${data.title.length}/80`}>
+            <Input
+              placeholder="예: 두려움을 넘어 믿음으로"
+              maxLength={80}
+              value={data.title}
+              onChange={(e) => setData((d) => ({ ...d, title: e.target.value }))}
+            />
           </Field>
 
           <Field
@@ -45,7 +51,7 @@ export default function BasicInfoCard() {
           </div>
 
           <div className={styles.field_row}>
-            <div className={styles.f2}>
+            <div className={styles.flex_2}>
               <Field label="설교 시리즈" optional>
                 <Select defaultValue="">
                   <option value="">단독 설교</option>

--- a/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
@@ -1,11 +1,16 @@
 import Field from '../primitives/Field';
 import Input from '../primitives/Input';
-import InputGroup from '../primitives/InputGroup';
 import Select from '../primitives/Select';
-import type { SermonCardProps } from '@/types/sermon-form';
+import type { BasicInfoCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function BasicInfoCard({ data, setData }: SermonCardProps) {
+export default function BasicInfoCard({
+  title,
+  sermonDate,
+  preacherId,
+  seriesId,
+  onChange
+}: BasicInfoCardProps) {
   return (
     <section className={styles.card}>
       <header className={styles.card_header}>
@@ -17,55 +22,50 @@ export default function BasicInfoCard({ data, setData }: SermonCardProps) {
       </header>
       <div className={styles.card_body}>
         <div className={styles.fields}>
-          <Field label="설교 제목" required counter={`${data.title.length}/80`}>
+          <Field label="설교 제목" required counter={`${title.length}/80`}>
             <Input
               placeholder="예: 두려움을 넘어 믿음으로"
               maxLength={80}
-              value={data.title}
-              onChange={(e) => setData((d) => ({ ...d, title: e.target.value }))}
+              value={title}
+              onChange={(e) => onChange({ title: e.target.value })}
             />
-          </Field>
-
-          <Field
-            label="URL slug"
-            optional="자동 생성"
-            hint="제목 입력 시 자동 생성됩니다. 수동으로 편집 가능합니다."
-          >
-            <InputGroup prefix="/sermons/" placeholder="dureoum-eul-neomeo-mideumeuro" />
           </Field>
 
           <div className={styles.field_row}>
             <Field label="설교 날짜" required>
-              <Input type="date" />
+              <Input
+                type="date"
+                value={sermonDate}
+                onChange={(e) => onChange({ sermonDate: e.target.value })}
+              />
             </Field>
             <Field label="설교자" required>
-              <Select defaultValue="">
+              <Select
+                value={preacherId}
+                onChange={(e) => onChange({ preacherId: e.target.value })}
+              >
                 <option value="" disabled>
                   설교자를 선택하세요
                 </option>
-                <option>김은혜 목사</option>
-                <option>박성민 목사</option>
-                <option>이주영 전도사</option>
+                <option value="김은혜 목사">김은혜 목사</option>
+                <option value="박성민 목사">박성민 목사</option>
+                <option value="이주영 전도사">이주영 전도사</option>
               </Select>
             </Field>
           </div>
 
-          <div className={styles.field_row}>
-            <div className={styles.flex_2}>
-              <Field label="설교 시리즈" optional>
-                <Select defaultValue="">
-                  <option value="">단독 설교</option>
-                  <option>마가복음 강해</option>
-                  <option>산상수훈</option>
-                  <option>시편 묵상</option>
-                  <option>로마서</option>
-                </Select>
-              </Field>
-            </div>
-            <Field label="시리즈 순번" optional>
-              <Input type="number" min={1} placeholder="1" />
-            </Field>
-          </div>
+          <Field label="설교 시리즈" optional>
+            <Select
+              value={seriesId}
+              onChange={(e) => onChange({ seriesId: e.target.value })}
+            >
+              <option value="">단독 설교</option>
+              <option value="마가복음 강해">마가복음 강해</option>
+              <option value="산상수훈">산상수훈</option>
+              <option value="시편 묵상">시편 묵상</option>
+              <option value="로마서">로마서</option>
+            </Select>
+          </Field>
         </div>
       </div>
     </section>

--- a/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
@@ -1,0 +1,67 @@
+import Field from '../primitives/Field';
+import Input from '../primitives/Input';
+import InputGroup from '../primitives/InputGroup';
+import Select from '../primitives/Select';
+import styles from '../index.module.scss';
+
+export default function BasicInfoCard() {
+  return (
+    <section className={styles.card}>
+      <header className={styles.card_h}>
+        <span className={styles.card_num}>1</span>
+        <div>
+          <h3 className={styles.card_ht}>기본 정보</h3>
+          <p className={styles.card_hd}>설교 제목·날짜·설교자를 입력합니다</p>
+        </div>
+      </header>
+      <div className={styles.card_b}>
+        <div className={styles.fields}>
+          <Field label="설교 제목" required counter="0/80">
+            <Input placeholder="예: 두려움을 넘어 믿음으로" maxLength={80} />
+          </Field>
+
+          <Field
+            label="URL slug"
+            optional="자동 생성"
+            hint="제목 입력 시 자동 생성됩니다. 수동으로 편집 가능합니다."
+          >
+            <InputGroup prefix="/sermons/" placeholder="dureoum-eul-neomeo-mideumeuro" />
+          </Field>
+
+          <div className={styles.field_row}>
+            <Field label="설교 날짜" required>
+              <Input type="date" />
+            </Field>
+            <Field label="설교자" required>
+              <Select defaultValue="">
+                <option value="" disabled>
+                  설교자를 선택하세요
+                </option>
+                <option>김은혜 목사</option>
+                <option>박성민 목사</option>
+                <option>이주영 전도사</option>
+              </Select>
+            </Field>
+          </div>
+
+          <div className={styles.field_row}>
+            <div className={styles.f2}>
+              <Field label="설교 시리즈" optional>
+                <Select defaultValue="">
+                  <option value="">단독 설교</option>
+                  <option>마가복음 강해</option>
+                  <option>산상수훈</option>
+                  <option>시편 묵상</option>
+                  <option>로마서</option>
+                </Select>
+              </Field>
+            </div>
+            <Field label="시리즈 순번" optional>
+              <Input type="number" min={1} placeholder="1" />
+            </Field>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/BasicInfoCard.tsx
@@ -2,13 +2,24 @@ import Field from '../primitives/Field';
 import Input from '../primitives/Input';
 import Select from '../primitives/Select';
 import type { BasicInfoCardProps } from '@/types/sermon-form';
+import type { ServiceType } from '@/types/sermon';
 import styles from '../index.module.scss';
+
+const SERVICE_TYPES: ServiceType[] = [
+  '주일오전예배',
+  '주일저녁예배',
+  '수요기도회',
+  '금요기도회',
+  '새벽예배',
+  '특별예배'
+];
 
 export default function BasicInfoCard({
   title,
   sermonDate,
   preacherId,
   seriesId,
+  serviceType,
   onChange
 }: BasicInfoCardProps) {
   return (
@@ -54,18 +65,35 @@ export default function BasicInfoCard({
             </Field>
           </div>
 
-          <Field label="설교 시리즈" optional>
-            <Select
-              value={seriesId}
-              onChange={(e) => onChange({ seriesId: e.target.value })}
-            >
-              <option value="">단독 설교</option>
-              <option value="마가복음 강해">마가복음 강해</option>
-              <option value="산상수훈">산상수훈</option>
-              <option value="시편 묵상">시편 묵상</option>
-              <option value="로마서">로마서</option>
-            </Select>
-          </Field>
+          <div className={styles.field_row}>
+            <Field label="설교 시리즈" optional>
+              <Select
+                value={seriesId}
+                onChange={(e) => onChange({ seriesId: e.target.value })}
+              >
+                <option value="">단독 설교</option>
+                <option value="마가복음 강해">마가복음 강해</option>
+                <option value="산상수훈">산상수훈</option>
+                <option value="시편 묵상">시편 묵상</option>
+                <option value="로마서">로마서</option>
+              </Select>
+            </Field>
+            <Field label="예배 종류" required>
+              <Select
+                value={serviceType}
+                onChange={(e) => onChange({ serviceType: e.target.value as ServiceType })}
+              >
+                <option value="" disabled>
+                  예배를 선택하세요
+                </option>
+                {SERVICE_TYPES.map((type) => (
+                  <option key={type} value={type}>
+                    {type}
+                  </option>
+                ))}
+              </Select>
+            </Field>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
@@ -1,25 +1,34 @@
 import clsx from 'clsx';
 import Field from '../primitives/Field';
+import type { SermonCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function PublishCard() {
+export default function PublishCard({ data, setData }: SermonCardProps) {
   return (
     <section className={styles.card}>
-      <header className={styles.card_h}>
-        <span className={styles.card_num}>5</span>
+      <header className={styles.card_header}>
+        <span className={styles.card_number}>5</span>
         <div>
-          <h3 className={styles.card_ht}>발행 설정</h3>
-          <p className={styles.card_hd}>공개 상태와 노출 옵션을 설정합니다</p>
+          <h3 className={styles.card_heading_title}>발행 설정</h3>
+          <p className={styles.card_heading_desc}>공개 상태와 노출 옵션을 설정합니다</p>
         </div>
       </header>
-      <div className={styles.card_b}>
+      <div className={styles.card_body}>
         <Field label="공개 상태">
           <div className={styles.toggle_row}>
-            <button type="button" className={clsx(styles.toggle, styles.on)}>
+            <button
+              type="button"
+              className={clsx(styles.toggle, !data.isPublished && styles.on)}
+              onClick={() => setData((d) => ({ ...d, isPublished: false }))}
+            >
               <span className={styles.main}>초안</span>
               <span className={styles.sub}>비공개</span>
             </button>
-            <button type="button" className={styles.toggle}>
+            <button
+              type="button"
+              className={clsx(styles.toggle, data.isPublished && styles.on)}
+              onClick={() => setData((d) => ({ ...d, isPublished: true }))}
+            >
               <span className={styles.main}>발행</span>
               <span className={styles.sub}>공개</span>
             </button>

--- a/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
@@ -1,0 +1,34 @@
+import clsx from 'clsx';
+import Field from '../primitives/Field';
+import styles from '../index.module.scss';
+
+export default function PublishCard() {
+  return (
+    <section className={styles.card}>
+      <header className={styles.card_h}>
+        <span className={styles.card_num}>5</span>
+        <div>
+          <h3 className={styles.card_ht}>발행 설정</h3>
+          <p className={styles.card_hd}>공개 상태와 노출 옵션을 설정합니다</p>
+        </div>
+      </header>
+      <div className={styles.card_b}>
+        <Field label="공개 상태">
+          <div className={styles.toggle_row}>
+            <button type="button" className={clsx(styles.toggle, styles.on)}>
+              <span className={styles.main}>초안</span>
+              <span className={styles.sub}>비공개</span>
+            </button>
+            <button type="button" className={styles.toggle}>
+              <span className={styles.main}>발행</span>
+              <span className={styles.sub}>공개</span>
+            </button>
+          </div>
+        </Field>
+        <div className={styles.warn_box}>
+          발행하려면 제목, 날짜, 설교자, 영상 연결이 필요합니다
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import Field from '../primitives/Field';
-import type { SermonCardProps } from '@/types/sermon-form';
+import type { PublishCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function PublishCard({ data, setData }: SermonCardProps) {
+export default function PublishCard({ isPublished, onChange }: PublishCardProps) {
   return (
     <section className={styles.card}>
       <header className={styles.card_header}>
@@ -18,16 +18,16 @@ export default function PublishCard({ data, setData }: SermonCardProps) {
           <div className={styles.toggle_row}>
             <button
               type="button"
-              className={clsx(styles.toggle, !data.isPublished && styles.on)}
-              onClick={() => setData((d) => ({ ...d, isPublished: false }))}
+              className={clsx(styles.toggle, !isPublished && styles.on)}
+              onClick={() => onChange({ isPublished: false })}
             >
               <span className={styles.main}>초안</span>
               <span className={styles.sub}>비공개</span>
             </button>
             <button
               type="button"
-              className={clsx(styles.toggle, data.isPublished && styles.on)}
-              onClick={() => setData((d) => ({ ...d, isPublished: true }))}
+              className={clsx(styles.toggle, isPublished && styles.on)}
+              onClick={() => onChange({ isPublished: true })}
             >
               <span className={styles.main}>발행</span>
               <span className={styles.sub}>공개</span>

--- a/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
@@ -1,30 +1,36 @@
 import { HiOutlinePaperClip, HiPlus } from 'react-icons/hi';
+import type { SermonCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function ResourcesCard() {
+export default function ResourcesCard({ data }: SermonCardProps) {
+  const hasFiles = data.resources.length > 0;
   return (
     <section className={styles.card}>
-      <header className={styles.card_h}>
-        <span className={styles.card_num}>4</span>
+      <header className={styles.card_header}>
+        <span className={styles.card_number}>4</span>
         <div>
-          <h3 className={styles.card_ht}>첨부 자료</h3>
-          <p className={styles.card_hd}>설교문·악보 등 첨부 파일을 업로드합니다</p>
+          <h3 className={styles.card_heading_title}>첨부 자료</h3>
+          <p className={styles.card_heading_desc}>설교문·악보 등 첨부 파일을 업로드합니다</p>
         </div>
       </header>
-      <div className={styles.card_b}>
-        <button type="button" className={styles.upload}>
-          <span className={styles.upload_ic}>
-            <HiOutlinePaperClip />
-          </span>
-          <span className={styles.upload_t}>
-            <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
-          </span>
-          <span className={styles.upload_d}>PDF, DOCX, PPTX · 최대 50MB</span>
-        </button>
-        <button type="button" className={styles.add_btn}>
-          <HiPlus />
-          파일 추가
-        </button>
+      <div className={styles.card_body}>
+        {!hasFiles && (
+          <button type="button" className={styles.upload}>
+            <span className={styles.upload_icon}>
+              <HiOutlinePaperClip />
+            </span>
+            <span className={styles.upload_text}>
+              <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
+            </span>
+            <span className={styles.upload_desc}>PDF, DOCX, PPTX · 최대 50MB</span>
+          </button>
+        )}
+        {hasFiles && (
+          <button type="button" className={styles.add_button}>
+            <HiPlus />
+            파일 추가
+          </button>
+        )}
       </div>
     </section>
   );

--- a/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
@@ -1,0 +1,31 @@
+import { HiOutlinePaperClip, HiPlus } from 'react-icons/hi';
+import styles from '../index.module.scss';
+
+export default function ResourcesCard() {
+  return (
+    <section className={styles.card}>
+      <header className={styles.card_h}>
+        <span className={styles.card_num}>4</span>
+        <div>
+          <h3 className={styles.card_ht}>첨부 자료</h3>
+          <p className={styles.card_hd}>설교문·악보 등 첨부 파일을 업로드합니다</p>
+        </div>
+      </header>
+      <div className={styles.card_b}>
+        <button type="button" className={styles.upload}>
+          <span className={styles.upload_ic}>
+            <HiOutlinePaperClip />
+          </span>
+          <span className={styles.upload_t}>
+            <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
+          </span>
+          <span className={styles.upload_d}>PDF, DOCX, PPTX · 최대 50MB</span>
+        </button>
+        <button type="button" className={styles.add_btn}>
+          <HiPlus />
+          파일 추가
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
@@ -1,14 +1,51 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { HiOutlinePaperClip, HiPlus, HiX } from 'react-icons/hi';
-import type { ResourcesCardProps } from '@/types/sermon-form';
-import { formatBytes } from '@/lib/sermon-resource';
+import type { ResourcesCardProps, SermonResourceInput } from '@/types/sermon-form';
+import {
+  MAX_RESOURCE_BYTES,
+  formatBytes,
+  inferResourceType
+} from '@/lib/sermon-resource';
 import styles from '../index.module.scss';
+
+interface RejectedFile {
+  name: string;
+  reason: '지원 안 함' | '50MB 초과';
+}
 
 export default function ResourcesCard({ resources, onAdd, onRemove }: ResourcesCardProps) {
   const inputRef = useRef<HTMLInputElement>(null);
+  const [rejected, setRejected] = useState<RejectedFile[]>([]);
   const hasFiles = resources.length > 0;
 
   const openPicker = () => inputRef.current?.click();
+
+  const handleFiles = (list: FileList) => {
+    const accepted: SermonResourceInput[] = [];
+    const rejections: RejectedFile[] = [];
+
+    for (const file of Array.from(list)) {
+      const fileType = inferResourceType(file.name);
+      if (fileType === null) {
+        rejections.push({ name: file.name, reason: '지원 안 함' });
+        continue;
+      }
+      if (file.size > MAX_RESOURCE_BYTES) {
+        rejections.push({ name: file.name, reason: '50MB 초과' });
+        continue;
+      }
+      accepted.push({
+        id: crypto.randomUUID(),
+        name: file.name,
+        size: file.size,
+        fileType,
+        file
+      });
+    }
+
+    if (accepted.length > 0) onAdd(accepted);
+    setRejected(rejections);
+  };
 
   return (
     <section className={styles.card}>
@@ -26,7 +63,7 @@ export default function ResourcesCard({ resources, onAdd, onRemove }: ResourcesC
           multiple
           hidden
           onChange={(e) => {
-            if (e.target.files) onAdd(e.target.files);
+            if (e.target.files) handleFiles(e.target.files);
             e.target.value = '';
           }}
         />
@@ -39,7 +76,7 @@ export default function ResourcesCard({ resources, onAdd, onRemove }: ResourcesC
             <span className={styles.upload_text}>
               <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
             </span>
-            <span className={styles.upload_desc}>PDF, DOCX, PPTX · 최대 50MB</span>
+            <span className={styles.upload_desc}>PDF, HWP, TXT, 오디오/영상 · 최대 50MB</span>
           </button>
         )}
 
@@ -74,6 +111,16 @@ export default function ResourcesCard({ resources, onAdd, onRemove }: ResourcesC
               파일 추가
             </button>
           </>
+        )}
+
+        {rejected.length > 0 && (
+          <ul className={styles.resource_rejected} role="alert">
+            {rejected.map((file) => (
+              <li key={`${file.name}-${file.reason}`}>
+                <strong>{file.name}</strong> — {file.reason}으로 제외됨
+              </li>
+            ))}
+          </ul>
         )}
       </div>
     </section>

--- a/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ResourcesCard.tsx
@@ -1,9 +1,15 @@
-import { HiOutlinePaperClip, HiPlus } from 'react-icons/hi';
-import type { SermonCardProps } from '@/types/sermon-form';
+import { useRef } from 'react';
+import { HiOutlinePaperClip, HiPlus, HiX } from 'react-icons/hi';
+import type { ResourcesCardProps } from '@/types/sermon-form';
+import { formatBytes } from '@/lib/sermon-resource';
 import styles from '../index.module.scss';
 
-export default function ResourcesCard({ data }: SermonCardProps) {
-  const hasFiles = data.resources.length > 0;
+export default function ResourcesCard({ resources, onAdd, onRemove }: ResourcesCardProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const hasFiles = resources.length > 0;
+
+  const openPicker = () => inputRef.current?.click();
+
   return (
     <section className={styles.card}>
       <header className={styles.card_header}>
@@ -14,8 +20,19 @@ export default function ResourcesCard({ data }: SermonCardProps) {
         </div>
       </header>
       <div className={styles.card_body}>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          hidden
+          onChange={(e) => {
+            if (e.target.files) onAdd(e.target.files);
+            e.target.value = '';
+          }}
+        />
+
         {!hasFiles && (
-          <button type="button" className={styles.upload}>
+          <button type="button" className={styles.upload} onClick={openPicker}>
             <span className={styles.upload_icon}>
               <HiOutlinePaperClip />
             </span>
@@ -25,11 +42,38 @@ export default function ResourcesCard({ data }: SermonCardProps) {
             <span className={styles.upload_desc}>PDF, DOCX, PPTX · 최대 50MB</span>
           </button>
         )}
+
         {hasFiles && (
-          <button type="button" className={styles.add_button}>
-            <HiPlus />
-            파일 추가
-          </button>
+          <>
+            <ul className={styles.resource_list}>
+              {resources.map((resource) => (
+                <li key={resource.id} className={styles.resource_item}>
+                  <span className={styles.resource_icon}>
+                    <HiOutlinePaperClip />
+                  </span>
+                  <span className={styles.resource_info}>
+                    <span className={styles.resource_name}>{resource.name}</span>
+                    <span className={styles.resource_meta}>
+                      <span className={styles.resource_badge}>{resource.fileType}</span>
+                      <span>{formatBytes(resource.size)}</span>
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.resource_remove}
+                    onClick={() => onRemove(resource.id)}
+                    aria-label={`${resource.name} 제거`}
+                  >
+                    <HiX />
+                  </button>
+                </li>
+              ))}
+            </ul>
+            <button type="button" className={styles.add_button} onClick={openPicker}>
+              <HiPlus />
+              파일 추가
+            </button>
+          </>
         )}
       </div>
     </section>

--- a/src/components/admin/sermons/SermonForm/sections/ScriptureCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ScriptureCard.tsx
@@ -1,26 +1,31 @@
 import Field from '../primitives/Field';
 import Input from '../primitives/Input';
 import Textarea from '../primitives/Textarea';
+import type { SermonCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function ScriptureCard() {
+export default function ScriptureCard({ data, setData }: SermonCardProps) {
   return (
     <section className={styles.card}>
-      <header className={styles.card_h}>
-        <span className={styles.card_num}>3</span>
+      <header className={styles.card_header}>
+        <span className={styles.card_number}>3</span>
         <div>
-          <h3 className={styles.card_ht}>말씀</h3>
-          <p className={styles.card_hd}>본문 구절과 설교 요약을 입력합니다</p>
+          <h3 className={styles.card_heading_title}>말씀</h3>
+          <p className={styles.card_heading_desc}>본문 구절과 설교 요약을 입력합니다</p>
         </div>
       </header>
-      <div className={styles.card_b}>
+      <div className={styles.card_body}>
         <div className={styles.fields}>
           <Field
             label="성경 구절"
             optional
             hint="본문 구절을 입력하면 설교 카드에 태그로 표시됩니다"
           >
-            <Input placeholder="예: 마가복음 4:35-41" />
+            <Input
+              placeholder="예: 마가복음 4:35-41"
+              value={data.scripture}
+              onChange={(e) => setData((d) => ({ ...d, scripture: e.target.value }))}
+            />
           </Field>
 
           <Field label="성경 본문" optional counter="0자">

--- a/src/components/admin/sermons/SermonForm/sections/ScriptureCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ScriptureCard.tsx
@@ -1,0 +1,43 @@
+import Field from '../primitives/Field';
+import Input from '../primitives/Input';
+import Textarea from '../primitives/Textarea';
+import styles from '../index.module.scss';
+
+export default function ScriptureCard() {
+  return (
+    <section className={styles.card}>
+      <header className={styles.card_h}>
+        <span className={styles.card_num}>3</span>
+        <div>
+          <h3 className={styles.card_ht}>말씀</h3>
+          <p className={styles.card_hd}>본문 구절과 설교 요약을 입력합니다</p>
+        </div>
+      </header>
+      <div className={styles.card_b}>
+        <div className={styles.fields}>
+          <Field
+            label="성경 구절"
+            optional
+            hint="본문 구절을 입력하면 설교 카드에 태그로 표시됩니다"
+          >
+            <Input placeholder="예: 마가복음 4:35-41" />
+          </Field>
+
+          <Field label="성경 본문" optional counter="0자">
+            <Textarea
+              tall
+              placeholder="성경 본문 전체를 입력하세요. 절 번호와 함께 작성하면 좋습니다."
+            />
+          </Field>
+
+          <Field label="설교 요약" optional counter="0/500">
+            <Textarea
+              placeholder="설교의 핵심 메시지를 2-3 문장으로 요약해주세요"
+              maxLength={500}
+            />
+          </Field>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/admin/sermons/SermonForm/sections/ScriptureCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/ScriptureCard.tsx
@@ -1,10 +1,10 @@
 import Field from '../primitives/Field';
 import Input from '../primitives/Input';
 import Textarea from '../primitives/Textarea';
-import type { SermonCardProps } from '@/types/sermon-form';
+import type { ScriptureCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function ScriptureCard({ data, setData }: SermonCardProps) {
+export default function ScriptureCard({ scripture, scriptureText, summary, onChange }: ScriptureCardProps) {
   return (
     <section className={styles.card}>
       <header className={styles.card_header}>
@@ -23,22 +23,26 @@ export default function ScriptureCard({ data, setData }: SermonCardProps) {
           >
             <Input
               placeholder="예: 마가복음 4:35-41"
-              value={data.scripture}
-              onChange={(e) => setData((d) => ({ ...d, scripture: e.target.value }))}
+              value={scripture}
+              onChange={(e) => onChange({ scripture: e.target.value })}
             />
           </Field>
 
-          <Field label="성경 본문" optional counter="0자">
+          <Field label="성경 본문" optional counter={`${scriptureText.length}자`}>
             <Textarea
               tall
               placeholder="성경 본문 전체를 입력하세요. 절 번호와 함께 작성하면 좋습니다."
+              value={scriptureText}
+              onChange={(e) => onChange({ scriptureText: e.target.value })}
             />
           </Field>
 
-          <Field label="설교 요약" optional counter="0/500">
+          <Field label="설교 요약" optional counter={`${summary.length}/500`}>
             <Textarea
               placeholder="설교의 핵심 메시지를 2-3 문장으로 요약해주세요"
               maxLength={500}
+              value={summary}
+              onChange={(e) => onChange({ summary: e.target.value })}
             />
           </Field>
         </div>

--- a/src/components/admin/sermons/SermonForm/sections/VideoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/VideoCard.tsx
@@ -2,28 +2,38 @@ import clsx from 'clsx';
 import { HiOutlineCloudUpload } from 'react-icons/hi';
 import Field from '../primitives/Field';
 import Input from '../primitives/Input';
+import type { SermonCardProps, VideoProvider } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
-export default function VideoCard() {
+const PROVIDERS: { key: VideoProvider; label: string }[] = [
+  { key: 'youtube', label: 'YouTube' },
+  { key: 'vimeo', label: 'Vimeo' }
+];
+
+export default function VideoCard({ data, setData }: SermonCardProps) {
   return (
     <section className={styles.card}>
-      <header className={styles.card_h}>
-        <span className={styles.card_num}>2</span>
+      <header className={styles.card_header}>
+        <span className={styles.card_number}>2</span>
         <div>
-          <h3 className={styles.card_ht}>영상 정보</h3>
-          <p className={styles.card_hd}>YouTube/Vimeo 영상과 썸네일을 연결합니다</p>
+          <h3 className={styles.card_heading_title}>영상 정보</h3>
+          <p className={styles.card_heading_desc}>YouTube/Vimeo 영상과 썸네일을 연결합니다</p>
         </div>
       </header>
-      <div className={styles.card_b}>
+      <div className={styles.card_body}>
         <div className={styles.fields}>
           <Field label="영상 플랫폼" required>
-            <div className={styles.prov_tabs}>
-              <button type="button" className={clsx(styles.prov_tab, styles.on)}>
-                YouTube
-              </button>
-              <button type="button" className={styles.prov_tab}>
-                Vimeo
-              </button>
+            <div className={styles.provider_tabs}>
+              {PROVIDERS.map(({ key, label }) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={clsx(styles.provider_tab, data.videoProvider === key && styles.on)}
+                  onClick={() => setData((d) => ({ ...d, videoProvider: key }))}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
           </Field>
 
@@ -39,13 +49,13 @@ export default function VideoCard() {
 
           <Field label="썸네일" optional>
             <button type="button" className={styles.upload}>
-              <span className={styles.upload_ic}>
+              <span className={styles.upload_icon}>
                 <HiOutlineCloudUpload />
               </span>
-              <span className={styles.upload_t}>
+              <span className={styles.upload_text}>
                 <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
               </span>
-              <span className={styles.upload_d}>
+              <span className={styles.upload_desc}>
                 JPG, PNG, WebP · 최대 5MB · 권장 1280×720
               </span>
             </button>

--- a/src/components/admin/sermons/SermonForm/sections/VideoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/VideoCard.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { HiOutlineCloudUpload } from 'react-icons/hi';
 import Field from '../primitives/Field';
 import Input from '../primitives/Input';
-import type { SermonCardProps, VideoProvider } from '@/types/sermon-form';
+import type { VideoCardProps, VideoProvider } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
 const PROVIDERS: { key: VideoProvider; label: string }[] = [
@@ -10,7 +10,21 @@ const PROVIDERS: { key: VideoProvider; label: string }[] = [
   { key: 'vimeo', label: 'Vimeo' }
 ];
 
-export default function VideoCard({ data, setData }: SermonCardProps) {
+export default function VideoCard({
+  videoProvider,
+  videoUrl,
+  videoId,
+  duration,
+  thumbnailUrl,
+  onChange
+}: VideoCardProps) {
+  const urlHint = videoUrl
+    ? videoId
+      ? `인식된 ID: ${videoId}`
+      : 'URL을 확인하세요'
+    : undefined;
+  const hasAutoThumb = Boolean(thumbnailUrl);
+
   return (
     <section className={styles.card}>
       <header className={styles.card_header}>
@@ -28,8 +42,8 @@ export default function VideoCard({ data, setData }: SermonCardProps) {
                 <button
                   key={key}
                   type="button"
-                  className={clsx(styles.provider_tab, data.videoProvider === key && styles.on)}
-                  onClick={() => setData((d) => ({ ...d, videoProvider: key }))}
+                  className={clsx(styles.provider_tab, videoProvider === key && styles.on)}
+                  onClick={() => onChange({ videoProvider: key })}
                 >
                   {label}
                 </button>
@@ -37,28 +51,43 @@ export default function VideoCard({ data, setData }: SermonCardProps) {
             </div>
           </Field>
 
-          <Field label="영상 URL" optional>
-            <Input placeholder="https://youtube.com/watch?v=... 또는 video ID" />
+          <Field label="영상 URL" optional hint={urlHint}>
+            <Input
+              placeholder="https://youtube.com/watch?v=... 또는 video ID"
+              value={videoUrl}
+              onChange={(e) => onChange({ videoUrl: e.target.value })}
+            />
           </Field>
 
           <div className={styles.field_short}>
             <Field label="재생 시간" optional>
-              <Input placeholder="예: 32:15" />
+              <Input
+                placeholder="예: 32:15"
+                value={duration}
+                onChange={(e) => onChange({ duration: e.target.value })}
+              />
             </Field>
           </div>
 
           <Field label="썸네일" optional>
-            <button type="button" className={styles.upload}>
-              <span className={styles.upload_icon}>
-                <HiOutlineCloudUpload />
-              </span>
-              <span className={styles.upload_text}>
-                <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
-              </span>
-              <span className={styles.upload_desc}>
-                JPG, PNG, WebP · 최대 5MB · 권장 1280×720
-              </span>
-            </button>
+            {hasAutoThumb ? (
+              <div className={styles.thumb_preview}>
+                <img src={thumbnailUrl} alt="썸네일 미리보기" />
+                <span className={styles.thumb_badge}>YouTube 자동 생성</span>
+              </div>
+            ) : (
+              <button type="button" className={styles.upload}>
+                <span className={styles.upload_icon}>
+                  <HiOutlineCloudUpload />
+                </span>
+                <span className={styles.upload_text}>
+                  <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
+                </span>
+                <span className={styles.upload_desc}>
+                  JPG, PNG, WebP · 최대 5MB · 권장 1280×720
+                </span>
+              </button>
+            )}
           </Field>
         </div>
       </div>

--- a/src/components/admin/sermons/SermonForm/sections/VideoCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/VideoCard.tsx
@@ -1,0 +1,57 @@
+import clsx from 'clsx';
+import { HiOutlineCloudUpload } from 'react-icons/hi';
+import Field from '../primitives/Field';
+import Input from '../primitives/Input';
+import styles from '../index.module.scss';
+
+export default function VideoCard() {
+  return (
+    <section className={styles.card}>
+      <header className={styles.card_h}>
+        <span className={styles.card_num}>2</span>
+        <div>
+          <h3 className={styles.card_ht}>영상 정보</h3>
+          <p className={styles.card_hd}>YouTube/Vimeo 영상과 썸네일을 연결합니다</p>
+        </div>
+      </header>
+      <div className={styles.card_b}>
+        <div className={styles.fields}>
+          <Field label="영상 플랫폼" required>
+            <div className={styles.prov_tabs}>
+              <button type="button" className={clsx(styles.prov_tab, styles.on)}>
+                YouTube
+              </button>
+              <button type="button" className={styles.prov_tab}>
+                Vimeo
+              </button>
+            </div>
+          </Field>
+
+          <Field label="영상 URL" optional>
+            <Input placeholder="https://youtube.com/watch?v=... 또는 video ID" />
+          </Field>
+
+          <div className={styles.field_short}>
+            <Field label="재생 시간" optional>
+              <Input placeholder="예: 32:15" />
+            </Field>
+          </div>
+
+          <Field label="썸네일" optional>
+            <button type="button" className={styles.upload}>
+              <span className={styles.upload_ic}>
+                <HiOutlineCloudUpload />
+              </span>
+              <span className={styles.upload_t}>
+                <span className={styles.upload_accent}>클릭하여 업로드</span> 또는 드래그
+              </span>
+              <span className={styles.upload_d}>
+                JPG, PNG, WebP · 최대 5MB · 권장 1280×720
+              </span>
+            </button>
+          </Field>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/layout/BottomNav/BottomNav.module.scss
+++ b/src/components/layout/BottomNav/BottomNav.module.scss
@@ -44,8 +44,8 @@
   line-height: $line-height-reset;
 
   svg {
-    width: 2.2rem;
-    height: 2.2rem;
+    width: 2rem;
+    height: 2rem;
   }
 }
 

--- a/src/components/layout/Header/Header.module.scss
+++ b/src/components/layout/Header/Header.module.scss
@@ -51,8 +51,8 @@ $indicator-height: 0.2rem;
   flex-shrink: 0;
 
   svg {
-    width: 2.2rem;
-    height: 2.2rem;
+    width: 2rem;
+    height: 2rem;
     color: $txt-primary;
   }
 }

--- a/src/config/adminNavigation.ts
+++ b/src/config/adminNavigation.ts
@@ -1,0 +1,79 @@
+// ══════════════════════════════════════════
+// Admin Navigation — 어드민 사이드바와 브레드크럼이 공유하는 단일 sitemap
+// ══════════════════════════════════════════
+
+export type AdminIconName = 'home' | 'play' | 'folder' | 'user' | 'users' | 'cog';
+
+export type AdminNavItem = {
+  label: string;
+  href: string;
+  icon: AdminIconName;
+  badge?: string;
+};
+
+export type AdminNavSection = {
+  title: string;
+  items: AdminNavItem[];
+};
+
+export const ADMIN_ROOT = '/admin';
+
+export const ADMIN_NAV_SECTIONS: AdminNavSection[] = [
+  {
+    title: '메인',
+    items: [{ label: '대시보드', href: '/admin', icon: 'home' }]
+  },
+  {
+    title: '설교',
+    items: [
+      { label: '설교 관리', href: '/admin/sermons', icon: 'play', badge: '128' },
+      { label: '시리즈 관리', href: '/admin/sermons/series', icon: 'folder', badge: '24' },
+      { label: '설교자 관리', href: '/admin/sermons/speakers', icon: 'user' }
+    ]
+  },
+  {
+    title: '멤버',
+    items: [{ label: '멤버 관리', href: '/admin/members', icon: 'users' }]
+  },
+  {
+    title: '시스템',
+    items: [{ label: '설정', href: '/admin/settings', icon: 'cog' }]
+  }
+];
+
+// ── Active 판별 ──
+
+/**
+ * 사이드바 메뉴 활성 판별.
+ * 대시보드(/admin)는 정확히 일치할 때만, 나머지는 하위 경로까지 포함.
+ */
+export function isActiveAdminNav(pathname: string, href: string): boolean {
+  if (href === ADMIN_ROOT) return pathname === ADMIN_ROOT;
+  return pathname === href || pathname.startsWith(href + '/');
+}
+
+// ── Breadcrumb ──
+
+/**
+ * 어드민 경로 → AdminHeader 브레드크럼 라벨 배열.
+ * 정적 라벨이 필요한 dynamic 경로(설교 수정)는 임시 플레이스홀더를 사용하며,
+ * 실제 설교 제목 주입은 추후 페이지 단에서 컨텍스트/props로 대체한다.
+ */
+export function resolveAdminBreadcrumbs(pathname: string): string[] {
+  const root = '관리자';
+
+  if (pathname === '/admin') return [root, '대시보드'];
+
+  if (pathname === '/admin/sermons') return [root, '설교 관리'];
+  if (pathname === '/admin/sermons/new') return [root, '설교 관리', '새 설교 등록'];
+  if (/^\/admin\/sermons\/[^/]+\/edit$/.test(pathname))
+    return [root, '설교 관리', '(설교 제목)'];
+
+  if (pathname === '/admin/sermons/series') return [root, '설교 관리', '시리즈 관리'];
+  if (pathname === '/admin/sermons/speakers') return [root, '설교 관리', '설교자 관리'];
+
+  if (pathname.startsWith('/admin/members')) return [root, '멤버 관리'];
+  if (pathname.startsWith('/admin/settings')) return [root, '설정'];
+
+  return [root];
+}

--- a/src/lib/sermon-form.ts
+++ b/src/lib/sermon-form.ts
@@ -1,0 +1,24 @@
+import type { SermonFormData, SermonFormPatch } from '@/types/sermon-form';
+import { parseVideoId } from './video-url';
+
+export function applyPatch(
+  current: SermonFormData,
+  patch: SermonFormPatch
+): SermonFormData {
+  const next = { ...current, ...patch };
+  const videoChanged =
+    patch.videoUrl !== undefined || patch.videoProvider !== undefined;
+
+  if (videoChanged) {
+    next.videoId = parseVideoId(next.videoUrl, next.videoProvider);
+  }
+
+  if (videoChanged && !current.thumbnailManual) {
+    next.thumbnailUrl =
+      next.videoProvider === 'youtube' && next.videoId
+        ? `https://img.youtube.com/vi/${next.videoId}/hqdefault.jpg`
+        : '';
+  }
+
+  return next;
+}

--- a/src/lib/sermon-resource.ts
+++ b/src/lib/sermon-resource.ts
@@ -1,0 +1,24 @@
+import type { SermonResourceType } from '@/types/sermon-form';
+
+const EXT_MAP: Record<string, SermonResourceType> = {
+  pdf: 'pdf',
+  hwp: 'hwp',
+  txt: 'txt',
+  mp3: 'audio',
+  wav: 'audio',
+  m4a: 'audio',
+  mp4: 'video',
+  mov: 'video',
+  webm: 'video'
+};
+
+export function inferResourceType(filename: string): SermonResourceType {
+  const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+  return EXT_MAP[ext] ?? 'link';
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}

--- a/src/lib/sermon-resource.ts
+++ b/src/lib/sermon-resource.ts
@@ -1,5 +1,7 @@
 import type { SermonResourceType } from '@/types/sermon-form';
 
+export const MAX_RESOURCE_BYTES = 50 * 1024 * 1024;
+
 const EXT_MAP: Record<string, SermonResourceType> = {
   pdf: 'pdf',
   hwp: 'hwp',
@@ -12,9 +14,11 @@ const EXT_MAP: Record<string, SermonResourceType> = {
   webm: 'video'
 };
 
-export function inferResourceType(filename: string): SermonResourceType {
+// 매핑되지 않는 확장자는 null을 반환 — 호출자가 업로드 거부로 처리.
+// ('link'는 URL 첨부 전용 enum 값이므로 업로드 fallback으로 쓰지 않는다.)
+export function inferResourceType(filename: string): SermonResourceType | null {
   const ext = filename.split('.').pop()?.toLowerCase() ?? '';
-  return EXT_MAP[ext] ?? 'link';
+  return EXT_MAP[ext] ?? null;
 }
 
 export function formatBytes(bytes: number): string {

--- a/src/lib/video-url.ts
+++ b/src/lib/video-url.ts
@@ -1,0 +1,23 @@
+import type { VideoProvider } from '@/types/sermon-form';
+
+const YOUTUBE_ID = /(?:v=|\/(?:embed|shorts|v)\/|youtu\.be\/)([A-Za-z0-9_-]{11})/;
+const VIMEO_ID = /vimeo\.com(?:\/(?:video|channels\/[^/]+|groups\/[^/]+\/videos))?\/(\d+)/;
+const RAW_YOUTUBE_ID = /^[A-Za-z0-9_-]{11}$/;
+const RAW_VIMEO_ID = /^\d+$/;
+
+export function parseVideoId(url: string, provider: VideoProvider): string {
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+
+  if (provider === 'youtube') {
+    if (RAW_YOUTUBE_ID.test(trimmed)) return trimmed;
+    return trimmed.match(YOUTUBE_ID)?.[1] ?? '';
+  }
+
+  if (provider === 'vimeo') {
+    if (RAW_VIMEO_ID.test(trimmed)) return trimmed;
+    return trimmed.match(VIMEO_ID)?.[1] ?? '';
+  }
+
+  return '';
+}

--- a/src/types/sermon-form.ts
+++ b/src/types/sermon-form.ts
@@ -1,4 +1,3 @@
-import type { Dispatch, SetStateAction } from 'react';
 import type { Database } from '@/types/database.types';
 import type { ServiceType } from '@/types/sermon';
 
@@ -52,11 +51,6 @@ export const INITIAL_SERMON_FORM_DATA: SermonFormData = {
   isPublished: false
 };
 
-export type SermonCardProps = {
-  data: SermonFormData;
-  setData: Dispatch<SetStateAction<SermonFormData>>;
-};
-
 // 파생 필드(videoId, thumbnailUrl)는 applyPatch에서만 계산되어야 하므로 외부 패치 대상에서 제외.
 type SermonFormInputKey = Exclude<keyof SermonFormData, 'videoId' | 'thumbnailUrl'>;
 export type SermonFormPatch = Partial<Pick<SermonFormData, SermonFormInputKey>>;
@@ -72,6 +66,14 @@ export type VideoCardProps = Pick<
   SermonFormData,
   'videoProvider' | 'videoUrl' | 'videoId' | 'duration' | 'thumbnailUrl'
 > & {
+  onChange: (patch: SermonFormPatch) => void;
+};
+
+export type ScriptureCardProps = Pick<SermonFormData, 'scripture' | 'scriptureText' | 'summary'> & {
+  onChange: (patch: SermonFormPatch) => void;
+};
+
+export type PublishCardProps = Pick<SermonFormData, 'isPublished'> & {
   onChange: (patch: SermonFormPatch) => void;
 };
 

--- a/src/types/sermon-form.ts
+++ b/src/types/sermon-form.ts
@@ -1,0 +1,67 @@
+import type { Dispatch, SetStateAction } from 'react';
+import type { Database } from '@/types/database.types';
+import type { ServiceType } from '@/types/sermon';
+
+export type VideoProvider = 'youtube' | 'vimeo';
+export type SermonResourceType = Database['public']['Enums']['sermon_resource_type'];
+
+export interface SermonResourceInput {
+  id: string;
+  name: string;
+  size: number;
+  fileType: SermonResourceType;
+  url?: string;
+}
+
+export interface SermonFormData {
+  title: string;
+  slug: string;
+  slugTouched: boolean;
+  sermonDate: string;
+  preacherId: string;
+  seriesId: string;
+  seriesOrder: number | '';
+  serviceType: ServiceType | '';
+
+  videoProvider: VideoProvider;
+  videoUrl: string;
+  videoId: string;
+  duration: string;
+  thumbnailUrl: string;
+  thumbnailManual: boolean;
+
+  scripture: string;
+  scriptureText: string;
+  summary: string;
+
+  resources: SermonResourceInput[];
+
+  isPublished: boolean;
+}
+
+export const INITIAL_SERMON_FORM_DATA: SermonFormData = {
+  title: '',
+  slug: '',
+  slugTouched: false,
+  sermonDate: '',
+  preacherId: '',
+  seriesId: '',
+  seriesOrder: '',
+  serviceType: '',
+  videoProvider: 'youtube',
+  videoUrl: '',
+  videoId: '',
+  duration: '',
+  thumbnailUrl: '',
+  thumbnailManual: false,
+  scripture: '',
+  scriptureText: '',
+  summary: '',
+  resources: [],
+  isPublished: false
+};
+
+export type SermonCardProps = {
+  data: SermonFormData;
+  setData: Dispatch<SetStateAction<SermonFormData>>;
+};

--- a/src/types/sermon-form.ts
+++ b/src/types/sermon-form.ts
@@ -57,11 +57,13 @@ export type SermonCardProps = {
   setData: Dispatch<SetStateAction<SermonFormData>>;
 };
 
-export type SermonFormPatch = Partial<SermonFormData>;
+// 파생 필드(videoId, thumbnailUrl)는 applyPatch에서만 계산되어야 하므로 외부 패치 대상에서 제외.
+type SermonFormInputKey = Exclude<keyof SermonFormData, 'videoId' | 'thumbnailUrl'>;
+export type SermonFormPatch = Partial<Pick<SermonFormData, SermonFormInputKey>>;
 
 export type BasicInfoCardProps = Pick<
   SermonFormData,
-  'title' | 'sermonDate' | 'preacherId' | 'seriesId'
+  'title' | 'sermonDate' | 'preacherId' | 'seriesId' | 'serviceType'
 > & {
   onChange: (patch: SermonFormPatch) => void;
 };
@@ -75,6 +77,6 @@ export type VideoCardProps = Pick<
 
 export type ResourcesCardProps = {
   resources: SermonResourceInput[];
-  onAdd: (files: FileList) => void;
+  onAdd: (inputs: SermonResourceInput[]) => void;
   onRemove: (id: string) => void;
 };

--- a/src/types/sermon-form.ts
+++ b/src/types/sermon-form.ts
@@ -11,42 +11,33 @@ export interface SermonResourceInput {
   size: number;
   fileType: SermonResourceType;
   url?: string;
+  file?: File;
 }
 
 export interface SermonFormData {
   title: string;
-  slug: string;
-  slugTouched: boolean;
   sermonDate: string;
   preacherId: string;
   seriesId: string;
-  seriesOrder: number | '';
   serviceType: ServiceType | '';
-
   videoProvider: VideoProvider;
   videoUrl: string;
   videoId: string;
   duration: string;
   thumbnailUrl: string;
   thumbnailManual: boolean;
-
   scripture: string;
   scriptureText: string;
   summary: string;
-
   resources: SermonResourceInput[];
-
   isPublished: boolean;
 }
 
 export const INITIAL_SERMON_FORM_DATA: SermonFormData = {
   title: '',
-  slug: '',
-  slugTouched: false,
   sermonDate: '',
   preacherId: '',
   seriesId: '',
-  seriesOrder: '',
   serviceType: '',
   videoProvider: 'youtube',
   videoUrl: '',
@@ -64,4 +55,26 @@ export const INITIAL_SERMON_FORM_DATA: SermonFormData = {
 export type SermonCardProps = {
   data: SermonFormData;
   setData: Dispatch<SetStateAction<SermonFormData>>;
+};
+
+export type SermonFormPatch = Partial<SermonFormData>;
+
+export type BasicInfoCardProps = Pick<
+  SermonFormData,
+  'title' | 'sermonDate' | 'preacherId' | 'seriesId'
+> & {
+  onChange: (patch: SermonFormPatch) => void;
+};
+
+export type VideoCardProps = Pick<
+  SermonFormData,
+  'videoProvider' | 'videoUrl' | 'videoId' | 'duration' | 'thumbnailUrl'
+> & {
+  onChange: (patch: SermonFormPatch) => void;
+};
+
+export type ResourcesCardProps = {
+  resources: SermonResourceInput[];
+  onAdd: (files: FileList) => void;
+  onRemove: (id: string) => void;
 };


### PR DESCRIPTION
## 📋 개요 (Summary)

설교 등록·수정을 위한 어드민 대시보드 레이아웃과 설교 폼(5개 섹션 카드 + 실시간 미리보기)을 구현합니다.
PR #66에서 완성된 설교 목록/상세 페이지에 이어, 콘텐츠를 직접 생성·관리할 수 있는 어드민 UI를 추가합니다.

<br/>

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**
- 설교 데이터를 등록·수정하려면 Supabase 대시보드에 직접 접근해야 했음
- 어드민 페이지가 없어 일반 사용자 레이아웃(Header/Footer)을 공유하는 구조 불가
- 폼 상태가 컴포넌트별로 분산되면 파생 필드(videoId, thumbnailUrl) 동기화가 어려움

<br/>

## 🔧 주요 변경점 (Key Changes)

**설교 목록/상세 후속 polish (PR #66 followup)**
- 설교 상세 페이지 mobile/PC 이원 구조(`mobile_info` + `side`) → `video_section` + `info_section` 평탄화, DOM 중복 렌더 제거
- 설교 카드 제목 폰트(`$font-family-secondary`), BottomNav 아이콘 크기, 필터 칩 패딩 통일

**일반 레이아웃 리팩터**
- `RootLayout`에서 Header/Hero/Footer/BottomNav를 분리, `(content)/layout.tsx`로 이관
- `app/page.tsx` → `app/(content)/page.tsx` 이동 (URL 경로 유지)

**어드민 레이아웃 신규 구현**
- `(admin)` 라우트 그룹: AdminLayout · AdminSidebar · AdminHeader · PageHeader 컴포넌트
- 어드민 전용 CSS 커스텀 프로퍼티를 `.shell` 스코프에 격리해 사이트 전역 토큰과 분리
- 어드민 사이드바 메뉴를 `src/config/adminNavigation.ts` 단일 소스(`ADMIN_NAV_SECTIONS`)로 중앙화

**설교 어드민 폼 신규 구현**
- 5개 섹션 카드: 기본 정보 · 영상 · 말씀 · 첨부 자료 · 발행 상태
- 단일 `useState<SermonFormData>` + `applyPatch()` 순수 함수로 전체 상태 관리
- VideoCard: YouTube/Vimeo URL 파싱 → videoId 자동 추출, 썸네일 자동 파생
- ResourcesCard: 파일 선택/제거 UI, 크기(50MB)·확장자 검증, 거부 파일 경고 인라인 표시
- 우측 사이드바: PreviewCard(실시간 미리보기) + Checklist(발행 준비 8항목) — 1280px↑ 2컬럼 grid
- 모바일: 하단 고정 액션 바 + PreviewCard/Checklist 바텀시트 (previewOpen 토글)

<br/>

## 🏗️ 설계 결정 사항 (Design Decisions)

| 고려한 대안 | 선택한 방법 | 선택 이유 |
|------------|------------|---------|
| `position:fixed` 사이드바 + `margin-left` 본문 | `flex row` + 사이드바 `position:sticky` | fixed+margin 조합이 1024px 경계에서 헤더 폭 애니메이션 버그 유발 |
| 각 섹션 카드에 분산된 상태 | 단일 `SermonFormData` + `applyPatch` | 파생 필드(videoId, thumbnailUrl) 동기화 보장, setState 콜백 단순화 |
| `SermonFormPatch`에 파생 필드 포함 | 파생 필드를 Patch 타입에서 제외 | 타입 레벨에서 외부 직접 수정 차단, 단일 진실 원천 강제 |
| 첨부 파일 검증을 부모(SermonForm)에서 처리 | ResourcesCard 내부 캡슐화 | 검증 책임이 UI와 함께 응집, onAdd 시그니처를 `FileList → SermonResourceInput[]`로 단순화 |
| 시리즈·예배종류를 별도 행 | 같은 `field_row`에 2열 배치 | 화면 공간 효율, 두 필드가 의미적으로 연관됨 |

> ⚠️ **트레이드오프:**
> - `useCallback` 미사용: consumers(섹션 카드)가 `React.memo`가 아니므로 실익 없음. memo 도입 시 재검토 필요.
> - 설교 폼 module.scss 단일 파일 통합: 섹션이 많아질수록 파일이 커지나, 현재 규모에서 barrel 분리보다 유지보수 비용이 낮음.

<br/>

## 📊 다이어그램 (Diagrams)

**설교 폼 상태 흐름**

```mermaid
flowchart TD
    U[사용자 입력] --> PC[섹션 카드\nonChange/onAdd/onRemove]
    PC --> AP[applyPatch\n순수 함수]
    AP -->|videoId·thumbnailUrl 파생 계산| SD[SermonFormData\n단일 state]
    SD --> PV[PreviewCard\n실시간 미리보기]
    SD --> CL[Checklist\n발행 준비도]
    SD --> SC[섹션 카드\n제어 컴포넌트]
```

**어드민 레이아웃 구조**

```mermaid
flowchart LR
    subgraph admin ["(admin) Route Group"]
        AL[AdminLayout\nflex row]
        AS[AdminSidebar\nsticky / 모바일 drawer]
        AH[AdminHeader\nbreadcrumb + actions]
        M[main content]
    end
    AL --> AS
    AL --> M
    M --> AH
    AN[adminNavigation.ts\nADMIN_NAV_SECTIONS] --> AS
    AN --> AH
```

<br/>

## ✅ 검증 결과 (Verification)

**수행한 테스트:**
- [ ] 단위 테스트 (Unit Test) — 테스트 환경 없음
- [ ] 통합 테스트 (Integration Test) — 테스트 환경 없음
- [x] 수동 테스트 (Manual Test)

**테스트 결과 / 스크린샷:**

| 항목 및 스크린샷 상세 | 항목 및 스크린샷 상세 |
| :--- | :--- | 
| **1. 어드민 사이드바 — 데스크톱 (sticky)** | **2. 어드민 사이드바 — 모바일 (drawer)** |
|   <img width="1518" height="854" alt="image" src="https://github.com/user-attachments/assets/edde419f-34cc-46d0-bdd0-54aac1e8e0ac" /> |  <img width="627" height="1007" alt="image" src="https://github.com/user-attachments/assets/17eedd76-af47-4606-b990-8bf92d264090" />    | 
| **3. 설교 폼 — 1280px↑ 2컬럼 (폼 + 미리보기)** |  **4. 설교 폼 — 모바일 하단 액션 바** |
| <img src="https://github.com/user-attachments/assets/cbcea852-bc0b-4b37-a78e-40736b58f399" width="600">  |  <img width="397" height="798" alt="image" src="https://github.com/user-attachments/assets/bd279bc2-5c1d-41bf-ab04-02bef06d875f" />   |
| **5. 미리보기 바텀시트 — open 상태** |  **6. YouTube URL 입력 → 썸네일 자동 파생** |
| <img width="395" height="791" alt="image" src="https://github.com/user-attachments/assets/cec7cfe9-aea5-453f-8ef5-1897bbae9ab4" />  | <img width="1053" height="786" alt="image" src="https://github.com/user-attachments/assets/701f2ace-c6d8-4f21-85f6-e3ce4d383983" />  |
| **7. 첨부 파일 — 업로드 / 거부 파일 경고** | **8. Checklist — 발행 준비 완료 상태** |
| <img width="1050" height="795" alt="image" src="https://github.com/user-attachments/assets/38456470-737b-45a1-a059-948023357e58" /> |<img width="311" height="544" alt="image" src="https://github.com/user-attachments/assets/d6baacfc-5dad-4c23-89aa-4829c5cf9ac1" />   |



<br/>

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**
- [x] 요구사항 전체 충족 여부
- [x] Null, 빈 배열 등 엣지 케이스 처리 여부 (빈 resources 배열, 썸네일 없음 상태 등)
- [ ] 신규 기능에 대한 단위 테스트 추가 여부 — 테스트 환경 없음

**코드 품질**
- [x] 변수명·함수명의 의도 명확성
- [x] 복잡한 로직 설명 주석 추가 여부 (applyPatch 파생 계산, inferResourceType null 반환 이유)
- [x] 불필요한 코드·디버그 로그 제거 여부

**보안 및 견고성**
- [x] 하드코딩된 비밀값(토큰, 비밀번호) 미포함 확인
- [x] 사용자 입력값 적절한 검증 여부 (파일 크기·확장자 검증)

**성능**
- [x] 불필요한 반복 연산·리소스 낭비 없음 확인 (useCallback 제거)
- [x] DB 쿼리 효율성 확인 — 이번 PR은 UI 레이어, DB 쿼리 없음

**테스트 및 문서화**
- [x] Conventional Commits 규격 준수 여부

<br/>

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- **설교 폼은 현재 UI만 완성된 상태** (Phase 2 완료). 실제 DB 저장(Server Action 연결)은 Phase 3에서 진행 예정.
- `SermonForm/index.module.scss`가 모든 섹션 카드 스타일을 통합 — 섹션 추가 시 이 파일에 작성.
- 어드민 CSS 변수는 `.shell` 스코프에만 적용되므로 일반 사용자 페이지에 영향 없음.
- `adminNavigation.ts`의 `ADMIN_NAV_SECTIONS`이 사이드바 메뉴 + 브레드크럼 두 곳에서 소비됨 — 메뉴 추가 시 이 파일만 수정.