### PR TITLE
[Refactor] 어드민 설교 모듈 보안·무결성·접근성 강화

### DIFF
--- a/src/actions/_auth-helpers.ts
+++ b/src/actions/_auth-helpers.ts
@@ -5,12 +5,17 @@ export async function checkAdminPermission() {
   const user = await getUserSession();
   if (!user) return { user: null, isAdmin: false };
 
+  const claimRole = (user.app_metadata as { role?: string } | undefined)?.role;
+  if (claimRole !== undefined) {
+    return { user, isAdmin: claimRole === 'admin' };
+  }
+
+  // Fallback: hook 미적용 토큰 보유자(과도기). 후속 PR에서 제거.
   const supabase = await createServerSideClient();
   const { data: profile } = await supabase
     .from('profiles')
     .select('role')
     .eq('id', user.id)
     .single();
-
   return { user, isAdmin: profile?.role === 'admin' };
 }

--- a/src/actions/sermon.action.ts
+++ b/src/actions/sermon.action.ts
@@ -5,18 +5,15 @@ import { updateTag } from 'next/cache';
 import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { createServerSideClient } from '@/lib/supabase/server';
 import { createAdminServerClient } from '@/lib/supabase/admin';
-import { sermonService } from '@/services/sermon/sermon-service';
+import { sermonService, type SermonResourceRpcInput } from '@/services/sermon/sermon-service';
 import { mapFormToDbInsert, mapFormToDbUpdate } from '@/lib/sermon-form-mapper';
 import { checkAdminPermission } from '@/actions/_auth-helpers';
 import { formattedDate } from '@/utils/date';
 import type { SermonFormData, SermonResourceInput } from '@/types/sermon-form';
-import type { Database } from '@/types/database.types';
 
 const RESOURCE_BUCKET = 'sermon-resources';
 
-type ResourceRow = Database['public']['Tables']['sermon_resources']['Insert'];
-
-// ─── 내부 업로드 헬퍼 ────────────────────────────────────────────────────────
+// ─── Storage 헬퍼 ────────────────────────────────────────────────────────────
 
 function buildResourcePath(sermonDate: string, originalName: string): string {
   const folder = formattedDate(sermonDate, 'YYYY/MM');
@@ -43,132 +40,78 @@ async function uploadResourceFiles(
   sermonDate: string
 ): Promise<{ resolved: SermonResourceInput[]; paths: string[] }> {
   const adminClient = createAdminServerClient();
-  const paths: string[] = [];
 
-  const resolved = await Promise.all(
-    resources.map(async (resource) => {
-      if (!resource.file) return resource;
+  // allSettled로 일괄 시도 → 부분 실패 시에도 성공한 모든 path를 정확히 수집하여 cleanup
+  const results = await Promise.allSettled(
+    resources.map(
+      async (
+        resource
+      ): Promise<{ resource: SermonResourceInput; path: string | null }> => {
+        if (!resource.file) return { resource, path: null };
 
-      const path = buildResourcePath(sermonDate, resource.name);
+        const path = buildResourcePath(sermonDate, resource.name);
 
-      const { error } = await adminClient.storage
-        .from(RESOURCE_BUCKET)
-        .upload(path, resource.file, { upsert: false });
+        const { error } = await adminClient.storage
+          .from(RESOURCE_BUCKET)
+          .upload(path, resource.file, { upsert: false });
 
-      if (error) throw error;
+        if (error) throw error;
 
-      paths.push(path);
-      const {
-        data: { publicUrl }
-      } = adminClient.storage.from(RESOURCE_BUCKET).getPublicUrl(path);
+        const {
+          data: { publicUrl }
+        } = adminClient.storage.from(RESOURCE_BUCKET).getPublicUrl(path);
 
-      const { file: _, ...rest } = resource;
-      return { ...rest, url: publicUrl };
-    })
+        const { file: _, ...rest } = resource;
+        return { resource: { ...rest, url: publicUrl }, path };
+      }
+    )
   );
 
-  return { resolved, paths };
-}
+  const resolved: SermonResourceInput[] = [];
+  const uploadedPaths: string[] = [];
+  let failure: unknown;
 
-async function rollbackUploads(resourcePaths?: string[]) {
-  if (resourcePaths && resourcePaths.length > 0) {
-    try {
-      const adminClient = createAdminServerClient();
-      await adminClient.storage.from(RESOURCE_BUCKET).remove(resourcePaths);
-    } catch (e) {
-      console.error('[rollback] Storage 리소스 삭제 실패', e);
-    }
-  }
-}
-
-// ─── DB 헬퍼 ─────────────────────────────────────────────────────────────────
-
-async function insertResourcesToDb(
-  supabase: Awaited<ReturnType<typeof createServerSideClient>>,
-  sermonId: number,
-  resources: SermonResourceInput[]
-) {
-  const rows: ResourceRow[] = resources
-    .filter((r) => r.url)
-    .map((r, index) => ({
-      id: r.id,
-      sermon_id: sermonId,
-      title: r.name,
-      file_url: r.url!,
-      file_type: r.fileType as ResourceRow['file_type'],
-      file_size_bytes: r.size,
-      sort_order: index + 1
-    }));
-
-  if (rows.length > 0) {
-    const { error } = await supabase.from('sermon_resources').insert(rows);
-    if (error) throw error;
-  }
-}
-
-async function syncResourcesToDb(
-  supabase: Awaited<ReturnType<typeof createServerSideClient>>,
-  sermonId: number,
-  resources: SermonResourceInput[]
-) {
-  const { data: existing, error: fetchError } = await supabase
-    .from('sermon_resources')
-    .select('id, file_url, sort_order')
-    .eq('sermon_id', sermonId)
-    .is('deleted_at', null);
-  if (fetchError) throw fetchError;
-
-  const existingRows = existing ?? [];
-  const formIds = new Set(resources.map((r) => r.id));
-
-  // 삭제 대상: DB에 있으나 폼에 없는 것 — 단일 패스로 id/경로 동시 수집
-  const toDelete: string[] = [];
-  const pathsToDelete: string[] = [];
-  for (const row of existingRows) {
-    if (formIds.has(row.id)) continue;
-    toDelete.push(row.id);
-    const path = extractStoragePath(row.file_url);
-    if (path) pathsToDelete.push(path);
-  }
-
-  if (toDelete.length > 0) {
-    const { error: deleteError } = await supabase
-      .from('sermon_resources')
-      .update({ deleted_at: new Date().toISOString() })
-      .in('id', toDelete);
-    if (deleteError) throw deleteError;
-
-    if (pathsToDelete.length > 0) {
-      try {
-        const adminClient = createAdminServerClient();
-        await adminClient.storage.from(RESOURCE_BUCKET).remove(pathsToDelete);
-      } catch (e) {
-        console.error('[sync] Storage 리소스 삭제 실패', e);
-      }
+  for (const r of results) {
+    if (r.status === 'fulfilled') {
+      resolved.push(r.value.resource);
+      if (r.value.path) uploadedPaths.push(r.value.path);
+    } else if (failure === undefined) {
+      failure = r.reason;
     }
   }
 
-  const existingIds = new Set(existingRows.map((r) => r.id));
-  const deletedIds = new Set(toDelete);
-  const maxSurvivingOrder = existingRows
-    .filter((r) => !deletedIds.has(r.id))
-    .reduce((max, r) => Math.max(max, r.sort_order ?? 0), 0);
-  const toInsert: ResourceRow[] = resources
-    .filter((r) => !existingIds.has(r.id) && r.url)
-    .map((r, index) => ({
-      id: r.id,
-      sermon_id: sermonId,
-      title: r.name,
-      file_url: r.url!,
-      file_type: r.fileType as ResourceRow['file_type'],
-      file_size_bytes: r.size,
-      sort_order: maxSurvivingOrder + index + 1
-    }));
-
-  if (toInsert.length > 0) {
-    const { error } = await supabase.from('sermon_resources').insert(toInsert);
-    if (error) throw error;
+  if (failure !== undefined) {
+    await removeStorageObjects(uploadedPaths);
+    throw failure;
   }
+
+  return { resolved, paths: uploadedPaths };
+}
+
+async function removeStorageObjects(paths: string[]) {
+  if (paths.length === 0) return;
+  try {
+    const adminClient = createAdminServerClient();
+    await adminClient.storage.from(RESOURCE_BUCKET).remove(paths);
+  } catch (e) {
+    console.error('[storage] 리소스 삭제 실패', e);
+  }
+}
+
+function pathsFromUrls(urls: string[]): string[] {
+  return urls.map(extractStoragePath).filter((p): p is string => p !== null);
+}
+
+// ─── 매핑 헬퍼 ────────────────────────────────────────────────────────────────
+
+function toRpcResource(resource: SermonResourceInput): SermonResourceRpcInput {
+  return {
+    id: resource.id,
+    title: resource.name,
+    file_url: resource.url!,
+    file_type: resource.fileType,
+    file_size_bytes: resource.size || null
+  };
 }
 
 // ─── Server Actions ───────────────────────────────────────────────────────────
@@ -192,24 +135,27 @@ export async function createSermonAction(
   let resourcePaths: string[] = [];
 
   try {
-    const { resolved: resolvedResources, paths } = await uploadResourceFiles(
+    const { resolved, paths } = await uploadResourceFiles(
       sermonFormData.resources,
       sermonFormData.sermonDate
     );
     resourcePaths = paths;
 
-    const supabase = await createServerSideClient();
-    const result = await sermonService(supabase).createSermon(mapFormToDbInsert(sermonFormData));
-    if (result.error) throw result.error;
-    if (!result.data) throw new Error('sermon insert returned no data');
+    const rpcResources = resolved.filter((r) => r.url).map(toRpcResource);
 
-    await insertResourcesToDb(supabase, result.data.id, resolvedResources);
+    const supabase = await createServerSideClient();
+    const result = await sermonService(supabase).createSermon(
+      mapFormToDbInsert(sermonFormData),
+      rpcResources
+    );
+    if (result.error) throw result.error;
+    if (!result.data) throw new Error('create_sermon RPC returned no data');
 
     updateTag('sermon');
     redirect(`/admin/sermons/${result.data.id}/edit`);
   } catch (error) {
     if (isRedirectError(error)) throw error;
-    await rollbackUploads(resourcePaths);
+    await removeStorageObjects(resourcePaths);
     console.error(error);
     return { success: false, message: '서버 오류가 발생했습니다.' };
   }
@@ -232,28 +178,40 @@ export async function updateSermonAction(
     return { success: false, message: '필수 항목(제목, 날짜, 설교자, 예배 종류)을 입력해주세요.' };
   }
 
-  let resourcePaths: string[] = [];
+  // 신규 업로드 대상(file 있는 것)과 기존 보존 대상(url만 있는 것)을 분리
+  const newCandidates = sermonFormData.resources.filter((r) => r.file);
+  const keepResourceIds = sermonFormData.resources
+    .filter((r) => !r.file && r.url)
+    .map((r) => r.id);
+
+  let newResourcePaths: string[] = [];
 
   try {
-    const { resolved: resolvedResources, paths } = await uploadResourceFiles(
-      sermonFormData.resources,
+    const { resolved, paths } = await uploadResourceFiles(
+      newCandidates,
       sermonFormData.sermonDate
     );
-    resourcePaths = paths;
+    newResourcePaths = paths;
+
+    const rpcNewResources = resolved.filter((r) => r.url).map(toRpcResource);
 
     const supabase = await createServerSideClient();
-    const updateResult = await sermonService(supabase).updateSermon(
+    const result = await sermonService(supabase).updateSermon(
       id,
-      mapFormToDbUpdate(sermonFormData)
+      mapFormToDbUpdate(sermonFormData),
+      keepResourceIds,
+      rpcNewResources
     );
-    if (updateResult.error) throw updateResult.error;
+    if (result.error) throw result.error;
 
-    await syncResourcesToDb(supabase, id, resolvedResources);
+    const payload = result.data as unknown as { sermon: unknown; deleted_urls: string[] } | null;
+    const deletedUrls = payload?.deleted_urls ?? [];
+    await removeStorageObjects(pathsFromUrls(deletedUrls));
 
     updateTag('sermon');
     return { success: true, message: '저장되었습니다.' };
   } catch (error) {
-    await rollbackUploads(resourcePaths);
+    await removeStorageObjects(newResourcePaths);
     console.error(error);
     return { success: false, message: '서버 오류가 발생했습니다.' };
   }
@@ -268,8 +226,11 @@ export async function deleteSermonAction(
 
   try {
     const supabase = await createServerSideClient();
-    const deleteResult = await sermonService(supabase).softDeleteSermon(id);
-    if (deleteResult.error) throw deleteResult.error;
+    const result = await sermonService(supabase).softDeleteSermon(id);
+    if (result.error) throw result.error;
+
+    const urls = result.data ?? [];
+    await removeStorageObjects(pathsFromUrls(urls));
 
     updateTag('sermon');
     redirect('/admin/sermons');

--- a/src/actions/sermon.action.ts
+++ b/src/actions/sermon.action.ts
@@ -8,10 +8,9 @@ import { createAdminServerClient } from '@/lib/supabase/admin';
 import { sermonService, type SermonResourceRpcInput } from '@/services/sermon/sermon-service';
 import { mapFormToDbInsert, mapFormToDbUpdate } from '@/lib/sermon-form-mapper';
 import { checkAdminPermission } from '@/actions/_auth-helpers';
+import { extractStoragePath, RESOURCE_BUCKET } from '@/lib/sermon-resource';
 import { formattedDate } from '@/utils/date';
 import type { SermonFormData, SermonResourceInput } from '@/types/sermon-form';
-
-const RESOURCE_BUCKET = 'sermon-resources';
 
 // ─── Storage 헬퍼 ────────────────────────────────────────────────────────────
 
@@ -26,13 +25,6 @@ function buildResourcePath(sermonDate: string, originalName: string): string {
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '') || 'file';
   return `${folder}/${sanitized}-${Date.now()}.${ext}`;
-}
-
-function extractStoragePath(fileUrl: string): string | null {
-  const marker = `/public/${RESOURCE_BUCKET}/`;
-  const idx = fileUrl.indexOf(marker);
-  if (idx === -1) return null;
-  return decodeURIComponent(fileUrl.substring(idx + marker.length));
 }
 
 async function uploadResourceFiles(

--- a/src/app/(admin)/admin/sermons/_components/SermonFormShell.tsx
+++ b/src/app/(admin)/admin/sermons/_components/SermonFormShell.tsx
@@ -57,10 +57,10 @@ export default function SermonFormShell({
   const handlePublish = () => {
     startTransition(async () => {
       if (mode === 'new') {
-        const result = await createSermonAction({ ...formData, isPublished: true });
+        const result = await createSermonAction(formData);
         if (result && !result.success) toast.error(result.message);
       } else if (sermonId) {
-        const result = await updateSermonAction(sermonId, { ...formData, isPublished: true });
+        const result = await updateSermonAction(sermonId, formData);
         if (result.success) {
           setIsDirty(false);
           router.push(`/admin/sermons/${sermonId}/edit`);
@@ -71,7 +71,11 @@ export default function SermonFormShell({
     });
   };
 
-  const publishLabel = mode === 'new' ? '발행' : '수정 저장';
+  const publishLabel = formData.isPublished
+    ? mode === 'new'
+      ? '발행'
+      : '발행 저장'
+    : '초안 저장';
   const description =
     mode === 'new'
       ? '영상, 본문, 자료를 입력하고 발행하세요'

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,6 +1,11 @@
 import { PropsWithChildren } from 'react';
+import { redirect } from 'next/navigation';
+import { checkAdminPermission } from '@/actions/_auth-helpers';
 import AdminLayout from '@/components/admin/layout/AdminLayout';
 
-export default function Layout({ children }: PropsWithChildren) {
+export default async function Layout({ children }: PropsWithChildren) {
+  const { isAdmin } = await checkAdminPermission();
+  if (!isAdmin) redirect('/');
+
   return <AdminLayout>{children}</AdminLayout>;
 }

--- a/src/components/admin/sermons/SermonForm/index.module.scss
+++ b/src/components/admin/sermons/SermonForm/index.module.scss
@@ -371,6 +371,35 @@
 }
 
 // PublishCard — 공개 상태 토글 (초안 / 발행 세그먼티드 컨트롤).
+.fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  min-inline-size: 0;
+}
+
+.legend {
+  padding: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--admin-t1);
+}
+
+.sr_only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .toggle_row {
   display: flex;
   gap: 4px;

--- a/src/components/admin/sermons/SermonForm/primitives/Field.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Field.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { createContext, useContext, useId, ReactNode } from 'react';
 import styles from './Field.module.scss';
 
 interface FieldProps {
@@ -11,6 +11,18 @@ interface FieldProps {
   children: ReactNode;
 }
 
+interface FieldContextValue {
+  id: string;
+  hintId?: string;
+  required: boolean;
+}
+
+const FieldContext = createContext<FieldContextValue | null>(null);
+
+export function useFieldContext() {
+  return useContext(FieldContext);
+}
+
 export default function Field({
   label,
   required,
@@ -19,28 +31,36 @@ export default function Field({
   counter,
   children
 }: FieldProps) {
+  const id = useId();
+  const hintId = hint ? `${id}-hint` : undefined;
   const optionalLabel = typeof optional === 'string' ? optional : optional ? '선택' : null;
 
   return (
-    <div className={styles.field}>
-      <div className={styles.label_row}>
-        <span className={styles.label}>
-          {label}
-          {required && (
-            <span className={styles.required} aria-hidden>
-              *
-            </span>
-          )}
-        </span>
-        {optionalLabel && <span className={styles.optional}>{optionalLabel}</span>}
-      </div>
-      {children}
-      {(hint || counter) && (
-        <div className={styles.foot}>
-          {hint && <span className={styles.hint}>{hint}</span>}
-          {counter && <span className={styles.counter}>{counter}</span>}
+    <FieldContext.Provider value={{ id, hintId, required: !!required }}>
+      <div className={styles.field}>
+        <div className={styles.label_row}>
+          <label htmlFor={id} className={styles.label}>
+            {label}
+            {required && (
+              <span className={styles.required} aria-hidden>
+                *
+              </span>
+            )}
+          </label>
+          {optionalLabel && <span className={styles.optional}>{optionalLabel}</span>}
         </div>
-      )}
-    </div>
+        {children}
+        {(hint || counter) && (
+          <div className={styles.foot}>
+            {hint && (
+              <span id={hintId} className={styles.hint}>
+                {hint}
+              </span>
+            )}
+            {counter && <span className={styles.counter}>{counter}</span>}
+          </div>
+        )}
+      </div>
+    </FieldContext.Provider>
   );
 }

--- a/src/components/admin/sermons/SermonForm/primitives/Input.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Input.tsx
@@ -1,9 +1,25 @@
 import { InputHTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { useFieldContext } from './Field';
 import styles from './primitives.module.scss';
 
 type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
-export default function Input({ className, ...rest }: InputProps) {
-  return <input className={clsx(styles.control, className)} {...rest} />;
+export default function Input({
+  id,
+  'aria-required': ariaRequired,
+  'aria-describedby': ariaDescribedBy,
+  className,
+  ...rest
+}: InputProps) {
+  const ctx = useFieldContext();
+  return (
+    <input
+      id={id ?? ctx?.id}
+      aria-required={ariaRequired ?? (ctx?.required || undefined)}
+      aria-describedby={ariaDescribedBy ?? ctx?.hintId}
+      className={clsx(styles.control, className)}
+      {...rest}
+    />
+  );
 }

--- a/src/components/admin/sermons/SermonForm/primitives/InputGroup.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/InputGroup.tsx
@@ -1,15 +1,29 @@
 import { InputHTMLAttributes, ReactNode } from 'react';
+import { useFieldContext } from './Field';
 import styles from './primitives.module.scss';
 
 interface InputGroupProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'prefix'> {
   prefix: ReactNode;
 }
 
-export default function InputGroup({ prefix, ...rest }: InputGroupProps) {
+export default function InputGroup({
+  id,
+  'aria-required': ariaRequired,
+  'aria-describedby': ariaDescribedBy,
+  prefix,
+  ...rest
+}: InputGroupProps) {
+  const ctx = useFieldContext();
   return (
     <div className={styles.group}>
       <span className={styles.prefix}>{prefix}</span>
-      <input className={styles.control} {...rest} />
+      <input
+        id={id ?? ctx?.id}
+        aria-required={ariaRequired ?? (ctx?.required || undefined)}
+        aria-describedby={ariaDescribedBy ?? ctx?.hintId}
+        className={styles.control}
+        {...rest}
+      />
     </div>
   );
 }

--- a/src/components/admin/sermons/SermonForm/primitives/Select.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Select.tsx
@@ -1,12 +1,27 @@
 import { SelectHTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { useFieldContext } from './Field';
 import styles from './primitives.module.scss';
 
 type SelectProps = SelectHTMLAttributes<HTMLSelectElement>;
 
-export default function Select({ className, children, ...rest }: SelectProps) {
+export default function Select({
+  id,
+  'aria-required': ariaRequired,
+  'aria-describedby': ariaDescribedBy,
+  className,
+  children,
+  ...rest
+}: SelectProps) {
+  const ctx = useFieldContext();
   return (
-    <select className={clsx(styles.control, styles.select, className)} {...rest}>
+    <select
+      id={id ?? ctx?.id}
+      aria-required={ariaRequired ?? (ctx?.required || undefined)}
+      aria-describedby={ariaDescribedBy ?? ctx?.hintId}
+      className={clsx(styles.control, styles.select, className)}
+      {...rest}
+    >
       {children}
     </select>
   );

--- a/src/components/admin/sermons/SermonForm/primitives/Textarea.tsx
+++ b/src/components/admin/sermons/SermonForm/primitives/Textarea.tsx
@@ -1,14 +1,26 @@
 import { TextareaHTMLAttributes } from 'react';
 import clsx from 'clsx';
+import { useFieldContext } from './Field';
 import styles from './primitives.module.scss';
 
 interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
   tall?: boolean;
 }
 
-export default function Textarea({ tall, className, ...rest }: TextareaProps) {
+export default function Textarea({
+  id,
+  'aria-required': ariaRequired,
+  'aria-describedby': ariaDescribedBy,
+  tall,
+  className,
+  ...rest
+}: TextareaProps) {
+  const ctx = useFieldContext();
   return (
     <textarea
+      id={id ?? ctx?.id}
+      aria-required={ariaRequired ?? (ctx?.required || undefined)}
+      aria-describedby={ariaDescribedBy ?? ctx?.hintId}
       className={clsx(styles.control, styles.textarea, tall && styles.tall, className)}
       {...rest}
     />

--- a/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
+++ b/src/components/admin/sermons/SermonForm/sections/PublishCard.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import Field from '../primitives/Field';
 import type { PublishCardProps } from '@/types/sermon-form';
 import styles from '../index.module.scss';
 
@@ -14,26 +13,33 @@ export default function PublishCard({ isPublished, onChange }: PublishCardProps)
         </div>
       </header>
       <div className={styles.card_body}>
-        <Field label="공개 상태">
+        <fieldset className={styles.fieldset}>
+          <legend className={styles.legend}>공개 상태</legend>
           <div className={styles.toggle_row}>
-            <button
-              type="button"
-              className={clsx(styles.toggle, !isPublished && styles.on)}
-              onClick={() => onChange({ isPublished: false })}
-            >
+            <label className={clsx(styles.toggle, !isPublished && styles.on)}>
+              <input
+                type="radio"
+                name="isPublished"
+                className={styles.sr_only}
+                checked={!isPublished}
+                onChange={() => onChange({ isPublished: false })}
+              />
               <span className={styles.main}>초안</span>
               <span className={styles.sub}>비공개</span>
-            </button>
-            <button
-              type="button"
-              className={clsx(styles.toggle, isPublished && styles.on)}
-              onClick={() => onChange({ isPublished: true })}
-            >
+            </label>
+            <label className={clsx(styles.toggle, isPublished && styles.on)}>
+              <input
+                type="radio"
+                name="isPublished"
+                className={styles.sr_only}
+                checked={isPublished}
+                onChange={() => onChange({ isPublished: true })}
+              />
               <span className={styles.main}>발행</span>
               <span className={styles.sub}>공개</span>
-            </button>
+            </label>
           </div>
-        </Field>
+        </fieldset>
         <div className={styles.warn_box}>
           발행하려면 제목, 날짜, 설교자, 영상 연결이 필요합니다
         </div>

--- a/src/lib/sermon-resource.ts
+++ b/src/lib/sermon-resource.ts
@@ -2,6 +2,8 @@ import type { SermonResourceType } from '@/types/sermon-form';
 
 export const MAX_RESOURCE_BYTES = 50 * 1024 * 1024;
 
+export const RESOURCE_BUCKET = 'sermon-resources';
+
 const EXT_MAP: Record<string, SermonResourceType> = {
   pdf: 'pdf',
   hwp: 'hwp',
@@ -25,4 +27,16 @@ export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+}
+
+/**
+ * 공개 URL(`getPublicUrl` 결과)에서 storage 내부 path를 추출한다.
+ * bucket이 private으로 전환된 후에도 file_url 컬럼은 동일 포맷을 유지하므로
+ * signed URL 발급 시 path 추출용으로 사용.
+ */
+export function extractStoragePath(fileUrl: string): string | null {
+  const marker = `/public/${RESOURCE_BUCKET}/`;
+  const idx = fileUrl.indexOf(marker);
+  if (idx === -1) return null;
+  return decodeURIComponent(fileUrl.substring(idx + marker.length));
 }

--- a/src/lib/sermon-slug.ts
+++ b/src/lib/sermon-slug.ts
@@ -1,6 +1,3 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Database } from '@/types/database.types';
-
 function slugify(text: string): string {
   return text
     .trim()
@@ -13,29 +10,4 @@ function slugify(text: string): string {
 
 export function buildBaseSlug(sermonDate: string, title: string): string {
   return `${sermonDate}-${slugify(title)}`;
-}
-
-export async function ensureUniqueSlug(
-  base: string,
-  supabase: SupabaseClient<Database>,
-  excludeId?: number
-): Promise<string> {
-  let slug = base;
-  let counter = 2;
-
-  while (true) {
-    let query = supabase.from('sermons').select('id').eq('slug', slug).maybeSingle();
-    if (excludeId) {
-      query = supabase
-        .from('sermons')
-        .select('id')
-        .eq('slug', slug)
-        .neq('id', excludeId)
-        .maybeSingle();
-    }
-    const { data, error } = await query;
-    if (error) throw error;
-    if (!data) return slug;
-    slug = `${base}-${counter++}`;
-  }
 }

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -14,9 +14,11 @@ export async function updateSession(request: NextRequest) {
   const isAuthPage = (path: string) => {
     const exactMatches = ['/mypage', '/news/bulletins/create'];
     const dynamicPattern = /^\/news\/bulletins\/[^/]+\/update$/;
+    const adminPattern = /^\/admin(\/|$)/;
 
     if (exactMatches.includes(path)) return true;
     if (dynamicPattern.test(path)) return true;
+    if (adminPattern.test(path)) return true;
     return false;
   };
 

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -1,5 +1,5 @@
 import { handleResponse } from '@/services/handle-response';
-import { buildBaseSlug, ensureUniqueSlug } from '@/lib/sermon-slug';
+import { buildBaseSlug } from '@/lib/sermon-slug';
 import type { SermonDbInsert, SermonDbUpdate } from '@/lib/sermon-form-mapper';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database.types';
@@ -10,6 +10,15 @@ import type {
   SeriesWithSermonCount,
   YearCount
 } from '@/types/sermon';
+
+/** RPC create_sermon / update_sermon에 전달하는 리소스 행 형식 */
+export type SermonResourceRpcInput = {
+  id: string;
+  title: string;
+  file_url: string;
+  file_type: Database['public']['Enums']['sermon_resource_type'];
+  file_size_bytes: number | null;
+};
 
 const SERMON_WITH_RELATIONS_SELECT = `
   *,
@@ -200,55 +209,40 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
     });
   },
 
-  /** [어드민] 설교 생성 — slug·series_order 서버 자동 계산 */
-  createSermon: async (insert: Omit<SermonDbInsert, 'slug' | 'series_order'>) => {
-    const slug = await ensureUniqueSlug(
-      buildBaseSlug(insert.sermon_date, insert.title),
-      supabase
-    );
-
-    let series_order: number | null = null;
-    if (insert.series_id) {
-      const { count, error: countError } = await supabase
-        .from('sermons')
-        .select('id', { count: 'exact', head: true })
-        .eq('series_id', insert.series_id)
-        .is('deleted_at', null);
-      if (countError) throw countError;
-      series_order = (count ?? 0) + 1;
-    }
-
-    const insertResponse = await supabase
-      .from('sermons')
-      .insert({ ...insert, slug, series_order })
-      .select('id, slug')
-      .single();
-
-    return handleResponse(insertResponse);
-  },
-
-  /** [어드민] 설교 수정 */
-  updateSermon: async (
-    id: number,
-    update: Omit<SermonDbUpdate, 'slug' | 'series_order' | 'id' | 'created_at'>
+  /** [어드민] 설교 생성 — RPC create_sermon으로 sermon + resources 원자 INSERT */
+  createSermon: async (
+    insert: Omit<SermonDbInsert, 'slug' | 'series_order'>,
+    resources: SermonResourceRpcInput[]
   ) => {
+    const payload = {
+      ...insert,
+      base_slug: buildBaseSlug(insert.sermon_date, insert.title)
+    };
     const res = await supabase
-      .from('sermons')
-      .update(update)
-      .eq('id', id)
-      .select('id')
-      .single();
-
+      .rpc('create_sermon', { p_payload: payload, p_resources: resources })
+      .maybeSingle();
     return handleResponse(res);
   },
 
-  /** [어드민] 설교 소프트 삭제 */
-  softDeleteSermon: async (id: number) => {
-    const res = await supabase
-      .from('sermons')
-      .update({ deleted_at: new Date().toISOString() })
-      .eq('id', id);
+  /** [어드민] 설교 수정 — RPC update_sermon으로 sermon + resources sync 원자 처리 */
+  updateSermon: async (
+    id: number,
+    update: Omit<SermonDbUpdate, 'slug' | 'series_order' | 'id' | 'created_at'>,
+    keepResourceIds: string[],
+    newResources: SermonResourceRpcInput[]
+  ) => {
+    const res = await supabase.rpc('update_sermon', {
+      p_id: id,
+      p_payload: update,
+      p_keep_resource_ids: keepResourceIds,
+      p_new_resources: newResources
+    });
+    return handleResponse(res);
+  },
 
+  /** [어드민] 설교 소프트 삭제 — RPC delete_sermon이 삭제할 storage URL 배열을 반환 */
+  softDeleteSermon: async (id: number) => {
+    const res = await supabase.rpc('delete_sermon', { p_id: id });
     return handleResponse(res);
   },
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -513,6 +513,38 @@ export type Database = {
           isSetofReturn: true
         }
       }
+      create_sermon: {
+        Args: { p_payload: Json; p_resources?: Json }
+        Returns: {
+          created_at: string
+          deleted_at: string | null
+          duration: string | null
+          id: number
+          is_published: boolean
+          preacher_id: string
+          scripture: string | null
+          scripture_text: string | null
+          series_id: string | null
+          series_order: number | null
+          sermon_date: string
+          service_type: Database["public"]["Enums"]["service_type_enum"]
+          slug: string
+          summary: string | null
+          thumbnail_url: string | null
+          title: string
+          updated_at: string
+          video_id: string | null
+          video_provider: string
+          view_count: number
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "sermons"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      delete_sermon: { Args: { p_id: number }; Returns: string[] }
       get_adjacent_bulletins: {
         Args: { target_id: number }
         Returns: {
@@ -560,6 +592,15 @@ export type Database = {
           isOneToOne: false
           isSetofReturn: true
         }
+      }
+      update_sermon: {
+        Args: {
+          p_id: number
+          p_keep_resource_ids?: string[]
+          p_new_resources?: Json
+          p_payload: Json
+        }
+        Returns: Json
       }
     }
     Enums: {


### PR DESCRIPTION
## 📋 개요 (Summary)

[admin-sermon-review.md](https://github.com/user-attachments/files/27114678/admin-sermon-review.md)에서 식별된 P0 5건을 일괄 처리 — admin 가드, 발행 토글 버그, 트랜잭션 일관성, 폼 a11y에 더해 권한 체크 성능 개선과 후속 작업을 위한 코드 정리까지 포함.


<br/>

## 💡 변경 배경 (Motivation)

- 설교 등록/관리(admin) 모듈에 대한 코드 리뷰 결과 페이지 진입 권한 부재, 설교 등록 시 부분 실패에 따른 데이터 정합성 깨짐, 폼 접근성 부재 등 운영·보안 측면 P0 결함이 다수 식별됨
- 이 결함들이 함께 누적되면 admin 영역의 신뢰성·운영 안정성·법적 컴플라이언스(접근성)에 일관된 위험을 만들기 때문에 한 PR로 묶어 처리.

**해결하려는 문제:**

| 검토 항목 | 분류 | 한 줄 요약 |
|---|---|---|
| 1-1 | 보안 | `/admin/*`이 페이지 진입 단계 권한 체크 없이 데이터 prefetch까지 진행됨 |
| 1-2 | 기능 결함 | PublishCard "초안" 토글이 사용자 선택을 무시하고 항상 `is_published=true`로 저장 |
| 1-7 | 데이터 무결성 | 설교 CUD 흐름이 비원자라 부분 실패 시 sermon/resources/storage가 영구 불일치 |
| 4-1 | 접근성 | `Field` primitive가 `<label htmlFor>` 없이 `<span>`만 → 스크린리더가 라벨-입력 매핑 불가 |
| 4-3 | 접근성 | PublishCard 토글이 일반 `<button>` 두 개 → 선택 상태/키보드 화살표 이동 미지원 |
| (성능) | 구조 | admin 페이지 진입당 `profiles.role` DB 조회 영구 발생 → JWT claim으로 영구 제거 |
| 3-8 | 정리 | bucket 상수/헬퍼가 action 파일 안에 묶여 후속 PR에서 재사용 불가 |

<br/>

## 🔧 주요 변경점 (Key Changes)

 | 분류 | 내용 |
|---|---|
| Feat | proxy `isAuthPage`에 `/admin/*` 추가 + `(admin)/layout.tsx`를 async 서버 컴포넌트로 변환해 `checkAdminPermission()` 적용 |
| Fix | `SermonFormShell.handlePublish`의 `isPublished:true` 강제 오버라이드 제거, `publishLabel`을 `formData.isPublished`+mode 기반 동적 계산 |
| Refactor | Postgres `custom_access_token_hook`으로 `profiles.role`을 JWT `app_metadata.role`에 주입, `checkAdminPermission`이 claim을 우선 읽고 DB 조회는 fallback |
| Refactor | `create_sermon`/`update_sermon`/`delete_sermon` RPC 3종 도입 — sermon + sermon_resources를 단일 트랜잭션으로 처리, 슬러그 충돌 retry, RPC 본문에서 `auth.uid()` 기반 admin 검증, `uploadResourceFiles` 부분 실패 race 수정 |
| Refactor | `Field`에 `useId()` + `FieldContext` 도입(span→label htmlFor), Input/Textarea/Select/InputGroup이 Context 자동 적용, PublishCard를 fieldset+legend+native radio로 재구조화 |
| Refactor | `RESOURCE_BUCKET` 상수와 `extractStoragePath` 함수를 `src/lib/sermon-resource.ts`로 이동 |

<br/>

## 🏗️ 설계 결정 사항 (Design Decisions)

| 고려한 대안 | 선택한 방법 | 선택 이유 |
|---|---|---|
| Edge proxy에서 admin role 체크 | **Server-component layout에서 체크** | proxy는 모든 매칭 경로에서 실행 — DB 쿼리 추가는 Edge 비용↑ + Supabase 권장 안 함. layout은 admin 영역에만 비용 발생, `checkAdminPermission` 재사용 가능. **proxy=인증 / layout=인가** 책임 분리 |
| 매번 DB 조회 / React `cache()` dedupe / 쿠키 박제 | **JWT Custom Access Token Hook** | Supabase 공식 권장 RBAC 패턴. 토큰 발급 시점 1회만 DB 조회, 이후 모든 권한 체크가 JWT 디코딩으로 완결 → `profiles.role` 조회 영구 제거 |
| Saga 패턴(TS 보상 트랜잭션) / 부분 RPC | **RPC 전면 도입 (bulletin 패턴 차용)** | 진정한 DB 트랜잭션 원자성. 기존 `create_bulletin` 코드 패턴과 일관 → 학습 비용 0. slug 충돌 retry까지 함수 안에서 처리 가능 |
| `cloneElement`로 children에 id 주입 / 호출자가 매번 id 주입 | **`useId()` + `FieldContext`** | 호출자 코드 변경 0. children 단일 element 강제 없음. 명시 props가 항상 우선이라 escape hatch 보장 |
| `<button>` + `aria-pressed` / `role="radio"` + `aria-checked` | **native `<input type="radio">` + label 래핑** | 키보드 화살표 이동/SR announce 무료. 시각 디자인은 label에 그대로 적용해 회귀 0 |
| Storage 작업도 트랜잭션에 포함하려 시도 | **DB만 원자, storage는 best-effort cleanup** | Storage는 외부 서비스라 트랜잭션 불가. "DB는 항상 정합 상태, storage orphan은 허용" 원칙으로 정합성 우선순위를 명확히 |

> ⚠️ **트레이드오프:**
>
> - **JWT claim 도입 → role 변경 stale**: JWT 만료(1시간)까지는 권한 변경이 즉시 반영 안 됨. admin 권한 부여/회수 같은 민감 작업은 강제 재로그인(`auth.admin.signOut`) 안내 필요. 현재 admin role 변경 UI가 없어 운영상 영향 없음
> - **JWT claim fallback 코드**: 운영 hook 적용 직전 토큰 호환성을 위해 `_auth-helpers.ts`에 DB 조회 fallback 분기를 남김. 1~2주 후 PR 1.6에서 제거 예정
> - **Storage orphan 허용**: best-effort cleanup이 실패하면 storage 파일이 남음. 별도 cleanup job(주기 작업) 필요 — 후속 과제로 분류

<br/>

## 📊 다이어그램 (Diagrams)

### Admin 권한 가드 — 2단 방어

```mermaid
flowchart LR
    A[클라이언트: /admin/sermons/new 진입] --> B{proxy: isAuthPage 매치}
    B -- /admin/* --> C{세션 존재?}
    C -- 없음 --> D[/login?redirect=... 302/]
    C -- 있음 --> E[layout: async server component]
    E --> F[checkAdminPermission]
    F --> G{role == admin?}
    G -- No --> H[/ 302/]
    G -- Yes --> I[자식 page.tsx 렌더 + 데이터 fetch]
```

### JWT Custom Access Token Hook 흐름

```mermaid
sequenceDiagram
    participant U as User
    participant G as GoTrue
    participant P as Postgres
    participant App as Next.js App

    U->>G: 로그인 / refresh
    G->>P: SELECT custom_access_token_hook(event)
    P->>P: profiles.role 조회 → claims에 주입
    P-->>G: 수정된 event 반환
    G-->>U: JWT 서명 (app_metadata.role 박힘)

    Note over U,App: 이후 모든 admin 페이지 진입
    U->>App: GET /admin/sermons
    App->>App: auth.getUser() → JWT 디코딩만
    App-->>U: page render (DB 조회 없이 role 확인 완료)
```

### 설교 CUD 트랜잭션 — RPC + 앱 시퀀싱

```mermaid
flowchart LR
    A[createSermonAction 호출] --> B[Storage: 파일 일괄 업로드]
    B --> C{모두 성공?}
    C -- No --> D[uploaded paths cleanup → throw]
    C -- Yes --> E[RPC create_sermon]
    E --> F{원자적 INSERT}
    F --> G[sermon row INSERT<br/>+ slug retry 루프]
    G --> H[sermon_resources INSERT]
    H -- 어디서든 실패 --> I[전체 ROLLBACK]
    I --> J[catch: storage cleanup]
    H -- 성공 --> K[updateTag + redirect]

    style F fill:#e1f5e1
    style I fill:#ffe1e1
```

---

## ✅ 검증 결과 (Verification)

**수행한 테스트:**

- [ ] 단위 테스트 (Unit Test) — 프로젝트에 테스트 환경 없음
- [ ] 통합 테스트 (Integration Test) — 동일 사유
- [x] 수동 테스트 (Manual Test)

**자동 검증:**

- 모든 커밋 후 `yarn build` 통과 (TypeScript + Next.js 빌드)
- `yarn generate:types`로 RPC 타입 동기화 완료

**수동 검증 시나리오:**

| 시나리오 | 기대 결과 | 결과 |
|---|---|---|
| 로그아웃 상태 + `/admin/sermons/new` 접근 | `/login?redirect=...`로 리다이렉트 | ✅ |
| 일반 유저(role≠admin) + `/admin/sermons/new` 접근 | `/`로 리다이렉트 | ✅ |
| Admin + `/admin/sermons/new` 정상 진입 | 페이지 렌더 + 데이터 fetch | ✅ |
| PublishCard "초안" 선택 + 저장 | `is_published=false` 저장, 라벨 "초안 저장" | ✅ |
| 동일 제목+날짜로 두 번 연속 등록 | 둘 다 성공, 두 번째는 slug에 `-2` | ✅ (RPC retry) |
| 자료 있는 설교 삭제 | sermons + sermon_resources 모두 soft-delete + storage 파일 제거 | ✅ |
| 폼 진입 후 Tab 이동 | 라벨이 보조기술에 announce | ✅ |
| PublishCard 화살표 키 이동 | 두 라디오 사이 이동 + 선택 상태 announce | ✅ |
| `app_metadata.role: 'admin'` JWT 디코딩 | jwt.io에서 claim 확인 | ✅ |

**테스트 결과 / 스크린샷:**

UI 시각 회귀 없음 — `Field`/PublishCard 변경은 시맨틱만 강화하고 디자인은 동일하게 유지. (Before/After 스크린샷 동일하므로 생략)

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 원래 요구사항을 충족하는가? (검토 문서 P0 5건 모두 처리)
- [x] Null, 빈 배열 등 엣지 케이스를 처리했는가? (RPC 안의 `IF NOT FOUND`, 빈 resources 배열 가드, fallback 분기 등)

**코드 품질**

- [x] 변수명·함수명이 의도를 명확히 드러내는가?
- [x] 복잡한 로직에 설명 주석을 추가했는가? (RPC slug retry 패턴, FieldContext 의도, fallback 분기 이유 등)
- [x] 불필요한 코드나 디버그 로그를 제거했는가? (dead helper 167줄 제거)

**보안 및 견고성**

- [x] 하드코딩된 비밀값(토큰, 비밀번호)이 없는가?
- [x] 사용자 입력값이 적절히 검증되는가? (admin 가드 + RPC 본문 admin 재검증으로 defense-in-depth) — 단, 파일 입력 검증은 후속 PR에서 처리(검토 문서 1-3, 1-4)

**성능**

- [x] 불필요한 반복 연산이나 리소스 낭비가 없는가?
- [x] DB 쿼리가 효율적인가? (JWT claim 도입으로 admin 진입당 쿼리 1건 영구 제거. RPC로 다중 쿼리를 단일 round-trip에 통합)

**테스트 및 문서화**

- [ ] 새 기능에 대한 테스트를 추가했는가? (프로젝트 테스트 환경 부재, 수동 검증으로 대체)
- [x] README 또는 API 문서에 변경 사항을 반영했는가? (이 PR 문서)
- [x] 커밋 메시지가 Conventional Commits 규격을 따르는가? (`Feat`, `Fix`, `Refactor` — 프로젝트 6종 prefix 준수)

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

**다음에 건드릴 때 주의할 점**

- **파일 sanitize + 서버 측 재검증. 별도 PR로 진행 예정
- (보류) bucket private 전환 + signed URL. ISR 캐시(24h)와 signed URL 만료의 충돌을 proxy route 패턴으로 풀기로 했으나 운영 영향이 커서 별도 검토 후 진행
- **Storage orphan cleanup job**: best-effort 정책의 보완책. RPC가 반환한 deleted_urls 제거가 실패하면 storage에 orphan 잔존 → 주기 cleanup 필요
- **Admin role 변경 UI 추가 시점**: JWT claim stale 이슈가 본격화 → `auth.admin.signOut(userId, 'global')` 호출로 강제 재로그인을 같이 도입해야 함
