### PR TITLE
[Feat] 어드민 설교 관리 목록 페이지 UI 구현 

### DIFF
--- a/src/app/(admin)/admin/sermons/page.tsx
+++ b/src/app/(admin)/admin/sermons/page.tsx
@@ -1,0 +1,5 @@
+import SermonListPage from '@/components/admin/sermons/SermonListPage';
+
+export default function SermonAdminListPage() {
+  return <SermonListPage />;
+}

--- a/src/components/admin/sermons/SermonListPage/dropdown.module.scss
+++ b/src/components/admin/sermons/SermonListPage/dropdown.module.scss
@@ -1,0 +1,210 @@
+.dropdown {
+  position: relative;
+}
+
+.filter_trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 8px 12px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  color: var(--admin-t2);
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    border-color 0.15s var(--admin-ease),
+    background 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover {
+    border-color: var(--admin-bd-s);
+    color: var(--admin-t1);
+  }
+}
+
+.filter_active {
+  border-color: var(--admin-accent);
+  background: var(--admin-accent-bg);
+  color: var(--admin-accent);
+  font-weight: 600;
+
+  &:hover {
+    border-color: var(--admin-accent);
+    color: var(--admin-accent);
+  }
+}
+
+.filter_count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1px 6px;
+  background: var(--admin-accent);
+  border-radius: 100px;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.dropdown_panel {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 40;
+  min-width: 240px;
+  max-width: 300px;
+  padding: 12px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 8px;
+  box-shadow: 0 8px 28px rgba(15, 20, 30, 0.09);
+  animation: dropdown_in 0.15s var(--admin-ease);
+}
+
+@keyframes dropdown_in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.dropdown_title {
+  margin: 0 0 8px;
+  color: var(--admin-t3);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.dropdown_list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.dropdown_item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: none;
+  color: var(--admin-t2);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    background 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover {
+    background: var(--admin-bg-w);
+    color: var(--admin-t1);
+  }
+}
+
+.dropdown_item_active {
+  background: var(--admin-accent-bg);
+  color: var(--admin-accent);
+  font-weight: 600;
+
+  &:hover {
+    background: var(--admin-accent-bg);
+    color: var(--admin-accent);
+  }
+}
+
+.dropdown_item_label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  border: 1.5px solid var(--admin-bd-s);
+  border-radius: 3px;
+  color: transparent;
+  font-size: 10px;
+  transition:
+    background 0.15s var(--admin-ease),
+    border-color 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+}
+
+.checkbox_checked {
+  background: var(--admin-accent);
+  border-color: var(--admin-accent);
+  color: #fff;
+}
+
+.item_count {
+  margin-left: auto;
+  color: var(--admin-t3);
+  font-size: 10px;
+
+  .dropdown_item_active & {
+    color: var(--admin-accent);
+  }
+}
+
+.date_row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--admin-t3);
+  font-size: 12px;
+}
+
+.date_input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 10px;
+  border: 1px solid var(--admin-bd);
+  border-radius: 5px;
+  background: var(--admin-bg-card);
+  color: var(--admin-t1);
+  font-size: 12px;
+  transition:
+    border-color 0.15s var(--admin-ease),
+    box-shadow 0.15s var(--admin-ease);
+
+  &:focus {
+    outline: none;
+    border-color: var(--admin-accent);
+    box-shadow: 0 0 0 3px var(--admin-accent-bg);
+  }
+}
+
+.date_clear {
+  margin-top: 8px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--admin-accent);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/src/components/admin/sermons/SermonListPage/index.module.scss
+++ b/src/components/admin/sermons/SermonListPage/index.module.scss
@@ -1,0 +1,18 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 1600px;
+  margin: 16px auto 0;
+}
+
+.placeholder {
+  margin: 0;
+  padding: 56px 20px;
+  text-align: center;
+  color: var(--admin-t3);
+  font-size: 13px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 10px;
+}

--- a/src/components/admin/sermons/SermonListPage/index.module.scss
+++ b/src/components/admin/sermons/SermonListPage/index.module.scss
@@ -16,3 +16,228 @@
   border: 1px solid var(--admin-bd);
   border-radius: 10px;
 }
+
+.status_tabs {
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--admin-t2);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    background 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover {
+    background: var(--admin-bg-w);
+    color: var(--admin-t1);
+  }
+}
+
+.tab_active {
+  background: var(--admin-bg-w);
+  color: var(--admin-t1);
+  font-weight: 600;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--admin-t3);
+
+  &.published {
+    background: var(--admin-ok);
+  }
+
+  &.draft {
+    background: var(--admin-t3);
+  }
+
+  &.scheduled {
+    background: var(--admin-accent);
+  }
+}
+
+.count {
+  padding: 1px 8px;
+  border-radius: 100px;
+  background: var(--admin-bg-w);
+  color: var(--admin-t3);
+  font-size: 11px;
+  font-weight: 600;
+
+  .tab_active & {
+    background: var(--admin-pri);
+    color: #fff;
+  }
+}
+
+.active_filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--admin-accent-bg);
+  border: 1px solid color-mix(in srgb, var(--admin-accent), transparent 80%);
+  border-radius: 6px;
+}
+
+.pill_list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.active_label {
+  color: var(--admin-accent);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 4px 3px 10px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 100px;
+  color: var(--admin-t2);
+  font-size: 11.5px;
+  font-weight: 500;
+}
+
+.pill_remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: none;
+  color: var(--admin-t3);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    background 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover {
+    background: var(--admin-bg-w);
+    color: var(--admin-err);
+  }
+}
+
+.clear_all {
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--admin-accent);
+  font-size: 11.5px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.search_box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 240px;
+  max-width: 420px;
+  padding: 8px 12px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 6px;
+  transition:
+    border-color 0.15s var(--admin-ease),
+    box-shadow 0.15s var(--admin-ease);
+
+  &:focus-within {
+    border-color: var(--admin-accent);
+    box-shadow: 0 0 0 3px var(--admin-accent-bg);
+  }
+}
+
+.search_icon {
+  flex-shrink: 0;
+  color: var(--admin-t3);
+  font-size: 16px;
+}
+
+.search_input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  outline: none;
+  background: none;
+  color: var(--admin-t1);
+  font-size: 13px;
+
+  &::placeholder {
+    color: var(--admin-t3);
+  }
+}
+
+.search_clear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: none;
+  color: var(--admin-t3);
+  cursor: pointer;
+  transition:
+    background 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover {
+    background: var(--admin-bg-w);
+    color: var(--admin-t1);
+  }
+}

--- a/src/components/admin/sermons/SermonListPage/index.tsx
+++ b/src/components/admin/sermons/SermonListPage/index.tsx
@@ -1,12 +1,68 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { HiPlus } from 'react-icons/hi';
 import PageHeader from '@/components/admin/layout/PageHeader';
+import { useClickOutside } from '@/hooks/useClickOutside';
+import StatusTabs, { type SermonStatus } from './parts/StatusTabs';
+import SearchBox from './parts/SearchBox';
+import PreacherFilter from './parts/PreacherFilter';
+import SeriesFilter from './parts/SeriesFilter';
+import DateRangeFilter from './parts/DateRangeFilter';
+import ActiveFilters from './parts/ActiveFilters';
+import { MOCK_PREACHERS, MOCK_SERIES } from './parts/mockData';
 import styles from './index.module.scss';
+
+type DropdownKey = 'preacher' | 'series' | 'date';
 
 export default function SermonListPage() {
   const router = useRouter();
+  const [search, setSearch] = useState('');
+  const [openDropdown, setOpenDropdown] = useState<DropdownKey | null>(null);
+  const [selectedPreachers, setSelectedPreachers] = useState<string[]>([]);
+  const [selectedSeries, setSelectedSeries] = useState<string[]>([]);
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+
+  const toggleDropdown = (key: DropdownKey) =>
+    setOpenDropdown((current) => (current === key ? null : key));
+
+  const togglePreacher = (id: string) =>
+    setSelectedPreachers((current) =>
+      current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
+    );
+
+  const toggleSeries = (id: string) =>
+    setSelectedSeries((current) =>
+      current.includes(id) ? current.filter((value) => value !== id) : [...current, id]
+    );
+
+  const clearDate = () => {
+    setDateFrom('');
+    setDateTo('');
+  };
+
+  const clearAll = () => {
+    setSearch('');
+    setSelectedPreachers([]);
+    setSelectedSeries([]);
+    clearDate();
+  };
+
+  useClickOutside({
+    enabled: openDropdown !== null,
+    selector: '[data-dropdown]',
+    onClickOutside: () => setOpenDropdown(null)
+  });
+
+  const activeStatus: SermonStatus = 'all';
+  const counts: Record<SermonStatus, number> = {
+    all: 42,
+    published: 38,
+    draft: 3,
+    scheduled: 1
+  };
 
   return (
     <>
@@ -24,6 +80,48 @@ export default function SermonListPage() {
         ]}
       />
       <div className={styles.wrapper}>
+        <StatusTabs activeStatus={activeStatus} counts={counts} onChange={() => {}} />
+        <div className={styles.toolbar}>
+          <SearchBox value={search} onChange={setSearch} onClear={() => setSearch('')} />
+          <PreacherFilter
+            preachers={MOCK_PREACHERS}
+            selected={selectedPreachers}
+            onToggle={togglePreacher}
+            isOpen={openDropdown === 'preacher'}
+            onToggleOpen={() => toggleDropdown('preacher')}
+          />
+          <SeriesFilter
+            series={MOCK_SERIES}
+            selected={selectedSeries}
+            onToggle={toggleSeries}
+            isOpen={openDropdown === 'series'}
+            onToggleOpen={() => toggleDropdown('series')}
+          />
+          <DateRangeFilter
+            dateFrom={dateFrom}
+            dateTo={dateTo}
+            onChange={({ from, to }) => {
+              setDateFrom(from);
+              setDateTo(to);
+            }}
+            isOpen={openDropdown === 'date'}
+            onToggleOpen={() => toggleDropdown('date')}
+          />
+        </div>
+        <ActiveFilters
+          search={search}
+          preachers={selectedPreachers}
+          series={selectedSeries}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
+          preachersData={MOCK_PREACHERS}
+          seriesData={MOCK_SERIES}
+          onRemovePreacher={togglePreacher}
+          onRemoveSeries={toggleSeries}
+          onClearSearch={() => setSearch('')}
+          onClearDate={clearDate}
+          onClearAll={clearAll}
+        />
         <p className={styles.placeholder}>설교 목록 테이블이 여기에 들어갑니다</p>
       </div>
     </>

--- a/src/components/admin/sermons/SermonListPage/index.tsx
+++ b/src/components/admin/sermons/SermonListPage/index.tsx
@@ -11,6 +11,7 @@ import PreacherFilter from './parts/PreacherFilter';
 import SeriesFilter from './parts/SeriesFilter';
 import DateRangeFilter from './parts/DateRangeFilter';
 import ActiveFilters from './parts/ActiveFilters';
+import SermonTable, { type SortKey, type SortState } from './parts/SermonTable';
 import { MOCK_PREACHERS, MOCK_SERIES } from './parts/mockData';
 import styles from './index.module.scss';
 
@@ -24,6 +25,9 @@ export default function SermonListPage() {
   const [selectedSeries, setSelectedSeries] = useState<string[]>([]);
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
+  const [sort, setSort] = useState<SortState | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
 
   const toggleDropdown = (key: DropdownKey) =>
     setOpenDropdown((current) => (current === key ? null : key));
@@ -48,6 +52,14 @@ export default function SermonListPage() {
     setSelectedPreachers([]);
     setSelectedSeries([]);
     clearDate();
+  };
+
+  const handleSortChange = (key: SortKey) => {
+    setSort((current) => {
+      if (current?.key !== key) return { key, direction: 'asc' };
+      if (current.direction === 'asc') return { key, direction: 'desc' };
+      return null;
+    });
   };
 
   useClickOutside({
@@ -122,7 +134,18 @@ export default function SermonListPage() {
           onClearDate={clearDate}
           onClearAll={clearAll}
         />
-        <p className={styles.placeholder}>설교 목록 테이블이 여기에 들어갑니다</p>
+        <SermonTable
+          sort={sort}
+          onSortChange={handleSortChange}
+          total={42}
+          currentPage={currentPage}
+          pageSize={pageSize}
+          onPageChange={setCurrentPage}
+          onPageSizeChange={(size) => {
+            setPageSize(size);
+            setCurrentPage(1);
+          }}
+        />
       </div>
     </>
   );

--- a/src/components/admin/sermons/SermonListPage/index.tsx
+++ b/src/components/admin/sermons/SermonListPage/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { HiPlus } from 'react-icons/hi';
+import PageHeader from '@/components/admin/layout/PageHeader';
+import styles from './index.module.scss';
+
+export default function SermonListPage() {
+  const router = useRouter();
+
+  return (
+    <>
+      <PageHeader
+        eyebrow="설교"
+        title="설교 관리"
+        description="등록된 설교를 검색하고 발행 상태를 관리합니다"
+        actions={[
+          {
+            label: '새 설교 등록',
+            variant: 'pri',
+            icon: <HiPlus />,
+            onClick: () => router.push('/admin/sermons/new')
+          }
+        ]}
+      />
+      <div className={styles.wrapper}>
+        <p className={styles.placeholder}>설교 목록 테이블이 여기에 들어갑니다</p>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/ActiveFilters.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/ActiveFilters.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { HiX } from 'react-icons/hi';
+import { NONE_SERIES_ID, type MockPreacher, type MockSeries } from './mockData';
+import styles from '../index.module.scss';
+
+interface ActiveFiltersProps {
+  search: string;
+  preachers: string[];
+  series: string[];
+  dateFrom: string;
+  dateTo: string;
+  preachersData: MockPreacher[];
+  seriesData: MockSeries[];
+  onRemovePreacher: (id: string) => void;
+  onRemoveSeries: (id: string) => void;
+  onClearSearch: () => void;
+  onClearDate: () => void;
+  onClearAll: () => void;
+}
+
+export default function ActiveFilters({
+  search,
+  preachers,
+  series,
+  dateFrom,
+  dateTo,
+  preachersData,
+  seriesData,
+  onRemovePreacher,
+  onRemoveSeries,
+  onClearSearch,
+  onClearDate,
+  onClearAll
+}: ActiveFiltersProps) {
+  const hasAny = Boolean(
+    search || preachers.length > 0 || series.length > 0 || dateFrom || dateTo
+  );
+  if (!hasAny) return null;
+
+  const preacherName = (id: string) =>
+    preachersData.find((preacher) => preacher.id === id)?.name ?? id;
+  const seriesTitle = (id: string) => {
+    if (id === NONE_SERIES_ID) return '단독 설교';
+    return seriesData.find((entry) => entry.id === id)?.title ?? id;
+  };
+
+  const dateLabel = () => {
+    if (dateFrom && dateTo) return `${dateFrom} ~ ${dateTo}`;
+    if (dateFrom) return `${dateFrom} ~`;
+    return `~ ${dateTo}`;
+  };
+
+  return (
+    <div className={styles.active_filters}>
+      <span className={styles.active_label}>적용된 필터</span>
+      <ul className={styles.pill_list}>
+        {search && (
+          <li className={styles.pill}>
+            검색: {search}
+            <button
+              type="button"
+              className={styles.pill_remove}
+              onClick={onClearSearch}
+              aria-label="검색어 필터 제거"
+            >
+              <HiX aria-hidden />
+            </button>
+          </li>
+        )}
+
+        {preachers.map((id) => (
+          <li key={`preacher-${id}`} className={styles.pill}>
+            설교자: {preacherName(id)}
+            <button
+              type="button"
+              className={styles.pill_remove}
+              onClick={() => onRemovePreacher(id)}
+              aria-label={`설교자 필터 ${preacherName(id)} 제거`}
+            >
+              <HiX aria-hidden />
+            </button>
+          </li>
+        ))}
+
+        {series.map((id) => (
+          <li key={`series-${id}`} className={styles.pill}>
+            시리즈: {seriesTitle(id)}
+            <button
+              type="button"
+              className={styles.pill_remove}
+              onClick={() => onRemoveSeries(id)}
+              aria-label={`시리즈 필터 ${seriesTitle(id)} 제거`}
+            >
+              <HiX aria-hidden />
+            </button>
+          </li>
+        ))}
+
+        {(dateFrom || dateTo) && (
+          <li className={styles.pill}>
+            기간: {dateLabel()}
+            <button
+              type="button"
+              className={styles.pill_remove}
+              onClick={onClearDate}
+              aria-label="기간 필터 제거"
+            >
+              <HiX aria-hidden />
+            </button>
+          </li>
+        )}
+      </ul>
+      <button type="button" className={styles.clear_all} onClick={onClearAll}>
+        모두 지우기
+      </button>
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/DateRangeFilter.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/DateRangeFilter.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import FilterDropdown from './FilterDropdown';
+import dropdownStyles from '../dropdown.module.scss';
+
+interface DateRangeValue {
+  from: string;
+  to: string;
+}
+
+interface DateRangeFilterProps {
+  dateFrom: string;
+  dateTo: string;
+  onChange: (value: DateRangeValue) => void;
+  isOpen: boolean;
+  onToggleOpen: () => void;
+}
+
+export default function DateRangeFilter({
+  dateFrom,
+  dateTo,
+  onChange,
+  isOpen,
+  onToggleOpen
+}: DateRangeFilterProps) {
+  const hasValue = Boolean(dateFrom || dateTo);
+
+  return (
+    <FilterDropdown
+      label="기간"
+      count={hasValue ? 1 : 0}
+      isOpen={isOpen}
+      onToggle={onToggleOpen}
+    >
+      <p className={dropdownStyles.dropdown_title}>설교 날짜 범위</p>
+      <div className={dropdownStyles.date_row}>
+        <input
+          type="date"
+          className={dropdownStyles.date_input}
+          value={dateFrom}
+          onChange={(event) => onChange({ from: event.target.value, to: dateTo })}
+          aria-label="시작일"
+        />
+        <span aria-hidden>~</span>
+        <input
+          type="date"
+          className={dropdownStyles.date_input}
+          value={dateTo}
+          onChange={(event) => onChange({ from: dateFrom, to: event.target.value })}
+          aria-label="종료일"
+        />
+      </div>
+      {hasValue && (
+        <button
+          type="button"
+          className={dropdownStyles.date_clear}
+          onClick={() => onChange({ from: '', to: '' })}
+        >
+          초기화
+        </button>
+      )}
+    </FilterDropdown>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/DropdownItem.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/DropdownItem.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import clsx from 'clsx';
+import { HiCheck } from 'react-icons/hi';
+import dropdownStyles from '../dropdown.module.scss';
+
+interface DropdownItemProps {
+  selected: boolean;
+  label: string;
+  onSelect: () => void;
+  count?: number | null;
+  truncate?: boolean;
+}
+
+export default function DropdownItem({
+  selected,
+  label,
+  onSelect,
+  count,
+  truncate = false
+}: DropdownItemProps) {
+  const hasCount = count !== undefined && count !== null;
+
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      className={clsx(
+        dropdownStyles.dropdown_item,
+        selected && dropdownStyles.dropdown_item_active
+      )}
+      onClick={onSelect}
+    >
+      <span
+        className={clsx(
+          dropdownStyles.checkbox,
+          selected && dropdownStyles.checkbox_checked
+        )}
+        aria-hidden
+      >
+        {selected && <HiCheck />}
+      </span>
+      <span className={truncate ? dropdownStyles.dropdown_item_label : undefined}>
+        {label}
+      </span>
+      {hasCount && <span className={dropdownStyles.item_count}>{count}</span>}
+    </button>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/FilterDropdown.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/FilterDropdown.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { type ReactNode } from 'react';
+import clsx from 'clsx';
+import { HiChevronDown, HiOutlineFilter } from 'react-icons/hi';
+import dropdownStyles from '../dropdown.module.scss';
+
+interface FilterDropdownProps {
+  label: string;
+  count: number;
+  isOpen: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}
+
+export default function FilterDropdown({
+  label,
+  count,
+  isOpen,
+  onToggle,
+  children
+}: FilterDropdownProps) {
+  const isActive = count > 0;
+
+  return (
+    <div className={dropdownStyles.dropdown} data-dropdown>
+      <button
+        type="button"
+        className={clsx(
+          dropdownStyles.filter_trigger,
+          isActive && dropdownStyles.filter_active
+        )}
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+      >
+        <HiOutlineFilter aria-hidden />
+        <span>{label}</span>
+        {isActive && <span className={dropdownStyles.filter_count}>{count}</span>}
+        <HiChevronDown aria-hidden />
+      </button>
+      {isOpen && <div className={dropdownStyles.dropdown_panel}>{children}</div>}
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/MobileCardList.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/MobileCardList.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import clsx from 'clsx';
+import {
+  HiChevronLeft,
+  HiChevronRight,
+  HiOutlineFilm,
+  HiOutlinePencil,
+  HiOutlineTrash
+} from 'react-icons/hi';
+import { formattedDate, formatRelativeTime } from '@/utils/date';
+import { MOCK_ROWS, SERMON_STATUS_LABEL } from './mockData';
+import styles from '../table.module.scss';
+
+interface MobileCardListProps {
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function MobileCardList({
+  total,
+  currentPage,
+  pageSize,
+  onPageChange
+}: MobileCardListProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const isFirst = currentPage === 1;
+  const isLast = currentPage === totalPages;
+
+  return (
+    <>
+      <div className={styles.mobile_list}>
+        {MOCK_ROWS.map((row) => (
+          <article key={row.id} className={styles.mobile_card}>
+            <div className={styles.mobile_card_top}>
+              <div className={clsx(styles.row_thumb, styles.mobile_thumb)}>
+                <HiOutlineFilm aria-hidden />
+                {row.duration && (
+                  <span className={styles.thumb_duration}>{row.duration}</span>
+                )}
+              </div>
+              <div className={styles.mobile_card_info}>
+                <p className={styles.mobile_card_title}>{row.title}</p>
+                <p className={styles.mobile_card_meta}>
+                  {formattedDate(row.date, 'YYYY.MM.DD')} · {row.preacher.name}
+                </p>
+                <div className={styles.mobile_card_tags}>
+                  <span className={clsx(styles.status_pill, styles[row.status])}>
+                    <span className={styles.status_dot} aria-hidden />
+                    {SERMON_STATUS_LABEL[row.status]}
+                  </span>
+                  {row.series ? (
+                    <span className={styles.series_pill}>{row.series.title}</span>
+                  ) : (
+                    <span className={styles.single_pill}>단독</span>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div className={styles.mobile_card_bottom}>
+              <div className={styles.mobile_card_stats}>
+                {formatRelativeTime(row.updatedAt)}
+              </div>
+              <div
+                className={styles.mobile_card_actions}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <button
+                  type="button"
+                  className={styles.action_button}
+                  aria-label={`${row.title} 수정`}
+                >
+                  <HiOutlinePencil aria-hidden />
+                </button>
+                <button
+                  type="button"
+                  className={clsx(styles.action_button, styles.danger)}
+                  aria-label={`${row.title} 삭제`}
+                >
+                  <HiOutlineTrash aria-hidden />
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+      <div className={styles.mobile_pagination}>
+        <button
+          type="button"
+          className={styles.page_button}
+          disabled={isFirst}
+          onClick={() => onPageChange(currentPage - 1)}
+          aria-label="이전 페이지"
+        >
+          <HiChevronLeft aria-hidden />
+        </button>
+        <span>
+          {currentPage} / {totalPages}
+        </span>
+        <button
+          type="button"
+          className={styles.page_button}
+          disabled={isLast}
+          onClick={() => onPageChange(currentPage + 1)}
+          aria-label="다음 페이지"
+        >
+          <HiChevronRight aria-hidden />
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/Pagination.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/Pagination.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import clsx from 'clsx';
+import { HiChevronLeft, HiChevronRight } from 'react-icons/hi';
+import styles from '../table.module.scss';
+
+interface PaginationProps {
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+}
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+const PAGE_WINDOW = 5;
+
+export default function Pagination({
+  total,
+  currentPage,
+  pageSize,
+  onPageChange,
+  onPageSizeChange
+}: PaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const startItem = total === 0 ? 0 : (currentPage - 1) * pageSize + 1;
+  const endItem = Math.min(currentPage * pageSize, total);
+
+  const windowStart = Math.max(
+    1,
+    Math.min(totalPages - PAGE_WINDOW + 1, currentPage - Math.floor(PAGE_WINDOW / 2))
+  );
+  const windowEnd = Math.min(totalPages, windowStart + PAGE_WINDOW - 1);
+  const pages: number[] = [];
+  for (let page = windowStart; page <= windowEnd; page += 1) pages.push(page);
+
+  const isFirst = currentPage === 1;
+  const isLast = currentPage === totalPages;
+
+  return (
+    <div className={styles.pagination}>
+      <span className={styles.pagination_info}>
+        {startItem}–{endItem} / 전체 {total}개
+      </span>
+      <div className={styles.pagination_controls}>
+        <button
+          type="button"
+          className={styles.page_button}
+          disabled={isFirst}
+          onClick={() => onPageChange(1)}
+        >
+          처음
+        </button>
+        <button
+          type="button"
+          className={styles.page_button}
+          disabled={isFirst}
+          onClick={() => onPageChange(currentPage - 1)}
+          aria-label="이전 페이지"
+        >
+          <HiChevronLeft aria-hidden />
+        </button>
+        {pages.map((page) => (
+          <button
+            key={page}
+            type="button"
+            className={clsx(styles.page_button, page === currentPage && styles.on)}
+            onClick={() => onPageChange(page)}
+            aria-current={page === currentPage ? 'page' : undefined}
+          >
+            {page}
+          </button>
+        ))}
+        <button
+          type="button"
+          className={styles.page_button}
+          disabled={isLast}
+          onClick={() => onPageChange(currentPage + 1)}
+          aria-label="다음 페이지"
+        >
+          <HiChevronRight aria-hidden />
+        </button>
+        <button
+          type="button"
+          className={styles.page_button}
+          disabled={isLast}
+          onClick={() => onPageChange(totalPages)}
+        >
+          끝
+        </button>
+      </div>
+      <label className={styles.page_size}>
+        페이지당
+        <select
+          value={pageSize}
+          onChange={(event) => onPageSizeChange(Number(event.target.value))}
+        >
+          {PAGE_SIZE_OPTIONS.map((size) => (
+            <option key={size} value={size}>
+              {size}개
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/PreacherFilter.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/PreacherFilter.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import FilterDropdown from './FilterDropdown';
+import DropdownItem from './DropdownItem';
+import type { MockPreacher } from './mockData';
+import dropdownStyles from '../dropdown.module.scss';
+
+interface PreacherFilterProps {
+  preachers: MockPreacher[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  isOpen: boolean;
+  onToggleOpen: () => void;
+}
+
+export default function PreacherFilter({
+  preachers,
+  selected,
+  onToggle,
+  isOpen,
+  onToggleOpen
+}: PreacherFilterProps) {
+  return (
+    <FilterDropdown
+      label="설교자"
+      count={selected.length}
+      isOpen={isOpen}
+      onToggle={onToggleOpen}
+    >
+      <p className={dropdownStyles.dropdown_title}>설교자 선택</p>
+      <div className={dropdownStyles.dropdown_list}>
+        {preachers.map((preacher) => (
+          <DropdownItem
+            key={preacher.id}
+            selected={selected.includes(preacher.id)}
+            label={preacher.name}
+            count={preacher.count}
+            onSelect={() => onToggle(preacher.id)}
+          />
+        ))}
+      </div>
+    </FilterDropdown>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/SearchBox.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/SearchBox.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { HiOutlineSearch, HiX } from 'react-icons/hi';
+import styles from '../index.module.scss';
+
+interface SearchBoxProps {
+  value: string;
+  onChange: (value: string) => void;
+  onClear: () => void;
+}
+
+export default function SearchBox({ value, onChange, onClear }: SearchBoxProps) {
+  return (
+    <div className={styles.search_box}>
+      <HiOutlineSearch className={styles.search_icon} aria-hidden />
+      <input
+        type="text"
+        className={styles.search_input}
+        placeholder="제목, 성경 구절, 설교자로 검색"
+        aria-label="설교 검색"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+      />
+      {value && (
+        <button
+          type="button"
+          className={styles.search_clear}
+          onClick={onClear}
+          aria-label="검색어 지우기"
+        >
+          <HiX />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/SeriesFilter.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/SeriesFilter.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import FilterDropdown from './FilterDropdown';
+import DropdownItem from './DropdownItem';
+import { NONE_SERIES_ID, type MockSeries } from './mockData';
+import dropdownStyles from '../dropdown.module.scss';
+
+interface SeriesFilterProps {
+  series: MockSeries[];
+  selected: string[];
+  onToggle: (id: string) => void;
+  isOpen: boolean;
+  onToggleOpen: () => void;
+}
+
+export default function SeriesFilter({
+  series,
+  selected,
+  onToggle,
+  isOpen,
+  onToggleOpen
+}: SeriesFilterProps) {
+  const items: { id: string; label: string; count: number | null }[] = [
+    { id: NONE_SERIES_ID, label: '단독 설교', count: null },
+    ...series.map(({ id, title, count }) => ({ id, label: title, count }))
+  ];
+
+  return (
+    <FilterDropdown
+      label="시리즈"
+      count={selected.length}
+      isOpen={isOpen}
+      onToggle={onToggleOpen}
+    >
+      <p className={dropdownStyles.dropdown_title}>시리즈 선택</p>
+      <div className={dropdownStyles.dropdown_list}>
+        {items.map((item) => (
+          <DropdownItem
+            key={item.id}
+            selected={selected.includes(item.id)}
+            label={item.label}
+            count={item.count}
+            truncate
+            onSelect={() => onToggle(item.id)}
+          />
+        ))}
+      </div>
+    </FilterDropdown>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/SermonTable.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/SermonTable.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-icons/hi';
 import { formattedDate, formatRelativeTime } from '@/utils/date';
 import { MOCK_ROWS, SERMON_STATUS_LABEL } from './mockData';
+import MobileCardList from './MobileCardList';
 import Pagination from './Pagination';
 import styles from '../table.module.scss';
 
@@ -85,7 +86,8 @@ export default function SermonTable({
   };
 
   return (
-    <div className={styles.table_wrap}>
+    <>
+      <div className={styles.table_wrap}>
         <div className={styles.table_scroll}>
           <table className={styles.table}>
             <thead>
@@ -211,6 +213,13 @@ export default function SermonTable({
           onPageChange={onPageChange}
           onPageSizeChange={onPageSizeChange}
         />
-    </div>
+      </div>
+      <MobileCardList
+        total={total}
+        currentPage={currentPage}
+        pageSize={pageSize}
+        onPageChange={onPageChange}
+      />
+    </>
   );
 }

--- a/src/components/admin/sermons/SermonListPage/parts/SermonTable.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/SermonTable.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import clsx from 'clsx';
+import {
+  HiChevronDown,
+  HiChevronUp,
+  HiOutlineFilm,
+  HiOutlinePencil,
+  HiOutlineSearch,
+  HiOutlineTrash
+} from 'react-icons/hi';
+import { formattedDate, formatRelativeTime } from '@/utils/date';
+import { MOCK_ROWS, SERMON_STATUS_LABEL } from './mockData';
+import Pagination from './Pagination';
+import styles from '../table.module.scss';
+
+export type SortKey = 'title' | 'date' | 'updated';
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortState {
+  key: SortKey;
+  direction: SortDirection;
+}
+
+interface ColumnDef {
+  id: string;
+  key: SortKey | null;
+  label: string;
+  srLabel?: string;
+  className?: string;
+}
+
+const COLUMNS: ColumnDef[] = [
+  { id: 'thumb', key: null, label: '', srLabel: '썸네일', className: styles.col_thumb },
+  { id: 'title', key: 'title', label: '제목' },
+  { id: 'status', key: null, label: '상태', className: styles.col_status },
+  { id: 'date', key: 'date', label: '설교일', className: styles.col_date },
+  { id: 'preacher', key: null, label: '설교자', className: styles.col_preacher },
+  { id: 'series', key: null, label: '시리즈', className: styles.col_series },
+  { id: 'updated', key: 'updated', label: '수정', className: styles.col_updated },
+  { id: 'actions', key: null, label: '액션', className: styles.col_actions }
+];
+
+interface SermonTableProps {
+  sort: SortState | null;
+  onSortChange: (key: SortKey) => void;
+  total: number;
+  currentPage: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+}
+
+export default function SermonTable({
+  sort,
+  onSortChange,
+  total,
+  currentPage,
+  pageSize,
+  onPageChange,
+  onPageSizeChange
+}: SermonTableProps) {
+  const renderSortIcon = (columnKey: SortKey) => {
+    const isActive = sort?.key === columnKey;
+    const isAsc = isActive && sort.direction === 'asc';
+    const isDesc = isActive && sort.direction === 'desc';
+    return (
+      <span className={styles.sort_icon}>
+        <HiChevronUp
+          className={clsx(
+            styles.sort_icon_chevron,
+            isAsc && styles.sort_icon_chevron_active
+          )}
+          aria-hidden
+        />
+        <HiChevronDown
+          className={clsx(
+            styles.sort_icon_chevron,
+            isDesc && styles.sort_icon_chevron_active
+          )}
+          aria-hidden
+        />
+      </span>
+    );
+  };
+
+  return (
+    <div className={styles.table_wrap}>
+        <div className={styles.table_scroll}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                {COLUMNS.map((column) => {
+                  const isSortable = column.key !== null;
+                  const ariaSort =
+                    isSortable && sort?.key === column.key
+                      ? sort.direction === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : undefined;
+                  return (
+                    <th
+                      key={column.id}
+                      className={clsx(column.className, isSortable && styles.sortable)}
+                      onClick={
+                        isSortable && column.key
+                          ? () => onSortChange(column.key as SortKey)
+                          : undefined
+                      }
+                      aria-sort={ariaSort}
+                    >
+                      {column.srLabel ? (
+                        <span className={styles.sr_only}>{column.srLabel}</span>
+                      ) : (
+                        column.label
+                      )}
+                      {isSortable && column.key && renderSortIcon(column.key)}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {MOCK_ROWS.length === 0 ? (
+                <tr>
+                  <td colSpan={COLUMNS.length}>
+                    <div className={styles.empty}>
+                      <span className={styles.empty_icon}>
+                        <HiOutlineSearch aria-hidden />
+                      </span>
+                      <p className={styles.empty_title}>결과가 없습니다</p>
+                      <p className={styles.empty_desc}>검색어나 필터 조건을 바꿔보세요</p>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                MOCK_ROWS.map((row) => (
+                  <tr key={row.id}>
+                    <td className={styles.col_thumb}>
+                      <div className={styles.row_thumb}>
+                        <HiOutlineFilm aria-hidden />
+                        {row.duration && (
+                          <span className={styles.thumb_duration}>{row.duration}</span>
+                        )}
+                      </div>
+                    </td>
+                    <td className={styles.title_cell}>
+                      <p className={styles.row_title}>{row.title}</p>
+                      <p
+                        className={clsx(
+                          styles.row_scripture,
+                          !row.scripture && styles.none
+                        )}
+                      >
+                        {row.scripture ?? '성경 구절 미입력'}
+                      </p>
+                    </td>
+                    <td className={styles.col_status}>
+                      <span className={clsx(styles.status_pill, styles[row.status])}>
+                        <span className={styles.status_dot} aria-hidden />
+                        {SERMON_STATUS_LABEL[row.status]}
+                      </span>
+                    </td>
+                    <td className={styles.col_date}>
+                      {formattedDate(row.date, 'YYYY.MM.DD')}
+                    </td>
+                    <td className={styles.col_preacher}>{row.preacher.name}</td>
+                    <td className={styles.col_series}>
+                      {row.series ? (
+                        <span className={styles.series_pill}>{row.series.title}</span>
+                      ) : (
+                        <span className={styles.single_pill}>단독</span>
+                      )}
+                    </td>
+                    <td className={styles.col_updated}>
+                      {formatRelativeTime(row.updatedAt)}
+                    </td>
+                    <td className={styles.col_actions}>
+                      <div
+                        className={styles.row_actions}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <button
+                          type="button"
+                          className={styles.action_button}
+                          title="수정"
+                          aria-label={`${row.title} 수정`}
+                        >
+                          <HiOutlinePencil aria-hidden />
+                        </button>
+                        <button
+                          type="button"
+                          className={clsx(styles.action_button, styles.danger)}
+                          title="삭제"
+                          aria-label={`${row.title} 삭제`}
+                        >
+                          <HiOutlineTrash aria-hidden />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+        <Pagination
+          total={total}
+          currentPage={currentPage}
+          pageSize={pageSize}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+        />
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/StatusTabs.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/StatusTabs.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import clsx from 'clsx';
+import styles from '../index.module.scss';
+
+export type SermonStatus = 'all' | 'published' | 'draft' | 'scheduled';
+
+interface StatusTabsProps {
+  activeStatus: SermonStatus;
+  counts: Record<SermonStatus, number>;
+  onChange: (status: SermonStatus) => void;
+}
+
+const TABS: { value: SermonStatus; label: string }[] = [
+  { value: 'all', label: '전체' },
+  { value: 'published', label: '발행' },
+  { value: 'draft', label: '초안' },
+  { value: 'scheduled', label: '예약' }
+];
+
+export default function StatusTabs({ activeStatus, counts, onChange }: StatusTabsProps) {
+  return (
+    <div className={styles.status_tabs}>
+      {TABS.map((tab) => {
+        const isActive = activeStatus === tab.value;
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            className={clsx(styles.tab, isActive && styles.tab_active)}
+            onClick={() => onChange(tab.value)}
+          >
+            {tab.value !== 'all' && <span className={clsx(styles.dot, styles[tab.value])} />}
+            <span>{tab.label}</span>
+            <span className={styles.count}>{counts[tab.value]}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/admin/sermons/SermonListPage/parts/mockData.ts
+++ b/src/components/admin/sermons/SermonListPage/parts/mockData.ts
@@ -27,3 +27,86 @@ export const MOCK_SERIES: MockSeries[] = [
   { id: 's5', title: '창세기 여정', year: 2025, count: 20 },
   { id: 's6', title: '사도행전과 초대교회', year: 2024, count: 14 }
 ];
+
+export type SermonRowStatus = 'published' | 'draft' | 'scheduled';
+
+export const SERMON_STATUS_LABEL: Record<SermonRowStatus, string> = {
+  published: '발행',
+  draft: '초안',
+  scheduled: '예약'
+};
+
+export interface SermonRow {
+  id: number;
+  title: string;
+  slug: string;
+  date: string;
+  preacher: { name: string };
+  series?: { title: string };
+  duration?: string;
+  scripture: string | null;
+  status: SermonRowStatus;
+  updatedAt: string;
+}
+
+export const MOCK_ROWS: SermonRow[] = [
+  {
+    id: 1,
+    title: '광야에서의 부르심',
+    slug: 'wilderness-calling',
+    date: '2026-03-29',
+    preacher: { name: '김은혜 목사' },
+    series: { title: '마가복음 강해' },
+    duration: '38:42',
+    scripture: '마가복음 1:9-13',
+    status: 'published',
+    updatedAt: '2026-04-27T05:50:00Z'
+  },
+  {
+    id: 2,
+    title: '하나님 나라의 비유',
+    slug: 'kingdom-parables',
+    date: '2026-03-22',
+    preacher: { name: '박성민 목사' },
+    series: { title: '마가복음 강해' },
+    duration: '42:15',
+    scripture: '마가복음 4:26-34',
+    status: 'published',
+    updatedAt: '2026-04-25T11:00:00Z'
+  },
+  {
+    id: 3,
+    title: '복 있는 사람',
+    slug: 'blessed-life',
+    date: '2026-04-05',
+    preacher: { name: '이주영 전도사' },
+    duration: '35:08',
+    scripture: null,
+    status: 'draft',
+    updatedAt: '2026-04-26T03:20:00Z'
+  },
+  {
+    id: 4,
+    title: '부활의 증인',
+    slug: 'witnesses-of-resurrection',
+    date: '2026-05-03',
+    preacher: { name: '김은혜 목사' },
+    series: { title: '사도행전과 초대교회' },
+    duration: '40:30',
+    scripture: '사도행전 1:1-11',
+    status: 'scheduled',
+    updatedAt: '2026-04-20T08:00:00Z'
+  },
+  {
+    id: 5,
+    title: '시편 23편 묵상',
+    slug: 'psalm-23-meditation',
+    date: '2025-12-14',
+    preacher: { name: '박성민 목사' },
+    series: { title: '시편 묵상' },
+    duration: '29:54',
+    scripture: '시편 23:1-6',
+    status: 'published',
+    updatedAt: '2026-03-15T10:00:00Z'
+  }
+];

--- a/src/components/admin/sermons/SermonListPage/parts/mockData.ts
+++ b/src/components/admin/sermons/SermonListPage/parts/mockData.ts
@@ -1,0 +1,29 @@
+export interface MockPreacher {
+  id: string;
+  name: string;
+  count: number;
+}
+
+export interface MockSeries {
+  id: string;
+  title: string;
+  year: number;
+  count: number;
+}
+
+export const NONE_SERIES_ID = '__none';
+
+export const MOCK_PREACHERS: MockPreacher[] = [
+  { id: 'p1', name: '김은혜 목사', count: 14 },
+  { id: 'p2', name: '박성민 목사', count: 15 },
+  { id: 'p3', name: '이주영 전도사', count: 13 }
+];
+
+export const MOCK_SERIES: MockSeries[] = [
+  { id: 's1', title: '마가복음 강해', year: 2026, count: 12 },
+  { id: 's2', title: '산상수훈', year: 2026, count: 5 },
+  { id: 's3', title: '시편 묵상', year: 2025, count: 8 },
+  { id: 's4', title: '로마서 깊이 읽기', year: 2025, count: 16 },
+  { id: 's5', title: '창세기 여정', year: 2025, count: 20 },
+  { id: 's6', title: '사도행전과 초대교회', year: 2024, count: 14 }
+];

--- a/src/components/admin/sermons/SermonListPage/table.module.scss
+++ b/src/components/admin/sermons/SermonListPage/table.module.scss
@@ -1,8 +1,13 @@
 .table_wrap {
+  display: none;
   background: var(--admin-bg-card);
   border: 1px solid var(--admin-bd);
   border-radius: 10px;
   overflow: hidden;
+
+  @media (min-width: 768px) {
+    display: block;
+  }
 }
 
 .table_scroll {
@@ -378,5 +383,103 @@
       outline: none;
       border-color: var(--admin-accent);
     }
+  }
+}
+
+.mobile_list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+}
+
+.mobile_card {
+  padding: 12px 14px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s var(--admin-ease);
+
+  &:hover {
+    border-color: var(--admin-bd-s);
+  }
+}
+
+.mobile_card_top {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.row_thumb.mobile_thumb {
+  flex-shrink: 0;
+  width: 64px;
+  height: 40px;
+  font-size: 18px;
+}
+
+.mobile_card_info {
+  flex: 1;
+  min-width: 0;
+}
+
+.mobile_card_title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  margin: 0;
+  color: var(--admin-t1);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.mobile_card_meta {
+  margin: 2px 0 0;
+  color: var(--admin-t3);
+  font-size: 11px;
+}
+
+.mobile_card_tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.mobile_card_bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 8px;
+  margin-top: 8px;
+  border-top: 1px solid var(--admin-bd);
+}
+
+.mobile_card_stats {
+  color: var(--admin-t3);
+  font-size: 11px;
+}
+
+.mobile_card_actions {
+  display: flex;
+  gap: 4px;
+}
+
+.mobile_pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 4px;
+  color: var(--admin-t3);
+  font-size: 12px;
+
+  @media (min-width: 768px) {
+    display: none;
   }
 }

--- a/src/components/admin/sermons/SermonListPage/table.module.scss
+++ b/src/components/admin/sermons/SermonListPage/table.module.scss
@@ -1,0 +1,382 @@
+.table_wrap {
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.table_scroll {
+  overflow-x: auto;
+  scrollbar-width: thin;
+}
+
+.table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: collapse;
+
+  thead {
+    background: var(--admin-bg-w);
+    border-bottom: 1px solid var(--admin-bd);
+  }
+
+  th {
+    padding: 10px 14px;
+    border: 0;
+    color: var(--admin-t3);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-align: left;
+    text-transform: uppercase;
+    white-space: nowrap;
+    user-select: none;
+  }
+}
+
+.sortable {
+  cursor: pointer;
+  transition: color 0.15s var(--admin-ease);
+
+  &:hover {
+    color: var(--admin-t1);
+  }
+}
+
+.sort_icon {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  margin-left: 4px;
+  vertical-align: middle;
+  line-height: 0.6;
+}
+
+.sort_icon_chevron {
+  font-size: 10px;
+  opacity: 0.35;
+}
+
+.sort_icon_chevron_active {
+  opacity: 1;
+  color: var(--admin-t1);
+}
+
+.col_thumb {
+  width: 68px;
+}
+
+.col_status {
+  width: 90px;
+}
+
+.col_date {
+  width: 110px;
+}
+
+.col_preacher {
+  width: 120px;
+}
+
+.col_series {
+  width: 200px;
+}
+
+.col_updated {
+  width: 110px;
+}
+
+.col_actions {
+  width: 92px;
+}
+
+.table th.col_actions,
+.table td.col_actions {
+  text-align: right;
+}
+
+.table tbody tr {
+  cursor: pointer;
+  border-bottom: 1px solid var(--admin-bd);
+  transition: background 0.15s var(--admin-ease);
+
+  &:hover {
+    background: var(--admin-bg-w);
+  }
+
+  &:last-child {
+    border-bottom: 0;
+  }
+}
+
+.table td {
+  padding: 12px 14px;
+  color: var(--admin-t2);
+  font-size: 13px;
+  vertical-align: middle;
+}
+
+.row_thumb {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 32px;
+  background: var(--admin-bg-w);
+  border-radius: 4px;
+  overflow: hidden;
+  color: var(--admin-t3);
+  font-size: 16px;
+}
+
+.thumb_duration {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  padding: 0 3px;
+  background: rgba(15, 20, 30, 0.78);
+  border-radius: 2px;
+  color: #fff;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.title_cell {
+  min-width: 0;
+}
+
+.row_title {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  max-width: 340px;
+  color: var(--admin-t1);
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.row_scripture {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+  margin: 2px 0 0;
+  color: var(--admin-t3);
+  font-size: 11px;
+
+  &.none {
+    font-style: italic;
+    opacity: 0.7;
+  }
+}
+
+.status_pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+
+  &.published {
+    background: var(--admin-ok-bg);
+    color: var(--admin-ok);
+  }
+
+  &.draft {
+    background: var(--admin-bg-w);
+    color: var(--admin-t3);
+  }
+
+  &.scheduled {
+    background: var(--admin-accent-bg);
+    color: var(--admin-accent);
+  }
+}
+
+.status_dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.series_pill,
+.single_pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 100px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.series_pill {
+  background: var(--admin-accent-bg);
+  color: var(--admin-accent);
+}
+
+.single_pill {
+  background: var(--admin-bg-w);
+  color: var(--admin-t3);
+}
+
+.empty {
+  padding: 56px 20px;
+  text-align: center;
+}
+
+.empty_icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  background: var(--admin-bg-w);
+  border-radius: 50%;
+  color: var(--admin-t3);
+  font-size: 22px;
+}
+
+.empty_title {
+  margin: 12px 0 4px;
+  color: var(--admin-t2);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.empty_desc {
+  margin: 0;
+  color: var(--admin-t3);
+  font-size: 12px;
+}
+
+.row_actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 4px;
+  opacity: 0.35;
+  transition: opacity 0.15s var(--admin-ease);
+}
+
+.table tbody tr:hover .row_actions,
+.table tbody tr:focus-within .row_actions {
+  opacity: 1;
+}
+
+.sr_only {
+  @include blind;
+}
+
+.action_button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 5px;
+  color: var(--admin-t2);
+  font-size: 14px;
+  cursor: pointer;
+  transition:
+    background 0.15s var(--admin-ease),
+    border-color 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover {
+    background: var(--admin-bg-w);
+    border-color: var(--admin-bd-s);
+    color: var(--admin-t1);
+  }
+
+  &.danger:hover {
+    background: color-mix(in srgb, var(--admin-err), transparent 94%);
+    border-color: var(--admin-err);
+    color: var(--admin-err);
+  }
+}
+
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-top: 1px solid var(--admin-bd);
+  color: var(--admin-t3);
+  font-size: 12px;
+}
+
+.pagination_info {
+  font-weight: 500;
+}
+
+.pagination_controls {
+  display: flex;
+  gap: 4px;
+}
+
+.page_button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 30px;
+  height: 30px;
+  padding: 0 8px;
+  background: var(--admin-bg-card);
+  border: 1px solid var(--admin-bd);
+  border-radius: 5px;
+  color: var(--admin-t2);
+  font-size: 12px;
+  cursor: pointer;
+  transition:
+    background 0.15s var(--admin-ease),
+    border-color 0.15s var(--admin-ease),
+    color 0.15s var(--admin-ease);
+
+  &:hover:not(:disabled) {
+    background: var(--admin-bg-w);
+    border-color: var(--admin-bd-s);
+    color: var(--admin-t1);
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  &.on {
+    background: var(--admin-pri);
+    border-color: var(--admin-pri);
+    color: #fff;
+    font-weight: 600;
+  }
+}
+
+.page_size {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  select {
+    padding: 5px 8px;
+    background: var(--admin-bg-card);
+    border: 1px solid var(--admin-bd);
+    border-radius: 5px;
+    color: var(--admin-t2);
+    font-size: 12px;
+    cursor: pointer;
+
+    &:focus {
+      outline: none;
+      border-color: var(--admin-accent);
+    }
+  }
+}

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+interface ClickOutsideOptions {
+  /** 리스너 등록 여부. 닫혀 있을 땐 false로 두어 글로벌 리스너 비용을 없앤다. */
+  enabled: boolean;
+  /** "내부"로 간주할 영역의 CSS selector. 예: '[data-dropdown]', '[data-popover]'. */
+  selector: string;
+  /** 외부 mousedown 또는 (옵션이 켜져 있다면) ESC 시 호출. */
+  onClickOutside: () => void;
+  /** ESC 키도 외부 동작으로 처리할지. 기본 true. */
+  closeOnEscape?: boolean;
+}
+
+/**
+ * dropdown / popover / tooltip 등 "내부 영역 외부에서 인터랙션이 일어나면 닫기" 패턴.
+ * 내부 영역에 selector에 매치되는 마커(예: data-dropdown)를 두고,
+ * 호출자는 onClickOutside에서 닫기 상태를 갱신한다.
+ */
+export function useClickOutside({
+  enabled,
+  selector,
+  onClickOutside,
+  closeOnEscape = true
+}: ClickOutsideOptions) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null;
+      if (target?.closest(selector)) return;
+      onClickOutside();
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClickOutside();
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    if (closeOnEscape) window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      if (closeOnEscape) window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [enabled, selector, onClickOutside, closeOnEscape]);
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,26 +1,19 @@
 import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko';
 import { NEW_BADGE_DAYS } from '@/constants/notice';
 
-const SECOND = 1000;
-const MINUTE = 60 * SECOND;
-const HOUR = 60 * MINUTE;
-const DAY = 24 * HOUR;
-const MONTH = 30 * DAY;
-const YEAR = 365 * DAY;
-const MS_PER_DAY = DAY;
+dayjs.extend(relativeTime);
+dayjs.locale('ko');
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export function formattedDate(date: string | number, format: string) {
   return dayjs(date).format(format);
 }
 
 export function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  if (diff < MINUTE) return '방금 전';
-  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}분 전`;
-  if (diff < DAY) return `${Math.floor(diff / HOUR)}시간 전`;
-  if (diff < MONTH) return `${Math.floor(diff / DAY)}일 전`;
-  if (diff < YEAR) return `${Math.floor(diff / MONTH)}개월 전`;
-  return `${Math.floor(diff / YEAR)}년 전`;
+  return dayjs(iso).fromNow();
 }
 
 export function isRecent(createdAt: string, daysThreshold = NEW_BADGE_DAYS): boolean {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,10 +1,26 @@
 import dayjs from 'dayjs';
 import { NEW_BADGE_DAYS } from '@/constants/notice';
 
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const MONTH = 30 * DAY;
+const YEAR = 365 * DAY;
+const MS_PER_DAY = DAY;
 
 export function formattedDate(date: string | number, format: string) {
   return dayjs(date).format(format);
+}
+
+export function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < MINUTE) return '방금 전';
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}분 전`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}시간 전`;
+  if (diff < MONTH) return `${Math.floor(diff / DAY)}일 전`;
+  if (diff < YEAR) return `${Math.floor(diff / MONTH)}개월 전`;
+  return `${Math.floor(diff / YEAR)}년 전`;
 }
 
 export function isRecent(createdAt: string, daysThreshold = NEW_BADGE_DAYS): boolean {


### PR DESCRIPTION
## 📋 개요 (Summary)

어드민 대시보드에 설교 관리 목록 페이지(`/admin/sermons`)를 신설하고, 상태 탭·검색·필터·테이블·페이지네이션·모바일 카드 리스트를 정적 UI를 구현합니다.

<br/>

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- 설교 등록 기능(#sermon-create)이 완성된 이후, 등록된 설교를 **한 화면에서 조회·탐색·상태 관리**할 수 있는 목록 페이지가 없었음
- 발행/초안/예약 상태가 혼재된 설교를 빠르게 식별하고 필터링하는 운영 워크플로우 필요
- 모바일 환경에서도 설교 관리가 가능해야 한다는 요구사항

**관련 이슈 / ADR:**
- ADR: [PROMPTS-sermon-list-admin.md](https://github.com/user-attachments/files/27152770/PROMPTS-sermon-list-admin.md)


<br/>

## 🔧 주요 변경점 (Key Changes)

### 1. 라우트 + 셸

- `app/admin/sermons/page.tsx` 서버 컴포넌트 신설
- `PageHeader` (eyebrow / title / description / "새 설교 등록" 버튼) 마운트
- `SermonListPage` 클라이언트 셸 분리 (`components/admin/sermons/SermonListPage/`)
- `app/admin/layout.tsx`에 `usePathname` 기반 브레드크럼 매핑 추가 (`["관리자", "설교 관리"]`)

### 2. 검색 · 필터 · 적용된 필터 바

- `StatusTabs` — 전체/발행/초안/예약 4개 탭, 상태별 색상 dot + 카운트 뱃지
- `SearchBox` — 포커스 링, 실시간 초기화(X 버튼)
- `FilterDropdown` + `DropdownItem` — 공통 트리거/패널 컴포넌트 (position: relative + animation)
- `PreacherFilter` / `SeriesFilter` / `DateRangeFilter` — 각 필터 내용 컴포넌트
- **single-open 정책**: `openDropdown: string | null` 단일 상태로 동시에 하나만 열림
- `useClickOutside` 커스텀 훅 추가 (`selector` + `enabled` 옵션, ESC 키 지원)
- `ActiveFilters` — 활성 조건별 pill + 개별/전체 제거 액션
- `mockData.ts`에 `MOCK_PREACHERS`, `MOCK_SERIES`, `NONE_SERIES_ID` 상수 노출

### 3. 테이블 + 페이지네이션

- `SermonTable` — 썸네일(YouTube mqdefault) / 상태 pill / 시리즈·단독 pill / 정렬 아이콘 / empty state
- `Pagination` — 페이지 번호 5-window 로직, 페이지 크기 select (10/20/50/100)
- `mockData.ts`에 `SermonRow` 타입 + `MOCK_ROWS` (5개) + `SERMON_STATUS_LABEL` 추가
- `lib/utils/format.ts` — `formatRelativeTime` / `formatDateDot` / `formatCompactNumber` 유틸 추가
- 행 호버 시 액션 버튼(수정/삭제) fade-in, `stopPropagation`으로 행 클릭 이벤트 격리

### 4.s 모바일 카드 리스트

- `MobileCardList` 컴포넌트 추가 — 썸네일 + 메타(날짜·설교자) + 상태·시리즈 pill + 수정/삭제 액션
- `SermonTable` 내부에서 데스크탑 `<table>`과 `MobileCardList`를 **sibling 렌더**, CSS로 분기 (`768px` 미만에서 table 숨김 / `mobile_*` 클래스 노출)
- 모바일 페이지네이션은 이전/다음 버튼 + "N / 전체 페이지" 간소 표시

<br/>

## 🏗️ 설계 결정 사항 (Design Decisions)

| 고려한 대안                                                 | 선택한 방법                                                | 선택 이유                                                    |
| ----------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
| 드롭다운을 각 필터 컴포넌트 내부에서 독립 관리              | 부모(`SermonListPage`)에서 `openDropdown` 단일 상태로 관리 | 동시에 두 드롭다운이 열리는 UX 버그 방지                     |
| `display:none` CSS만으로 모바일 전환                        | 테이블·카드 리스트를 sibling 렌더 + CSS 분기               | 컴포넌트 간 데이터·페이지 상태를 공유하면서 레이아웃만 교체 가능 |
| 테이블 내부에 필터·검색 로직 포함                           | `SermonListPage`가 상태 소유, `SermonTable`은 표시 전용    | 관심사 분리; Phase 2에서 서버 필터링 연동 시 교체 범위 최소화 |
| 외부 클릭 감지를 각 드롭다운 컴포넌트 내 `useEffect`로 처리 | `useClickOutside` 훅 분리 (`selector` + `enabled` 옵션)    | 재사용성 확보, 드롭다운이 닫힌 상태일 때 리스너 미등록(`enabled=false`)으로 성능 개선 |

> ⚠️ **트레이드오프:**
>
> - 현재 `MOCK_ROWS` 하드코딩 데이터 사용. 추후 API 연동 시 `SermonTable`의 props 시그니처(`SermonRow[]`)는 유지되지만 페이지네이션·정렬 상태가 쿼리 파라미터로 이동해야 함.
> - 모바일 카드와 데스크탑 테이블이 sibling 렌더이므로, 데이터셋이 커지면 불필요한 DOM 노드가 생성됨. 이후 필요하면 `useMediaQuery`로 조건부 렌더로 전환 고려.

<br/>

## 📊 다이어그램 (Diagrams)

```mermaid
flowchart LR
    A["/admin/sermons (page.tsx)"] --> B["PageHeader\n새 설교 등록 버튼"]
    A --> C["SermonListPage (클라이언트)"]

    C --> D["StatusTabs\n전체·발행·초안·예약"]
    C --> E["Toolbar\nSearchBox + Filters"]
    C --> F["ActiveFilters\n활성 조건 pill"]
    C --> G["SermonTable"]

    E --> E1["PreacherFilter"]
    E --> E2["SeriesFilter"]
    E --> E3["DateRangeFilter"]

    G --> G1["&lt;table&gt; 데스크탑\n≥ 768px"]
    G --> G2["MobileCardList\n< 768px"]
    G --> G3["Pagination"]
```

------

## ✅ 검증 결과 (Verification)

**수행한 테스트:**

- [ ] 단위 테스트 (Unit Test)
- [ ] 통합 테스트 (Integration Test)
- [x] 수동 테스트 (Manual Test) — Vercel Preview 배포 확인

**테스트 결과 / 스크린샷:**

| 항목                            | 결과                                       |
| ------------------------------- | ------------------------------------------ |
| `/admin/sermons` 라우트 접근    | ✅ 사이드바 + 헤더 + PageHeader + 목록 렌더 |
| StatusTabs 탭 전환              | ✅ 활성 탭 스타일 + 카운트 뱃지 정상        |
| SearchBox 포커스·초기화         | ✅ 포커스 링 + X 버튼 동작                  |
| 필터 드롭다운 single-open       | ✅ 다른 드롭다운 열면 이전 것 자동 닫힘     |
| 외부 클릭 / ESC 닫기            | ✅ `useClickOutside` + keydown 리스너 정상  |
| ActiveFilters pill 노출 및 제거 | ✅ 개별 X / 전체 초기화 동작                |
| 테이블 정렬 아이콘              | ✅ asc·desc 상태 시각 피드백                |
| 행 호버 시 액션 버튼            | ✅ fade-in, 행 클릭 이벤트 격리             |
| 빈 상태(empty state)            | ✅ 결과 없음 일러스트 + 안내 문구           |
| 페이지네이션 5-window           | ✅ 페이지 버튼, 크기 select 동작            |
| 모바일(767px 이하) 카드 전환    | ✅ 테이블 숨김 + 카드 리스트 노출           |

| 시연 영상 |
|--|
| <img width="1254" height="688" alt="_20260428_152150-ezgif com-optiwebp" src="https://github.com/user-attachments/assets/bb4a3b68-5e69-4c3c-ad77-3b207b75e224" />| 

<br/>

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 요구사항 전체 충족 여부 (Prompt 1-1 ~ 1-15)
- [x] Null, 빈 배열 등 엣지 케이스 처리 여부 (empty state, scripture null, series null)
- [ ] 신규 기능에 대한 단위 테스트 추가 여부 — Phase 1 UI 구현으로 테스트 미포함, Phase 2에서 추가 예정

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 복잡한 로직 설명 주석 추가 여부 (페이지 5-window 계산, relative time 분기 등)
- [x] 불필요한 코드·디버그 로그 제거 여부

**보안 및 견고성**

- [x] 하드코딩된 비밀값(토큰, 비밀번호) 미포함 확인
- [x] 사용자 입력값 적절한 검증 여부 (검색 input controlled, date input type 제한)

**성능**

- [x] 불필요한 반복 연산·리소스 낭비 없음 확인
- [ ] DB 쿼리 효율성 확인 — Phase 1은 mock 데이터, Phase 3에서 해당

**테스트 및 문서화**

- [ ] README·API 문서 변경 사항 반영 여부 — 해당 없음 (UI Only)
- [x] Conventional Commits 규격 준수 여부 (`Feat:`)

<br/>

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- `MOCK_ROWS`를 실제 API 응답으로 교체, 검색·필터·정렬 파라미터를 URL 쿼리스트링(`useSearchParams`)으로 이동하여 딥링크 지원
- `SermonTable`의 `rows: SermonRow[]` prop과 `Pagination`의 `total / currentPage / pageSize` prop만 교체하면 나머지 UI는 그대로 재사용 가능
- 모바일 카드의 썸네일 이미지는 YouTube `mqdefault`(320×180) 사용 중 — 추후 자체 CDN 썸네일로 교체 시 `getSermonThumbnail(videoId)` 유틸로 래핑할 것