### PR TITLE
[Refactor] Cloudinary 자산 폴더 구조 재설계 + dev/prod 환경 prefix 합성

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "cloudinary-asset-mgmt": {
+      "type": "http",
+      "url": "https://asset-management.mcp.cloudinary.com/mcp"
+    },
+    "cloudinary-env-config": {
+      "type": "http",
+      "url": "https://environment-config.mcp.cloudinary.com/mcp"
+    }
+  }
+}

--- a/docs/decisions/0007-cloudinary-asset-folder-convention.md
+++ b/docs/decisions/0007-cloudinary-asset-folder-convention.md
@@ -1,0 +1,124 @@
+# 0007 — cloudinary asset folder convention
+
+- **Status**: Accepted
+- **Date**: 2026-05-11
+- **Deciders**: scseong
+- **Tags**: cloudinary, asset-management, env-separation
+
+## Context
+
+dnchurch는 모든 이미지·미디어를 Cloudinary로 서빙하지만, 폴더 구조·환경 분리·DB 참조 방식에 다음 문제가 누적되어 있었음:
+
+1. **정적/동적 자산이 같은 prefix에 혼재** — `dnchurch-dev/site/`(코드 참조 정적)와 `dnchurch-dev/bulletins/`(DB row 동적)가 평행. 운영 주체·생명주기가 다른 자산이 같은 레벨에 섞여 신규 페이지·신규 도메인 추가 시 어디에 둘지 매번 판단 필요.
+2. **환경 prefix가 DB에 박혀 있음** — `bulletin_images.cloudinary_id`에 `dnchurch-dev/bulletins/...` 형태로 저장. dev DB row를 prod에 dump-restore 시 cloudinary 경로가 dev를 가리켜 broken. 의도한 dev/prod 분리가 데이터 레이어에서 깨짐.
+3. **정적 자산 경로가 코드에 하드코딩** — `NewHere.tsx`에 `src="dnchurch-dev/site/home/sketch"` 직접 박힘. 동적 업로드는 `NEXT_PUBLIC_CLOUDINARY_ROOT_FOLDER` env로 분리되는데 정적은 안 됨.
+4. **legacy 루트 폴더 3개** (`bulletins/`, `bulletin/`, `dnchurch/`) — 초기 테스트 잔존. dev DB row 11개 중 6개가 이 legacy 폴더를 참조 중이라 단순 삭제 시 broken image.
+5. **`bulletin_images.url` 컬럼 redundant 저장** — `cloudinary_id`만으로 URL 재생성 가능한데 두 값을 동시 저장. 한쪽만 갱신하면 정합성 깨짐.
+
+결정 안 하면: 신규 페이지·신규 도메인 추가 시 폴더 위치·prefix 처리·DB 참조 형식이 매번 ad-hoc하게 결정되어 컨벤션 분산. prod 환경 분리 미완성 상태로 누적.
+
+Codex 검토(2026-05-11): static/dynamic 1차 분리·`asset_folder`는 운영 편의·`public_id`는 delivery contract·hero는 페이지 폴더 내부 권장.
+
+## Decision
+
+세 가지를 **하나의 통합 계약**으로 결정한다 — 모두 "Cloudinary delivery identifier를 어떻게 저장하고 조합할 것인가"라는 단일 질문에 대한 답:
+
+### 1. 폴더 구조 (asset_folder)
+
+```
+dnchurch-{env}/                  ← env prefix는 운영 편의 (Cloudinary Console 분리만 담당)
+├── site/                        ← 정적: 코드에서 직접 참조, 관리자 수동 업로드
+│   ├── home/
+│   ├── about/
+│   │   ├── hero.jpg             ← 페이지 hero는 페이지 폴더 안에 직접 (`hero.jpg`)
+│   │   ├── welcome/
+│   │   ├── worship/
+│   │   ├── vision/
+│   │   ├── location/
+│   │   ├── pastor/
+│   │   └── serving-people/
+│   ├── fellowship/
+│   ├── next-gen/{elementary,kindergarten,young-adult,youth}/
+│   └── shared/                  ← 로고, og-image, favicon 등 페이지 횡단 자산
+│
+└── uploads/                     ← 동적: DB row가 참조, 관리자/사용자 업로드
+    ├── bulletins/{YYYY}/{MM}/{DD}/
+    ├── sermons/{YYYY}/{MM}/
+    ├── gallery/{YYYY}/{MM}/
+    ├── notices/{notice-id}/
+    └── community/{prayer,sharing,groups}/{post-id}/
+```
+
+**원칙**:
+- **1차 축 = 정적/동적** (운영 주체가 다름 — 코드 참조 vs DB row 참조)
+- **정적 = 라우트 트리 미러링** (페이지 path == 폴더 path. 페이지 추가 = 같은 이름의 폴더)
+- **동적 = DB 도메인 미러링** (테이블 단위 폴더, 날짜 또는 row id로 하위 분기)
+- **hero는 페이지 폴더 내부** (`<page>/hero.jpg`. `_hero.jpg` 언더스코어 prefix·별도 `hero/` 폴더 모두 채택 안 함)
+- **재사용 정적 자산은 `site/shared/`** (로고·og-image 등 여러 페이지에서 사용)
+
+### 2. 환경 prefix 합성 규칙 (delivery identifier)
+
+| 위치 | 저장 형식 | 예 |
+|---|---|---|
+| **Cloudinary `public_id`** (실제 자산) | env prefix 포함 fully qualified | `dnchurch-dev/uploads/bulletins/2026/03/28/주보_001` |
+| **DB `cloudinary_id`** | env prefix 제거된 ROOT-relative | `uploads/bulletins/2026/03/28/주보_001` |
+| **코드 helper 합성 결과** | 호출 컨텍스트에 따라 합성/분해 | — |
+
+**핵심**: `asset_folder`는 운영 편의 도구(Cloudinary Console 탐색·필터)이고, `public_id`는 delivery contract(URL 안정성). 환경 prefix는 코드에서 합성하여 DB는 환경 독립.
+
+**헬퍼 계약** (`src/utils/cloudinary.ts`):
+- `siteAsset(relPath)` → `${ROOT}/site/${relPath}` — 정적 자산용 fully qualified public_id 반환
+- `uploadFolder(domain, ...parts)` → `${ROOT}/uploads/${domain}/${parts.join('/')}` — 동적 업로드 folder path
+- `stripRootPrefix(publicId)` → ROOT 제거 — 업로드 응답을 DB에 저장할 때
+- `getCloudinaryUrl(publicId)`·`createCloudinaryLoader` → 입력값에 ROOT가 누락이면 자동 합성, 이미 있으면 그대로 (`normalizePublicId` 방어 로직)
+- 모든 헬퍼는 빈 segment·중복 slash·leading slash를 거부
+
+### 3. 마이그레이션·범위 정책
+
+- **새 데이터부터 컨벤션 적용** — `public_id` 자체 rename은 URL 계약·CDN 캐시·DB 동시 변경 위험. 기존 데이터는 truncate(시드일 때) 또는 점진 정리(운영 데이터일 때)
+- **본 PR이 실제로 만드는 폴더는 `dnchurch-dev/uploads/bulletins/...`만** — `uploads/sermons/`, `uploads/gallery/`, `uploads/notices/`, `uploads/community/*`는 **첫 업로드 시점에 자동 생성될 미래 컨벤션**. 본 PR에서 폴더만 미리 만들지 않음
+- **prod 적용은 별도 plan** — 본 ADR이 정한 컨벤션을 prod에 적용하려면 운영 데이터 마이그레이션 plan 필요. 본 PR은 dev only
+- **정적 자산 재배치는 후속 PR** — `site/welcome/` → `site/about/welcome/`, `site/hero/about` → `site/about/hero` 같은 기존 자산 이동은 코드 헬퍼 도입 후 점진적으로
+- **다른 5개 `*_url` 컬럼 (notices/sermons/staff/preachers/sermon_series)** — 실제 cloudinary 자산이 아님 (YouTube 썸네일·Next.js public/·PDF 파일명)이므로 본 ADR 범위 밖. 향후 cloudinary로 이관 시 본 컨벤션 따름
+
+## Alternatives Considered
+
+| 대안 | 기각 사유 |
+|---|---|
+| **prefix를 DB에 그대로 저장** (현 상태 유지) | dev/prod 환경 분리가 데이터 레이어에서 깨짐. dump-restore·migration·새 환경 추가 시 매번 경로 변환 필요 |
+| **flat 폴더 + Cloudinary tags로 분류** | 5-10 페이지 규모에는 과한 메타데이터. 폴더 탐색이 우선 (Codex 권장) |
+| **hero를 별도 `hero/` 폴더에 분리** | 페이지 단위로 자산이 모이지 않음. 페이지 이동/삭제 시 자산 위치도 따로 관리 필요 |
+| **`_hero.jpg` 언더스코어 prefix** | "숨김/내부 파일" 의미가 강하고 Cloudinary Media Library에서 시각적 이점 없음 (Codex 검토 반영) |
+| **PR 분리** (코드 / DB / Cloudinary 정리 각각) | `cloudinary_id` 계약 변경 하나에 묶여 있어 분리 시 임시 호환 코드 부담 (Codex 검토 반영) |
+| **community를 날짜로 partition** (`community/prayer/{YYYY}/{MM}/`) | per-row 폴더가 row 생명주기와 일치. 삭제·감사·소유 추적 우선 (Codex 권장) |
+
+## Consequences
+
+**좋아지는 것**:
+- 신규 페이지·신규 도메인 추가 시 폴더 위치 결정이 1줄 규칙 ("정적이면 site/<page>/, 동적이면 uploads/<domain>/")
+- DB가 환경 독립 — dev↔prod 데이터 이동 시 cloudinary 경로 변환 불필요
+- `public_id` URL 안정성 보장 (운영 정리는 `asset_folder`만 만지므로 기존 URL이 깨지지 않음)
+- 코드에서 `dnchurch-dev/` 같은 환경 prefix 하드코딩 0건 보장
+
+**부담**:
+- `siteAsset()`·`uploadFolder()` 헬퍼 호출을 잊으면 broken image (단, `normalizePublicId` 방어로 일부 자동 복구). lint·코드 리뷰에서 catch 필요
+- 정적 자산 재배치 후속 작업이 별도 PR로 남음 (점진적 정리 부담)
+- prod 환경 적용 plan 별도 필요
+
+**다음 작업**:
+- 정적 자산 재배치 PR (`site/welcome/` → `site/about/welcome/`, hero co-location)
+- prod cloudinary 마이그레이션 plan (운영 데이터 보존 전략·downtime 평가)
+
+## Verification
+
+- 본 PR exec-plan: `docs/exec-plans/active/2026-05-11-cloudinary-asset-structure.md`
+- `grep -rn "dnchurch-dev" src/` → 0 hits
+- `getCloudinaryUrl(prefix-free path)` 호출 시 ROOT 자동 합성됨 (`normalizePublicId`)
+- Cloudinary MCP `search-folders`로 신 컨벤션 폴더만 존재하는지 확인 (legacy 0건)
+
+## References
+
+- [Cloudinary folder modes](https://cloudinary.com/documentation/folder_modes)
+- [Cloudinary invalidate cached assets](https://cloudinary.com/documentation/invalidate_cached_media_assets_on_the_cdn)
+- Codex 설계 검토: 본 PR 진행 중 codex:rescue 응답 (PASS, 7건 피드백 반영)
+- ADR [0001 — codex orchestration strategy](0001-codex-orchestration-strategy.md) — Codex 위임 트리거 (설계 판단)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -36,5 +36,6 @@
 | [0004](0004-ui-component-foundation.md) | UI Component Foundation (디자인 시스템 v4) | Accepted | 2026-05-06 |
 | [0005](0005-about-pages-content-model.md) | about pages content model | Superseded by [0006](0006-about-pages-domain-driven-content.md) | 2026-05-09 |
 | [0006](0006-about-pages-domain-driven-content.md) | about pages domain driven content | Proposed | 2026-05-09 |
+| [0007](0007-cloudinary-asset-folder-convention.md) | Cloudinary asset folder convention (정적/동적 분리 + env prefix 합성) | Accepted | 2026-05-11 |
 
 <!-- last-audit: 2026-05-01 -->

--- a/docs/exec-plans/active/2026-05-11-cloudinary-asset-structure.md
+++ b/docs/exec-plans/active/2026-05-11-cloudinary-asset-structure.md
@@ -1,0 +1,199 @@
+# cloudinary-asset-structure
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-11
+- **브랜치**: refactor/cloudinary-asset-structure
+
+## 목표
+
+Cloudinary 폴더 구조를 `site/` (정적) + `uploads/{도메인}/` (동적)로 1차 분리하고, DB·코드의 환경 prefix를 제거해 dev/prod 환경 분리를 완성한다. legacy seed 데이터·폴더(`bulletins/`, `bulletin/`, `dnchurch/`)를 정리한다.
+
+## Assumptions
+
+- dev DB의 `bulletins`(7) + `bulletin_images`(11) row는 모두 시드/테스트 — truncate 가능 (사용자 확인 완료)
+- prod DB·prod Cloudinary는 이번 작업에서 건드리지 않는다 (별도 후속 작업으로 분리)
+- 정적 자산(`site/welcome/`, `site/hero/`, `site/home/*`)의 폴더 재배치는 본 작업에서 **하지 않는다** — 코드 헬퍼 도입 후 점진적으로 옮긴다 (Codex 권장)
+- 환경 prefix는 코드에서 합성: DB `cloudinary_id`는 prefix-free (`uploads/bulletins/...`), `getCloudinaryUrl`이 `${ROOT_FOLDER}/${cloudinary_id}` 합성
+- `bulletin_images.url`은 `cloudinary_id`로 재생성 가능하므로 컬럼 DROP
+
+## Non-goals
+
+- prod 환경(`dnchurch-prod`) 자산·DB 변경
+- 정적 자산 재배치 (`site/welcome/` → `site/about/welcome/`, hero co-location)
+- 다른 5개 `*_url` 컬럼(notices/sermons/staff/preachers/sermon_series) 정리 — 이들은 cloudinary 자산이 아님 (YouTube/PDF 파일명/Next.js public)
+- Tags 기반 자산 분류 도입
+- `public_id` 자체 rename (Cloudinary 마이그레이션 시에는 새 데이터부터 새 컨벤션 적용)
+
+## Success Criteria
+
+1. dev Cloudinary에서 legacy 폴더(`bulletins/`, `bulletin/`, `dnchurch/`)와 `dnchurch-dev/bulletins/*` 자산이 0개
+2. dev DB에서 `bulletins` rows = 0, `bulletin_images` rows = 0
+3. `bulletin_images.url` 컬럼이 schema에서 제거됨 (`generate:types` 결과 반영)
+4. `getCloudinaryUrl(cloudinary_id)`가 `${BASE_URL}/${ROOT_FOLDER}/${cloudinary_id}` 형태를 반환 — DB값에 prefix 없이도 동작 (방어적으로 leading `/` 및 `${ROOT_FOLDER}/` 중복 prefix 1회 strip)
+5. `siteAsset(relPath)` 헬퍼가 `${ROOT_FOLDER}/site/${relPath}` (public_id form, full URL 아님) 반환, 코드에서 `dnchurch-dev/` 하드코딩 0건 (`grep -r "dnchurch-dev" src/`)
+6. 새 주보를 관리자 UI로 업로드 시 `dnchurch-dev/uploads/bulletins/{YYYY}/{MM}/{DD}/...` 경로에 저장됨
+7. `yarn lint && yarn lint:styles && yarn build && yarn knip` 통과
+8. 기존 정적 이미지(home banner 등) 페이지 노출 정상 (회귀 없음)
+9. 새 bulletin upload 후 `bulletin_images.cloudinary_id` 값이 `uploads/bulletins/...`로 시작 (`dnchurch-dev/`로 시작하지 않음) — Supabase MCP `execute_sql`로 검증
+10. `src/`에서 `bulletin_images.url` 또는 `BulletinImageInput.url` 참조 0건 (`grep -rn "\.url" src/services/bulletin/ src/actions/*bulletin* src/types/bulletin.ts src/app/(content)/news/bulletins/`)
+
+## Verification
+
+- `node scripts/verify-task.mjs cloudinary-asset-structure` (lint + lint:styles + build + knip)
+- `grep -rn "dnchurch-dev" src/ | grep -v ".test."` → 0 hits
+- `yarn dev`에서 홈/주보 페이지 렌더 확인 (수동)
+- 관리자 주보 업로드 후 Cloudinary MCP로 `search-assets` → 새 경로 확인
+- Supabase MCP `execute_sql`: `SELECT count(*) FROM bulletin_images, bulletins` → 0/0
+
+## 접근법
+
+**4단계 — step 1~3은 하나의 구현 단위로 묶고, step 4는 정리 단계로 분리**:
+
+1. **코드 헬퍼 + 동적 업로드 경로 변경** — `cloudinary.ts`에 `siteAsset()`/`uploadFolder()` 추가, `_bulletin-helpers.ts`의 `folderPath`를 `${ROOT}/uploads/bulletins/...`로 변경, `getCloudinaryUrl`에서 prefix 자동 합성. NewHere 등 하드코딩 제거.
+2. **DB 마이그레이션** — `ALTER TABLE bulletin_images DROP COLUMN url` + `TRUNCATE bulletin_images, bulletins RESTART IDENTITY CASCADE`. dev 프로젝트(`mficogrxekuahjqborxw`)에 적용 후 `yarn generate:types`.
+3. **코드 정리** — `BulletinImageInput.url` 필드 제거, `bulletin-service.ts`에서 url 저장 로직 제거. `LatestBulletin.tsx`/`bulletins/[id]/page.tsx` 등에서 `getCloudinaryUrl(img.cloudinary_id)` 통해 URL 복원.
+4. **Cloudinary 정리** — MCP `delete-asset`로 `dnchurch-dev/bulletins/*` 자산 7개를 먼저 삭제(폴더가 비어야 `delete-folder`가 성공) → `delete-folder`로 legacy 루트 3개(`dnchurch`, `bulletins`, `bulletin`) 삭제. site/* 자산 보존.
+
+**중간 빌드 가정**: step 2(컬럼 drop) 직후 step 3(코드 정리) 완료 전까지는 빌드가 깨질 수 있다. 이는 의도된 중간 상태이며, **검증(`verify-task.mjs`)은 step 3 완료 후 1회만** 실행한다. step 1-3 사이에 중간 commit·push 금지.
+
+**헬퍼 반환 타입 (Codex 검토 반영)**:
+- `siteAsset(relPath: string): string` — `public_id` form (`${ROOT}/site/${relPath}`). Next.js `<Image src>` + 커스텀 Cloudinary loader가 src를 public_id로 해석하므로 full URL 아님.
+- `uploadFolder(domain: string, ...parts: string[]): string` — public_id form (`${ROOT}/uploads/${domain}/${parts.join('/')}`). 빈 segment·leading slash·중복 slash 거부.
+- `getCloudinaryUrl(cloudinary_id: string): string` — full delivery URL. 입력값에서 leading `/`와 `${ROOT}/` 중복 prefix를 1회 방어적으로 strip한 뒤 합성.
+
+**핵심 결정**: 환경 prefix는 DB에 저장하지 않고 코드에서 합성한다 (env 따라 자동 분기). 이는 Codex 권장(folder는 운영 편의, public_id는 delivery contract)과 일관 — 다만 우리는 신규 데이터에만 적용하고 기존은 truncate한다.
+
+## 영향받는 파일
+
+**코드**:
+- `src/utils/cloudinary.ts` — `siteAsset()`, `uploadFolder()` 헬퍼 추가, `getCloudinaryUrl` prefix 합성
+- `src/apis/cloudinary.ts` — `uploadImage` 호출부 정리 (선택)
+- `src/actions/_bulletin-helpers.ts` — folderPath를 `${ROOT}/uploads/bulletins/...`로 변경, return에서 url 제거
+- `src/actions/create-bulletin.action.ts` — url 필드 의존 제거
+- `src/actions/update-bulletin.action.ts` — url 필드 의존 제거
+- `src/services/bulletin/bulletin-service.ts` — url 컬럼 insert 제거
+- `src/types/bulletin.ts` — `BulletinImageInput.url` 제거
+- `src/types/database.types.ts` — `yarn generate:types`로 재생성
+- `src/app/_component/home/NewHere.tsx` — `dnchurch-dev/site/home/sketch` → `siteAsset('home/sketch')`
+- `src/app/(content)/news/bulletins/_component/LatestBulletin.tsx` — img.cloudinary_id로 URL 합성
+- `src/app/(content)/news/bulletins/[id]/page.tsx` — 동일
+- `src/app/(content)/news/bulletins/[id]/update/page.tsx` — 동일
+- `src/components/file/ImagePreview.tsx` — cloudinaryId 사용처 검토
+
+**DB**:
+- `supabase/migrations/<timestamp>_drop_bulletin_images_url_and_truncate.sql`
+
+**Cloudinary (MCP, 코드 외부)**:
+- `delete-folder`: `dnchurch`, `bulletins`, `bulletin`
+- `delete-asset` × 7: `dnchurch-dev/bulletins/...` 전체
+
+## 단계별 체크리스트
+
+- [x] 1. CODEX_PLAN_REVIEW 요청 (구조 변경 + DB schema + 다단계 → 필수 트리거) — PASS
+- [x] 2. 코드 헬퍼 도입 + 동적 업로드 경로 변경 (4단계 step 1)
+- [x] 3. DB 마이그레이션 작성 + dev 적용 + 타입 재생성 (Supabase MCP)
+- [x] 4. 코드 url 의존 제거 + cloudinary_id 기반 URL 합성으로 통일
+- [x] 5. CODEX_FIRST_PASS — 구현 diff 검증 (CHANGE_REQUEST → 2건 수정 적용 → FIX_APPLIED)
+- [x] 6. Cloudinary MCP로 legacy 폴더·자산 정리 — 자산 8개 + 폴더 5개 삭제 (자세한 내역은 의사결정 로그)
+- [ ] 7. `yarn dev`에서 홈/주보 페이지 회귀 확인 + 새 주보 업로드 smoke test (사용자 직접)
+- [x] 8. `node scripts/verify-task.mjs cloudinary-asset-structure` 통과 (knip warning은 기존 부채)
+- [x] 9. Claude 2차 검증 기록
+- [x] 10. ADR 0007 작성 (Cloudinary 폴더 컨벤션) — Accepted
+- [ ] 11. 사용자 승인 후 커밋 + PR (base: develop, label: refactor)
+
+## 완료 기준 (DoD)
+
+- [ ] `node scripts/verify-task.mjs cloudinary-asset-structure` 통과 (lint + lint:styles + build + knip)
+- [ ] 사용자 승인 후 커밋
+- [ ] 마이그레이션 적용 (`mficogrxekuahjqborxw` dev only)
+- [ ] ADR 0007 작성 (Cloudinary asset 폴더 컨벤션)
+- [ ] tech-debt-tracker.md 갱신 — 정적 자산 재배치(site/welcome → site/about/welcome 등) 후속 부채로 기록
+
+## 참고 자료
+
+- Codex 설계 검토 결과 (이 세션 내 codex:rescue 응답): `site/`+`uploads/` 분리, hero는 `hero.jpg`(언더스코어 X), per-row 폴더 유지, asset_folder만 정리·public_id는 보존
+- [Cloudinary folder modes](https://cloudinary.com/documentation/folder_modes)
+- [Cloudinary invalidate cached assets](https://cloudinary.com/documentation/invalidate_cached_media_assets_on_the_cdn)
+
+## 의사결정 로그
+
+- 2026-05-11: 정적 자산 폴더 재배치(site/welcome → site/about/welcome, hero co-location)는 본 PR에서 제외 — 코드 헬퍼 도입 후 점진 마이그레이션 (Codex 권장 반영)
+- 2026-05-11: bulletin* 테이블은 truncate (시드 데이터 확인됨). in-place 자산 이동·UPDATE 회피
+- 2026-05-11: 환경 prefix(`dnchurch-dev/`)는 DB 컬럼에서 제거하고 코드에서 합성. 새 cloudinary_id 패턴: `uploads/bulletins/{YYYY}/{MM}/{DD}/{filename}`
+- 2026-05-11: hero 자산 컨벤션은 `<page>/hero.jpg` (Codex 권장 — `_hero.jpg` 언더스코어 prefix 채택 안 함)
+- 2026-05-11: step 1~3은 단일 구현 단위, 중간 commit 금지. step 2(column drop) 직후 step 3 완료 전까지 빌드 깨짐 허용 (Codex 검토 반영)
+- 2026-05-11: Cloudinary 정리 순서 = 자산 삭제 → 폴더 삭제 (빈 폴더만 delete-folder 성공)
+- 2026-05-11: `getCloudinaryUrl`에 방어적 prefix strip 추가 (leading `/`, `${ROOT}/` 중복 1회) — truncate 후엔 발생할 수 없으나 helper 안전장치
+- 2026-05-11: Cloudinary `delete-folder`가 자동 cascade 안 함이 확인됨 ("Folder is not empty" 에러). 자산을 먼저 모두 `delete-asset`으로 정리한 후 폴더 삭제. 단, 한 번 비워지면 하위 폴더는 cascade됨 (`{deleted: [2026, 2026/03, 2026/03/28, bulletins]}`)
+- 2026-05-11: dev cloudinary 정리 결과 — 자산 8개 삭제 (`bulletin/...` 2 + `bulletins/...` 3 + `dnchurch-dev/bulletins/...` 3), 폴더 5개 삭제 (`dnchurch`, `bulletins` + 하위 2개, `dnchurch-dev/bulletins` + 하위 3개). `bulletin` (단수형)은 폴더 등록 안 된 상태 (자산 4개에 path만 박혀있던 형태)
+- 2026-05-11: `dnchurch-dev/assets` 빈 폴더는 본 PR 범위 밖이라 보존 — tech-debt 후보
+- 2026-05-11: smoke test 회귀 1건 수정 — `LatestBulletin.tsx:28`이 빈 `images`에서 `getCloudinaryUrl(undefined)` 호출하던 기존 버그가 truncate로 노출됨. `imageIds[0] ? getCloudinaryUrl(imageIds[0]) : undefined` guard 추가. `KakaoShareProps.imageUrl`은 optional이라 type-safe
+- 2026-05-11: smoke test 회귀 2건 — 본 PR 회귀. `apis/cloudinary.ts:deleteImage`가 ROOT-relative `cloudinary_id`(DB 저장 형식)를 받지만 `cloudinary.uploader.destroy`는 fully-qualified public_id 요구 → 자산 삭제 실패 → orphan 발생. 호출부 4곳 (create 1, update 3) 그대로 두고 `deleteImage` 안에 `toFullyQualifiedPublicId()` 합성 추가 (apis 격리 위해 utils의 normalizePublicId 재사용 안 함, inline 작은 함수). ADR 0007의 "코드 헬퍼가 ROOT 합성" 원칙 그대로 적용 — 새 결정 아님
+- 2026-05-11: 담임목사 사진 cloudinary 업로드 (`dnchurch-dev/site/about/pastor/portrait.png`) + `staff.image_url` 갱신. Console 업로드는 dynamic folder mode라 public_id가 파일명만으로 설정됨 → rename 1단계 필요 발견. 또한 rename 직후 자산은 default delivery format 라우팅 지연으로 확장자 명시 필수 → DB값에 `.png` 포함. 후속 부채(tech-debt-tracker): Console 업로드 자동 정정 방안 검토(upload preset `use_asset_folder_as_public_id_prefix`, admin UI 통일, webhook 자동 rename)
+- 2026-05-11: pastor 페이지 career 섹션 PC/Mobile UI 통일 — PC 전용 `career_list_pc` 제거, mobile `career_card_mobile`을 `career_card`로 rename + profile_block 안으로 통합. ADR 0007과 별개 작업이지만 같은 PR에 포함 (cloudinary 사진 업로드 흐름과 함께 작업). primitive `$beige-100` → semantic `$bg-beige-subtle` 적용. CloudinaryImage `fill` 모드 동작 fix(`.photo`에 `position: relative` + `overflow: hidden` 추가, CloudinaryImage style override를 fill/non-fill 분기) 포함
+- 2026-05-11: vision 페이지 교회 외관 이미지 cloudinary 업로드 (`dnchurch-dev/site/about/vision/exterior.jpg`) + `IMAGE_URL` 하드코딩 교체 (`'dnchurch_nxmttl'` → `'site/about/vision/exterior.jpg'`). 사용자가 console에서 처음부터 fully-qualified Public ID로 업로드 → rename 불필요 + 확장자 유무 무관하게 양쪽 200. portrait의 확장자 quirk는 rename된 자산 한정임을 확인. 후속 부채 우선순위 ↓ — Console 업로드 시 Public ID를 fully-qualified로 입력하는 운영 절차로 충분
+
+## ADR 판단
+
+- **필요 여부**: 필요
+- **결정 링크**: [0007-cloudinary-asset-folder-convention.md](../../decisions/0007-cloudinary-asset-folder-convention.md)
+- **사유**: ADR 0007은 다음 3가지를 **하나의 통합 결정**으로 다룬다 (Codex 검토 반영) — 모두 "Cloudinary delivery identifier를 어떻게 저장하고 조합할 것인가"라는 단일 계약:
+  1. **폴더 구조 컨벤션**: `site/`(정적) + `uploads/{domain}/`(동적), hero는 페이지 폴더 안 `hero.jpg`
+  2. **환경 prefix 합성 규칙**: DB는 prefix-free, 코드 헬퍼가 `${ROOT_FOLDER}/` 합성. `asset_folder`는 운영 편의·`public_id`는 delivery contract
+  3. **정적/동적 분리 원칙**: 운영 주체(코드 참조 vs DB row 참조)에 따른 1차 축
+  4. **범위 제한**: 본 ADR이 수립한 컨벤션의 prod 적용은 별도 후속 plan에서만 수행
+
+## Codex 계획 검증
+
+- **상태**: 완료
+- **요청 시점**: 2026-05-11 (이 세션 내)
+- **결론**: **PASS**
+- **핵심 지적**:
+  1. step 1~3은 하나의 구현 단위로 취급, 중간 commit·검증 금지 (step 2 직후 빌드 깨짐 허용)
+  2. `getCloudinaryUrl`에 방어적 prefix strip 추가 (leading `/`, `${ROOT}/` 중복)
+  3. `siteAsset()`는 full URL이 아닌 public_id form 반환 (loader가 src를 public_id로 해석)
+  4. PR 분리 금지 — `cloudinary_id` 계약 변경 하나에 묶여 있어 분리 시 임시 호환 코드 부담 큼
+  5. Success Criteria에 2개 추가: 새 cloudinary_id의 prefix 부재 + url 컬럼 참조 0건
+  6. ADR 0007은 folder convention + prefix composition + static/dynamic separation을 단일 결정으로 통합
+  7. Cloudinary cleanup 순서: 자산 삭제 → 폴더 삭제. helper 입력 규칙(빈 segment·중복 slash 거부) 명시
+- **반영 내용**: 위 7건 모두 plan에 반영 — Success Criteria 9·10번 추가, 접근법에 step ordering·헬퍼 시그니처 명시, 의사결정 로그·ADR 판단·체크리스트 갱신
+
+## Codex 1차 검증
+
+- **상태**: 완료 (CHANGE_REQUEST 2건 → FIX_APPLIED)
+- **요청 시점**: 2026-05-11 step 1~3 + ADR 작성 직후
+- **결론**: **FIX_APPLIED** (Codex 결론은 CHANGE_REQUEST, 모두 수정 적용 후 self-resolved)
+- **수정 파일**:
+  - `src/utils/cloudinary.ts` — `normalizePublicId`에 `^https?://` guard 추가 (full URL pass-through)
+  - `supabase/migrations/20260511000000_drop_bulletin_images_url.sql` — TRUNCATE 제거 + 파일명 rename (`_and_truncate` 제거)
+  - `docs/research/2026-05-11-cloudinary-bulletin-cleanup.sql` — TRUNCATE를 one-off SQL로 분리 (replay 금지 명시)
+  - `docs/decisions/0007-cloudinary-asset-folder-convention.md` — 본 PR이 실제로 만드는 폴더는 `uploads/bulletins/`만, 나머지는 첫 업로드 시 자동 생성될 미래 컨벤션임을 명확화
+- **핵심 지적**:
+  1. **BUG**: `normalizePublicId`가 full URL(`https://...`)을 받으면 `dnchurch-dev/https://...`로 망가질 수 있음 → URL guard로 pass-through
+  2. **SAFETY**: versioned migration에 `TRUNCATE`가 포함되어 있어 다른 환경 replay 시 데이터 삭제 위험 → migration에서 분리, dev 일회성 작업으로 명시
+  3. **NEEDS_VERIFY**: ADR 0007이 community 폴더를 "이번 PR에서 만들어진 것"처럼 서술하는지 확인 → "미래 컨벤션" 명시로 보강
+- **남은 리스크**:
+  - dev DB의 migration history는 옛 이름(`drop_bulletin_images_url_and_truncate`)으로 등록되어 있으나 파일명은 `drop_bulletin_images_url`. 같은 timestamp이므로 fresh apply에서 idempotent. 운영 영향 없음 (의사결정 로그에 기록)
+  - Step 4 (Cloudinary 자산·legacy 폴더 삭제)는 MCP 토큰 만료로 보류. 코드는 self-consistent (truncate된 DB는 legacy 자산을 더 이상 참조 안 함). 사용자 재인증 후 진행 필요
+
+## Claude 2차 검증
+
+- **검토 내용**: Codex CHANGE_REQUEST 2건 적용 후 diff 재확인. URL guard(`^https?://` pass-through)가 `normalizePublicId` 진입점에 1회 적용되어 `siteAsset`/`uploadFolder`/`stripRootPrefix`/`getCloudinaryUrl`/`createCloudinaryLoader` 모두 보호. migration 파일 rename + TRUNCATE 분리 후에도 dev DB는 이미 적용된 상태(`bulletins`/`bulletin_images` rows=0)이므로 정합 유지. ADR 0007에 "본 PR이 만드는 폴더는 `uploads/bulletins/`만" 명시되어 community/sermons는 첫 업로드 시 자동 생성될 미래 컨벤션으로 분리됨.
+- **실행한 검증**:
+  - `yarn build` (URL guard fix 후 재실행) — pass
+  - 시각적 diff 확인: `cloudinary.ts:10` URL guard 라인 진입 위치 정확. `migration` 파일 단일 진실 (column drop + RPC만 포함, TRUNCATE 없음)
+  - `grep -rn "dnchurch-dev|dnchurch-prod" src/` → 0 hits 유지
+  - `grep -rn "\.url\b" src/services/bulletin/ src/actions/*bulletin* src/types/bulletin.ts src/components/file/` → DB 컬럼 의존 0건 유지
+- **최종 판단**: **PASS**. 코드는 self-consistent하며 dev DB와 동기화됨. Step 4(Cloudinary 자산·legacy 폴더 삭제)만 MCP 토큰 만료로 보류 — DB 참조가 truncate된 상태라 legacy 자산 정리는 비차단적 후속 작업. 사용자 재인증 후 진행 가능.
+
+## 리뷰 (완료 직전)
+
+- [ ] 셀프 리뷰: 이 PR을 처음 보는 사람도 EXEC_PLAN만으로 변경 의도를 이해할 수 있는가?
+- [ ] **멀티 세션 리뷰** (권장): 같은 세션의 구현자는 무의식적 바이어스가 생긴다.
+      별도 Claude 세션 또는 `codex:rescue`로 객관적 검토를 요청해 시선을 분리한다.
+
+## 회고 (머지 후 작성, completed/로 이동 시)
+
+- 잘된 것:
+- 다음에 할 것:
+- 발견된 부채 (→ tech-debt-tracker.md 옮길 것):

--- a/docs/research/2026-05-11-cloudinary-bulletin-cleanup.sql
+++ b/docs/research/2026-05-11-cloudinary-bulletin-cleanup.sql
@@ -1,0 +1,15 @@
+-- One-off cleanup SQL: dev DB seed truncate (cloudinary-asset-structure refactor)
+--
+-- ⚠️ 운영 환경에서 절대 실행하지 말 것 — 이 스크립트는 dnchurch-dev (mficogrxekuahjqborxw) 시드 정리용.
+-- ⚠️ versioned migration에 포함하지 않음 — replay 시 다른 환경 데이터 삭제 위험.
+--
+-- 실행 이력:
+-- - 2026-05-11: dev (mficogrxekuahjqborxw)에 Supabase MCP `apply_migration`으로 적용됨.
+--               당시 11 rows의 bulletin_images가 모두 legacy 폴더 또는 환경 prefix 포함 cloudinary_id를 참조하여 신 컨벤션과 불일치.
+--               사용자가 시드 데이터로 확정 후 truncate 결정.
+--
+-- 신 컨벤션 (ADR 0007):
+-- - DB cloudinary_id는 ROOT-relative (`uploads/bulletins/{YYYY}/{MM}/{DD}/...`)
+-- - 환경 prefix는 코드 헬퍼(`getCloudinaryUrl`, `createCloudinaryLoader`)에서 합성
+
+TRUNCATE bulletin_images, bulletins RESTART IDENTITY CASCADE;

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -223,6 +223,64 @@
   - rgba: `news/notices/_component/NoticeDrawer.module.scss:27`, `sermons/_component/{SortBottomSheet:4, GridCard:59,77,93, SermonCard:69,87,109}`
 - **발견일**: 2026-05-07 (Codex 디자인 시스템 audit)
 
+### 🟢 Cloudinary `uploadImage()` `folder` + `public_id` 중복 전달
+
+- **무엇**: `src/apis/cloudinary.ts:36-39`에서 `cloudinary.uploader.upload()`에 `folder`와 fully-qualified `public_id`를 동시 전달
+- **왜**: dnchurch dev/prod preset의 dynamic folder mode에서 경험적으로 검증된 조합. Cloudinary 공식은 dynamic folder mode에서 `asset_folder` + `public_id_prefix` 또는 `use_asset_folder_as_public_id_prefix`를 권장
+- **마이그레이션 경로**: 단순화 시도 전 smoke test 필수 — `folder` 제거 / `asset_folder` 전환 각각 시도 후 결과 `public_id` 형태와 폴더 위치 확인. 검증 통과 시 단순화
+- **영향 범위**: `src/apis/cloudinary.ts`
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
+### 🟡 bulletin 이미지 filename 충돌 위험
+
+- **무엇**: `src/actions/_bulletin-helpers.ts:20`에서 업로드 filename은 sanitize만 수행하고 uniqueness suffix 없음. 같은 날(`uploads/bulletins/YYYY/MM/DD`) 동일 이름 파일 재업로드 시 `public_id` 중복으로 overwrite 가능
+- **왜**: 단순 sanitize만으로 충분하다고 판단(날짜별 폴더 분리 가정). 실제로는 같은 날 같은 이름 파일 재업로드 시나리오가 가능
+- **마이그레이션 경로**: filename에 `${orderIndex}-${randomUUID().slice(0,8)}-${name}` 같은 prefix 추가. orderIndex만으로도 같은 폼 내 중복은 방지되지만, 다른 세션/같은 날 재업로드는 UUID로 보호
+- **영향 범위**: `src/actions/_bulletin-helpers.ts`
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
+### 🟡 bulletin 업로드 부분실패 orphan asset
+
+- **무엇**: `src/actions/_bulletin-helpers.ts:18` `Promise.all` 병렬 업로드 — 1장이라도 실패하면 throw로 끝나고, 이미 업로드 성공한 자산은 Cloudinary에 orphan으로 남음
+- **왜**: 초기 구현에서 happy-path만 고려. cleanup 정책 미정의
+- **마이그레이션 경로**: `Promise.allSettled` + fulfilled 결과의 `public_id`를 `deleteImage()`로 cleanup 후 rejection 재throw. sermon 업로드(`actions/sermon.action.ts`의 `removeStorageObjects`) 패턴 참고
+- **영향 범위**: `src/actions/_bulletin-helpers.ts`, `src/apis/cloudinary.ts`
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
+### 🟡 `serverActions.bodySizeLimit` ↔ bulletin UI 정책 불일치
+
+- **무엇**: `next.config.ts:24`의 `bodySizeLimit: '5mb'` vs bulletin UI는 1장 5MB × 최대 5장 허용. 여러 장 동시 업로드 시 Server Action 진입 전 body limit으로 차단 가능 (Cloudinary upload는 base64 직렬화로 추가 bloat ≈ +33%)
+- **왜**: 단일 파일 업로드 가정으로 설정. multi-upload 추가 시 limit 재검토 누락
+- **마이그레이션 경로**: (a) `bodySizeLimit`을 `30mb`로 상향(5MB×5 + base64 + 메타데이터) 또는 (b) 클라이언트에서 순차 업로드로 전환(메모리 안전). (a)가 단순하지만 DoS 위험 약간 증가
+- **확인 필요**: 실제로 5장 동시 업로드 시 차단되는지 reproduce
+- **영향 범위**: `next.config.ts`, `src/actions/_bulletin-helpers.ts`, bulletin form
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
+### 🟢 Cloudinary 이미지 품질 `q_85` 고정 → `q_auto` 전환 검토
+
+- **무엇**: `src/utils/cloudinary.ts:72`의 loader가 `q_85` 고정. Cloudinary 공식 권장은 `q_auto` (또는 `q_auto:good`) — 컨텐츠별 최적 품질로 자동 조정
+- **왜**: 명시적 품질 관리 의도. 자동화 결과 품질 변동성 우려로 보류
+- **마이그레이션 경로**: 일부 use-case(`hero`, `bulletin`)에서 A/B 비교 후 `q_auto:good` 전환. PSNR/SSIM 또는 시각 검토로 품질 회귀 없음 확인 → 전체 전환
+- **영향 범위**: `src/utils/cloudinary.ts`, 모든 `<CloudinaryImage>` 사용처
+- **참고**: https://cloudinary.com/documentation/image_optimization
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
+### 🟢 Cloudinary use-case별 preset 부재 (OG/카카오/다운로드)
+
+- **무엇**: `getCloudinaryUrl()`은 변환 없이 원본 URL 생성. OG 이미지·카카오 공유·다운로드 등 각 use-case에 적절한 사이즈/품질 변환이 일괄 적용되지 않음
+- **왜**: 초기에는 `<Image>` 컴포넌트만 사용하는 가정. OG/공유 등 외부 use-case 추가 시 case-by-case로 변환 추가
+- **마이그레이션 경로**: use-case별 명명된 preset 함수 도입 — 예: `getOgImageUrl(publicId)`, `getKakaoShareUrl(publicId)`, `getThumbnailUrl(publicId)`. 각각 `w`/`c`/`q`/`f` 조합 고정 → derived asset 종류 통제 → bandwidth/transformation 비용 절감
+- **영향 범위**: `src/utils/cloudinary.ts`, OG metadata 생성 사이트, 공유 버튼 컴포넌트
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
+### 🟢 `CloudinaryImage` 불필요한 `'use client'` boundary
+
+- **무엇**: `src/components/common/CloudinaryImage.tsx:1`이 `'use client'`이지만 React 훅을 사용하지 않음. 단순히 `<Image>`에 loader 함수를 넘기는 wrapper
+- **왜**: 초기 작성 시 안전하게 client 지정. `loader` prop이 함수라 RSC에서 직접 전달 시 직렬화 문제 우려
+- **마이그레이션 경로**: `'use client'` 제거 후 RSC 호환성 검증 — `loader={createCloudinaryLoader(...)}` 패턴이 RSC에서 동작하는지 확인. 안 되면 module-level pre-built loader 인스턴스(cropMode 조합별)로 우회. 통과 시 client JS 번들 감소
+- **영향 범위**: `src/components/common/CloudinaryImage.tsx`
+- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
+
 ---
 
 ## 해결된 항목

--- a/src/actions/_bulletin-helpers.ts
+++ b/src/actions/_bulletin-helpers.ts
@@ -1,4 +1,5 @@
 import { uploadImage } from '@/apis/cloudinary';
+import { stripRootPrefix, uploadFolder } from '@/utils/cloudinary';
 import type { BulletinImageInput } from '@/types/bulletin';
 
 export { checkAdminPermission } from './_auth-helpers';
@@ -8,12 +9,11 @@ export async function uploadBulletinImages(
   date: string,
   startOrderIndex = 0
 ): Promise<BulletinImageInput[]> {
-  const d = new Date(date);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const rootFolder = process.env.NEXT_PUBLIC_CLOUDINARY_ROOT_FOLDER;
-  const folderPath = `${rootFolder}/bulletins/${year}/${month}/${day}`;
+  const targetDate = new Date(date);
+  const year = String(targetDate.getFullYear());
+  const month = String(targetDate.getMonth() + 1).padStart(2, '0');
+  const day = String(targetDate.getDate()).padStart(2, '0');
+  const folderPath = uploadFolder('bulletins', year, month, day);
 
   const results = await Promise.all(
     files.map((file) => {
@@ -23,8 +23,7 @@ export async function uploadBulletinImages(
   );
 
   return results.map((res, i) => ({
-    cloudinaryId: res.public_id,
-    url: res.secure_url,
+    cloudinaryId: stripRootPrefix(res.public_id),
     orderIndex: startOrderIndex + i
   }));
 }

--- a/src/apis/cloudinary.ts
+++ b/src/apis/cloudinary.ts
@@ -2,11 +2,21 @@
 
 import { v2 as cloudinary } from 'cloudinary';
 
+const ROOT_FOLDER = process.env.NEXT_PUBLIC_CLOUDINARY_ROOT_FOLDER ?? '';
+
 cloudinary.config({
   cloud_name: process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME,
   api_key: process.env.CLOUDINARY_API_KEY,
   api_secret: process.env.CLOUDINARY_API_SECRET
 });
+
+// Cloudinary destroy는 fully-qualified public_id를 요구. DB에 저장된 ROOT-relative cloudinary_id를 받으면 ROOT 합성
+function toFullyQualifiedPublicId(publicId: string): string {
+  const trimmed = publicId.replace(/^\/+/, '');
+  if (!ROOT_FOLDER) return trimmed;
+  const prefix = `${ROOT_FOLDER}/`;
+  return trimmed.startsWith(prefix) ? trimmed : `${prefix}${trimmed}`;
+}
 
 export async function uploadImage({
   file,
@@ -36,7 +46,7 @@ export async function uploadImage({
 
 export async function deleteImage(publicId: string) {
   try {
-    const result = await cloudinary.uploader.destroy(publicId);
+    const result = await cloudinary.uploader.destroy(toFullyQualifiedPublicId(publicId));
     return result;
   } catch (error: any) {
     console.error('[Cloudinary Delete Error] ', error.response?.data || error.message);

--- a/src/apis/cloudinary.ts
+++ b/src/apis/cloudinary.ts
@@ -12,6 +12,7 @@ cloudinary.config({
 
 // Cloudinary destroy는 fully-qualified public_id를 요구. DB에 저장된 ROOT-relative cloudinary_id를 받으면 ROOT 합성
 function toFullyQualifiedPublicId(publicId: string): string {
+  if (/^https?:\/\//i.test(publicId)) return publicId;
   const trimmed = publicId.replace(/^\/+/, '');
   if (!ROOT_FOLDER) return trimmed;
   const prefix = `${ROOT_FOLDER}/`;
@@ -34,7 +35,7 @@ export async function uploadImage({
 
     const result = await cloudinary.uploader.upload(dataUri, {
       folder,
-      public_id: filename
+      public_id: `${folder}/${filename}`
     });
 
     return result;
@@ -49,7 +50,10 @@ export async function deleteImage(publicId: string) {
     const result = await cloudinary.uploader.destroy(toFullyQualifiedPublicId(publicId));
     return result;
   } catch (error: any) {
-    console.error('[Cloudinary Delete Error] ', error.response?.data || error.message);
+    console.error('[Cloudinary Delete Error] ', {
+      publicId,
+      error: error.response?.data || error.message
+    });
     throw error;
   }
 }

--- a/src/app/(content)/about/pastor/page.module.scss
+++ b/src/app/(content)/about/pastor/page.module.scss
@@ -1,8 +1,7 @@
 // ══════════════════════════════════════════
 // PASTOR — 인사말 페이지
-// references/Greeting.jsx PCGreeting + MGreeting 100% 적용
-//   PC: 좌측 (사진 + 이름 + career) / 우측 (verse + 인사말 + signature)
-//   Mobile: 사진+이름 / verse(center) / 인사말 / signature / career 카드 (별도)
+//   PC: 좌측 profile (사진 + 이름 + career 카드) / 우측 content (verse + 인사말 + signature)
+//   Mobile: content / profile (사진 + 이름 + career 카드)
 // ══════════════════════════════════════════
 
 .container {
@@ -20,13 +19,12 @@
   grid-template-columns: 1fr;
   grid-template-areas:
     'content'
-    'profile'
-    'career';
+    'profile';
   gap: $spacing-32;
 
-  @include respond-up($breakpoint-pc-sm) {
-    grid-template-columns: 32rem 1fr;
-    grid-template-areas: 'profile content';
+  @include respond-up($breakpoint-tablet) {
+    grid-template-columns: 1fr 30%;
+    grid-template-areas: 'content profile';
     column-gap: $spacing-56;
     row-gap: 0;
     align-items: start;
@@ -44,9 +42,11 @@
 }
 
 .photo {
+  position: relative;
   width: 100%;
   aspect-ratio: 4 / 5;
   margin-bottom: $spacing-12;
+  overflow: hidden;
   background: linear-gradient(135deg, $beige-100, $beige-150);
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
@@ -106,31 +106,7 @@
   }
 }
 
-// ── PC: profile 하단 career list ──
-
-.career_list_pc {
-  display: none;
-
-  @include respond-up($breakpoint-pc-sm) {
-    display: block;
-    list-style: none;
-    margin-top: $spacing-16;
-    border-top: 0.1rem solid $border-card;
-  }
-}
-
-.career_item_pc {
-  display: flex;
-  align-items: flex-start;
-  gap: $spacing-8;
-  padding: $spacing-10 0;
-  border-bottom: 0.1rem solid $border-card;
-  font-size: $font-size-12;
-  color: $txt-secondary;
-  word-break: keep-all;
-}
-
-// ── 우측 / Mobile 본문: content ──
+// ── 우측 (PC) / Mobile 본문: content ──
 
 .content {
   grid-area: content;
@@ -170,9 +146,10 @@
   border-top: 0.1rem solid $border-card;
   text-align: right;
 
-  @include respond-up($breakpoint-pc-sm) {
+  @include respond-up($breakpoint-tablet) {
     margin-top: $spacing-32;
     padding-top: $spacing-24;
+    text-align: left;
   }
 }
 
@@ -204,18 +181,14 @@
   font-weight: $font-weight-regular;
 }
 
-// ── Mobile: career 별도 카드 ──
+// ── profile_block 하단 career 카드 ──
 
-.career_card_mobile {
-  grid-area: career;
+.career_card {
+  margin-top: $spacing-16;
   padding: $spacing-16;
-  background: $beige-100;
+  background-color: $bg-beige-subtle;
   border: 0.1rem solid $border-card;
   border-radius: $radius-s;
-
-  @include respond-up($breakpoint-pc-sm) {
-    display: none;
-  }
 }
 
 .career_label {

--- a/src/app/(content)/about/pastor/page.module.scss
+++ b/src/app/(content)/about/pastor/page.module.scss
@@ -24,7 +24,7 @@
 
   @include respond-up($breakpoint-tablet) {
     grid-template-columns: 1fr 30%;
-    grid-template-areas: 'content profile';
+    grid-template-areas: 'profile content';
     column-gap: $spacing-56;
     row-gap: 0;
     align-items: start;
@@ -47,7 +47,7 @@
   aspect-ratio: 4 / 5;
   margin-bottom: $spacing-12;
   overflow: hidden;
-  background: linear-gradient(135deg, $beige-100, $beige-150);
+  background: linear-gradient(135deg, $bg-beige-subtle, $bg-secondary);
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
   display: flex;

--- a/src/app/(content)/about/pastor/page.tsx
+++ b/src/app/(content)/about/pastor/page.tsx
@@ -30,7 +30,7 @@ export default async function PastorPage() {
   return (
     <LayoutContainer className={styles.container}>
       <div className={styles.grid}>
-        {/* 좌측: 사진 + 이름 (+ PC 한정 career) */}
+        {/* 좌측 (PC) / 상단 (Mobile): 사진 + 이름 + career 카드 */}
         <aside className={styles.profile_block}>
           <div className={styles.photo}>
             {pastor?.imageUrl ? (
@@ -51,15 +51,18 @@ export default async function PastorPage() {
               <span className={styles.name}>{name}</span>
               <span className={styles.role}>{title}</span>
             </p>
-            <ul className={styles.career_list_pc}>
+          </div>
+          <section className={styles.career_card}>
+            <p className={styles.career_label}>CAREER</p>
+            <ul className={styles.career_list}>
               {career.map((line, index) => (
-                <li key={index} className={styles.career_item_pc}>
+                <li key={index} className={styles.career_item}>
                   <span className={styles.career_dot} aria-hidden="true" />
                   {line}
                 </li>
               ))}
             </ul>
-          </div>
+          </section>
         </aside>
 
         {/* 우측 (PC) / 본문 (Mobile): 인사말 + signature */}
@@ -84,19 +87,6 @@ export default async function PastorPage() {
             </p>
           </footer>
         </article>
-
-        {/* Mobile 한정: career 별도 카드 (references MGreeting) */}
-        <aside className={styles.career_card_mobile}>
-          <p className={styles.career_label}>CAREER</p>
-          <ul className={styles.career_list}>
-            {career.map((line, index) => (
-              <li key={index} className={styles.career_item}>
-                <span className={styles.career_dot} aria-hidden="true" />
-                {line}
-              </li>
-            ))}
-          </ul>
-        </aside>
       </div>
     </LayoutContainer>
   );

--- a/src/app/(content)/about/serving-people/page.tsx
+++ b/src/app/(content)/about/serving-people/page.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import MainContainer from '@/components/layout/container/MainContainer';
 // eslint-disable-next-line no-restricted-imports -- 점진 마이그레이션 대상 (tech-debt-tracker.md)
 import { getActiveStaff } from '@/apis/staff';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
 import type { StaffType } from '@/types/common';
 import styles from './page.module.scss';
 
@@ -36,47 +37,62 @@ export default async function ServingPeople() {
   );
 }
 
-const StaffProfile = ({ staff }: { staff: StaffType }) => (
-  <div className={styles.profile}>
-    <div className={styles.title}>
-      <h4>
-        {staff.title} {staff.name}
-      </h4>
-    </div>
-    <div className={styles.detail}>
-      <div className={styles.image_wrap}>
-        <img src={staff.image_url ?? ''} alt="프로필 이미지" />
+const StaffProfile = ({ staff }: { staff: StaffType }) => {
+  const isLegacyPublicPath = staff.image_url?.startsWith('/');
+
+  return (
+    <div className={styles.profile}>
+      <div className={styles.title}>
+        <h4>
+          {staff.title} {staff.name}
+        </h4>
       </div>
-      <div className={styles.content}>
-        {staff.education.length > 0 && (
-          <div>
-            <h5>학력</h5>
-            <ul>
-              {staff.education.map((edu, idx) => (
-                <li key={idx}>{edu}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {staff.experience.length > 0 && (
-          <div>
-            <h5>약력</h5>
-            <ul>
-              {staff.experience.map((exp, idx) => (
-                <li key={idx}>{exp}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {staff.contact && (
-          <div>
-            <h5>연락처</h5>
-            <ul>
-              <li>{staff.contact}</li>
-            </ul>
-          </div>
-        )}
+      <div className={styles.detail}>
+        <div className={styles.image_wrap}>
+          {staff.image_url &&
+            (isLegacyPublicPath ? (
+              // eslint-disable-next-line @next/next/no-img-element -- 점진 마이그레이션: cloudinary 이관 전 legacy public/ 자산
+              <img src={staff.image_url} alt="프로필 이미지" width={200} height={267} />
+            ) : (
+              <CloudinaryImage
+                src={staff.image_url}
+                alt="프로필 이미지"
+                width={200}
+                height={267}
+              />
+            ))}
+        </div>
+        <div className={styles.content}>
+          {staff.education.length > 0 && (
+            <div>
+              <h5>학력</h5>
+              <ul>
+                {staff.education.map((edu, idx) => (
+                  <li key={idx}>{edu}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {staff.experience.length > 0 && (
+            <div>
+              <h5>약력</h5>
+              <ul>
+                {staff.experience.map((exp, idx) => (
+                  <li key={idx}>{exp}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {staff.contact && (
+            <div>
+              <h5>연락처</h5>
+              <ul>
+                <li>{staff.contact}</li>
+              </ul>
+            </div>
+          )}
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};

--- a/src/app/(content)/about/vision/page.tsx
+++ b/src/app/(content)/about/vision/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   }
 };
 
-const IMAGE_URL = 'dnchurch_nxmttl';
+const IMAGE_URL = 'site/about/vision/exterior.jpg';
 
 const VISION = {
   slogan: '복음 위에 서서, 이웃과 함께 자라는 교회',

--- a/src/app/(content)/news/bulletins/[id]/update/page.tsx
+++ b/src/app/(content)/news/bulletins/[id]/update/page.tsx
@@ -22,7 +22,6 @@ export default async function BulletinPage({ params }: { params: Promise<{ id: s
       id: `existing-${img.id}`,
       imageId: img.id,
       cloudinaryId: img.cloudinary_id,
-      url: img.url,
       orderIndex: img.order_index
     }));
 

--- a/src/app/(content)/news/bulletins/_component/LatestBulletin.tsx
+++ b/src/app/(content)/news/bulletins/_component/LatestBulletin.tsx
@@ -25,7 +25,7 @@ export default function LatestBulletin({ title, images }: Props) {
         <KakaoShareBtn
           title={`${title} | 대구동남교회`}
           description="이번 주 교회 주보에서 예배 일정과 소식을 살펴보세요."
-          imageUrl={getCloudinaryUrl(imageIds[0])}
+          imageUrl={imageIds[0] ? getCloudinaryUrl(imageIds[0]) : undefined}
         />
       </div>
     </section>

--- a/src/app/_component/home/NewHere.tsx
+++ b/src/app/_component/home/NewHere.tsx
@@ -6,6 +6,7 @@ import { PiArrowRight } from 'react-icons/pi';
 import clsx from 'clsx';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
 import { LayoutContainer } from '@/components/layout';
+import { siteAsset } from '@/utils/cloudinary';
 import { getRevealStyle } from '@/utils/reveal';
 import styles from './NewHere.module.scss';
 
@@ -51,7 +52,7 @@ export default function NewHere() {
             <div className={styles.image_sticky}>
               <div className={styles.image_frame}>
                 <CloudinaryImage
-                  src="dnchurch-dev/site/home/sketch"
+                  src={siteAsset('home/sketch')}
                   alt="대구동남교회 전경"
                   width={600}
                   height={800}

--- a/src/components/common/CloudinaryImage.tsx
+++ b/src/components/common/CloudinaryImage.tsx
@@ -31,12 +31,11 @@ export default function CloudinaryImage({
       fill={fill}
       sizes={sizes}
       loader={createCloudinaryLoader({ cropMode, gravity, aspectRatio })}
-      style={{
-        width: fill ? undefined : '100%',
-        height: fill ? undefined : style?.height || 'auto',
-        display: 'block',
-        ...style
-      }}
+      style={
+        fill
+          ? { objectFit: 'cover', ...style }
+          : { width: '100%', height: style?.height || 'auto', display: 'block', ...style }
+      }
       {...rest}
     />
   );

--- a/src/components/file/ImagePreview.tsx
+++ b/src/components/file/ImagePreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FaRegTrashAlt } from 'react-icons/fa';
+import { getCloudinaryUrl } from '@/utils/cloudinary';
 import { formattedDate } from '@/utils/date';
 import { convertBytesToFileSize } from '@/utils/file';
 import type { ImageItem } from '@/types/bulletin';
@@ -18,7 +19,7 @@ export default function ImagePreview({ images, onDelete }: Props) {
     <div className={styles.container}>
       {images.map((image) => {
         const isExisting = image.type === 'existing';
-        const imageSrc = isExisting ? image.url : image.previewUrl;
+        const imageSrc = isExisting ? getCloudinaryUrl(image.cloudinaryId) : image.previewUrl;
 
         const fileName = isExisting
           ? image.cloudinaryId.split('/').pop() || '기존 이미지'

--- a/src/services/bulletin/bulletin-service.ts
+++ b/src/services/bulletin/bulletin-service.ts
@@ -111,7 +111,6 @@ export const bulletinService = (supabase: SupabaseClient<Database>) => ({
         p_author_id: authorId,
         p_images: images.map((img) => ({
           cloudinary_id: img.cloudinaryId,
-          url: img.url,
           order_index: img.orderIndex
         }))
       })
@@ -134,7 +133,6 @@ export const bulletinService = (supabase: SupabaseClient<Database>) => ({
         p_sunday_date: sundayDate,
         p_images_to_add: imagesToAdd.map((img) => ({
           cloudinary_id: img.cloudinaryId,
-          url: img.url,
           order_index: img.orderIndex
         })),
         p_image_ids_to_delete: imageIdsToDelete

--- a/src/types/bulletin.ts
+++ b/src/types/bulletin.ts
@@ -9,7 +9,6 @@ export type BulletinParams = { year?: number; page?: number; limit?: number };
 
 export type BulletinImageInput = {
   cloudinaryId: string;
-  url: string;
   orderIndex: number;
 };
 
@@ -40,7 +39,6 @@ export type ExistingImageItem = {
   id: string;
   imageId: number;
   cloudinaryId: string;
-  url: string;
   orderIndex: number;
 };
 

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -21,7 +21,6 @@ export type Database = {
           created_at: string
           id: number
           order_index: number
-          url: string
         }
         Insert: {
           bulletin_id: number
@@ -29,7 +28,6 @@ export type Database = {
           created_at?: string
           id?: never
           order_index?: number
-          url: string
         }
         Update: {
           bulletin_id?: number
@@ -37,7 +35,6 @@ export type Database = {
           created_at?: string
           id?: never
           order_index?: number
-          url?: string
         }
         Relationships: [
           {
@@ -816,7 +813,10 @@ export const Constants = {
         "새벽예배",
         "특별예배",
       ],
-      worship_category: ["main", "church_school"],
+      worship_category: [
+        "main",
+        "church_school",
+      ],
     },
   },
 } as const

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -4,10 +4,8 @@ const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
 const ROOT_FOLDER = process.env.NEXT_PUBLIC_CLOUDINARY_ROOT_FOLDER ?? '';
 const BASE_URL = `https://res.cloudinary.com/${CLOUD_NAME}/image/upload`;
 
-// 입력 public_id에 ROOT prefix가 누락되면 합성, 이미 있으면 그대로 (이중 prefix 방지)
-// full URL(http/https)이 들어오면 변형 없이 통과 — 호출자 misuse를 망가뜨리지 않음
+// ROOT prefix missing from public_id is composed here; full URL passthrough belongs to URL builders.
 const normalizePublicId = (input: string): string => {
-  if (/^https?:\/\//i.test(input)) return input;
   const trimmed = input.replace(/^\/+/, '');
   if (!ROOT_FOLDER) return trimmed;
   const prefix = `${ROOT_FOLDER}/`;
@@ -44,7 +42,8 @@ export const uploadFolder = (domain: string, ...parts: string[]): string => {
 };
 
 // Cloudinary 전송 URL 빌더 — <img>·OG 메타데이터·다운로드 등 <Image> 컴포넌트 외 사용처
-export const getCloudinaryUrl = (publicId: string) => `${BASE_URL}/${normalizePublicId(publicId)}`;
+export const getCloudinaryUrl = (publicId: string) =>
+  /^https?:\/\//i.test(publicId) ? publicId : `${BASE_URL}/${normalizePublicId(publicId)}`;
 
 export const getCloudinaryDownloadUrl = (publicId: string) =>
   `${BASE_URL}/fl_attachment/${normalizePublicId(publicId)}`;
@@ -61,6 +60,7 @@ type CloudinaryLoaderOptions = {
 // next/image의 loader — <CloudinaryImage>가 내부적으로 사용. src에 ROOT가 없으면 자동 합성됨
 export function createCloudinaryLoader({ cropMode, gravity, aspectRatio }: CloudinaryLoaderOptions = {}) {
   return function ({ src, width, quality }: ImageLoaderProps) {
+    if (/^https?:\/\//i.test(src)) return src;
     const params = ['f_auto'];
     if (cropMode) {
       params.push(`c_${cropMode}`);

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -1,12 +1,53 @@
 import { ImageLoaderProps } from 'next/image';
 
 const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+const ROOT_FOLDER = process.env.NEXT_PUBLIC_CLOUDINARY_ROOT_FOLDER ?? '';
 const BASE_URL = `https://res.cloudinary.com/${CLOUD_NAME}/image/upload`;
 
-export const getCloudinaryUrl = (publicId: string) => `${BASE_URL}/${publicId}`;
+// 입력 public_id에 ROOT prefix가 누락되면 합성, 이미 있으면 그대로 (이중 prefix 방지)
+// full URL(http/https)이 들어오면 변형 없이 통과 — 호출자 misuse를 망가뜨리지 않음
+const normalizePublicId = (input: string): string => {
+  if (/^https?:\/\//i.test(input)) return input;
+  const trimmed = input.replace(/^\/+/, '');
+  if (!ROOT_FOLDER) return trimmed;
+  const prefix = `${ROOT_FOLDER}/`;
+  return trimmed.startsWith(prefix) ? trimmed : `${prefix}${trimmed}`;
+};
+
+const assertSegment = (segment: string, label: string) => {
+  if (!segment) throw new Error(`${label}: segment cannot be empty`);
+  if (segment.includes('/')) throw new Error(`${label}: segment "${segment}" cannot contain "/"`);
+};
+
+// Cloudinary 업로드 응답의 public_id에서 환경 prefix를 떼서 DB에 저장할 때 사용
+export const stripRootPrefix = (publicId: string): string => {
+  const cleaned = publicId.replace(/^\/+/, '');
+  if (!ROOT_FOLDER) return cleaned;
+  const prefix = `${ROOT_FOLDER}/`;
+  return cleaned.startsWith(prefix) ? cleaned.slice(prefix.length) : cleaned;
+};
+
+// 정적 자산(코드에서 직접 참조하는 사이트 이미지)의 public_id 합성: <CloudinaryImage src={siteAsset('home/sketch')} />
+export const siteAsset = (relativePath: string): string => {
+  const cleaned = relativePath.replace(/^\/+|\/+$/g, '');
+  if (!cleaned) throw new Error('siteAsset: relativePath cannot be empty');
+  if (cleaned.includes('//')) throw new Error('siteAsset: relativePath cannot contain "//"');
+  return ROOT_FOLDER ? `${ROOT_FOLDER}/site/${cleaned}` : `site/${cleaned}`;
+};
+
+// 동적 업로드(주보·설교 등 DB 첨부 자산)의 업로드 folder path 합성: uploadFolder('bulletins', '2026', '03', '28')
+export const uploadFolder = (domain: string, ...parts: string[]): string => {
+  assertSegment(domain, 'uploadFolder');
+  parts.forEach((part) => assertSegment(part, 'uploadFolder'));
+  const tail = [domain, ...parts].join('/');
+  return ROOT_FOLDER ? `${ROOT_FOLDER}/uploads/${tail}` : `uploads/${tail}`;
+};
+
+// Cloudinary 전송 URL 빌더 — <img>·OG 메타데이터·다운로드 등 <Image> 컴포넌트 외 사용처
+export const getCloudinaryUrl = (publicId: string) => `${BASE_URL}/${normalizePublicId(publicId)}`;
 
 export const getCloudinaryDownloadUrl = (publicId: string) =>
-  `${BASE_URL}/fl_attachment/${publicId}`;
+  `${BASE_URL}/fl_attachment/${normalizePublicId(publicId)}`;
 
 export type CropMode = 'fill' | 'crop' | 'thumb' | 'scale' | 'fit' | 'limit' | 'pad' | 'auto';
 export type CropGravity = 'auto' | 'face' | 'faces' | 'center' | 'north' | 'south' | 'east' | 'west' | 'north_east' | 'north_west' | 'south_east' | 'south_west';
@@ -17,6 +58,7 @@ type CloudinaryLoaderOptions = {
   aspectRatio?: string;
 };
 
+// next/image의 loader — <CloudinaryImage>가 내부적으로 사용. src에 ROOT가 없으면 자동 합성됨
 export function createCloudinaryLoader({ cropMode, gravity, aspectRatio }: CloudinaryLoaderOptions = {}) {
   return function ({ src, width, quality }: ImageLoaderProps) {
     const params = ['f_auto'];
@@ -28,7 +70,7 @@ export function createCloudinaryLoader({ cropMode, gravity, aspectRatio }: Cloud
       params.push('c_limit');
     }
     params.push(`w_${width}`, `q_${quality || 85}`);
-    return `${BASE_URL}/${params.join(',')}/${src}`;
+    return `${BASE_URL}/${params.join(',')}/${normalizePublicId(src)}`;
   };
 }
 


### PR DESCRIPTION
## 📋 개요

Cloudinary 자산 폴더 구조를 `site/`(정적) + `uploads/{도메인}/`(동적)로 1차 분리하고, DB `cloudinary_id`에서 환경 prefix를 제거해 dev/prod 환경 분리를 완성. legacy seed 데이터·폴더 정리 + 회귀 fix + pastor 페이지 UI 통일까지 포함.

---

## 🔗 개발 컨텍스트

- **Task ID**: `cloudinary-asset-structure`
- **Exec Plan**: `docs/exec-plans/active/2026-05-11-cloudinary-asset-structure.md`
- **관련 ADR**: `docs/decisions/0007-cloudinary-asset-folder-convention.md`
- **작업 범위**: 코드 헬퍼·DB schema·Cloudinary 자산 정리·정적 자산 마이그레이션 일부(NewHere/vision/pastor)·회귀 fix 3건·pastor career UI 통일
- **제외한 범위**: prod 환경 적용 (별 plan), 정적 자산 일괄 재배치, 5개 비-cloudinary `*_url` 컬럼

---

## 💡 리팩토링 배경

**개선하려는 문제:**
- [x] 가독성 저하 (정적·동적 자산이 한 prefix에 혼재)
- [x] 유지보수 난이도 증가 (DB `cloudinary_id`에 환경 prefix 박힘 → dev/prod 분리가 데이터 레이어에서 깨짐)
- [x] 기술 부채 해소 (legacy 폴더 3개 + 11/11 시드 row가 컨벤션 위반)

---

## 🔧 주요 변경점

- **헬퍼 4개 도입** (`utils/cloudinary.ts`): `siteAsset()`, `uploadFolder()`, `stripRootPrefix()`, `normalizePublicId()`(private, full URL guard 포함)
- **`getCloudinaryUrl`/`createCloudinaryLoader`/`apis/deleteImage`** 모두 ROOT prefix 자동 합성 — DB는 ROOT-relative 저장
- **`bulletin_images.url` 컬럼 DROP** + RPC 재정의 (cloudinary_id로 URL 재생성, redundant 제거)
- **bulletin* 시드 truncate** (dev only — 11/11 row가 legacy 폴더 또는 환경 prefix 포함 등 컨벤션 위반)
- **legacy cloudinary 폴더 정리**: `dnchurch`, `bulletins`, `bulletin`, `dnchurch-dev/bulletins/` 삭제
- **정적 자산 마이그레이션**: NewHere(home/sketch), vision(IMAGE_URL), pastor(portrait) — 새 컨벤션 적용
- **회귀 fix 3건** (별 commit): bulletin 빈 데이터 페이지 + Image fill 모드 layout + deleteImage ROOT 합성
- **pastor 페이지 career UI 통일** (별 commit): PC 전용 인라인 리스트 폐지, mobile 카드 디자인을 모든 viewport에 적용

---

## 🏗️ 의사 결정 기록

상세는 ADR 0007 참조. 핵심:

| 결정 | 선택 | 이유 |
|---|---|---|
| 1차 축 | static/dynamic | 운영 주체(코드 vs DB row) 분리 |
| DB 저장 형식 | ROOT-relative | dev/prod 환경 독립, 코드 헬퍼가 합성 |
| 마이그레이션 | truncate (dev 시드) | 11/11 row가 컨벤션 위반, 운영 데이터 아님 |
| Hero 자산 | `<page>/hero.jpg` | 페이지 폴더 내부 (별도 hero/ 폴더 X, `_hero.jpg` underscore X) |
| Console 업로드 | rename 1단계 필요 (또는 fully-qualified Public ID 직접 입력) | dynamic folder mode → public_id가 파일명만 됨 |

> ⚠️ **주의사항**: Cloudinary Console 업로드 시 Public ID를 fully-qualified로 입력하지 않으면 rename 1단계 필요. 후속 부채로 운영 절차 문서화 예정.

---

## ✅ 하네스 검증

| 항목 | 결과 |
| ---- | ---- |
| `verify-task` | PASS (Knip warning은 기존 부채) |
| Codex 계획 검증 | **PASS** |
| Codex 1차 검증 | **CHANGE_REQUEST → 2건 모두 FIX_APPLIED** (URL guard, TRUNCATE 분리) |
| Claude 2차 검증 | 완료 |
| ADR 판단 | `docs/decisions/0007-cloudinary-asset-folder-convention.md` |
| 남은 warning | 기존 부채 (ESLint 28 / Knip — pastor PR 전부터 존재) |

---

## 🗂️ 셀프 체크리스트

- [x] 외부 동작(기능, API 인터페이스) 변경 없음 — 컨벤션·내부 구조만 변경
- [x] 불필요한 기능 변경 미포함 — pastor career UI는 별 commit으로 분리
- [x] 변수명·함수명의 의도 명확성 — 헬퍼 이름이 사용 컨텍스트 표현
- [x] 불필요한 코드·디버그 로그 제거

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 새 주보·정적 자산은 새 컨벤션 폴더(`uploads/bulletins/`, `site/about/`)로 저장. 기존 dev 시드 데이터는 truncate (운영 데이터 아님)
- **운영 / 릴리스 주의사항**: prod 환경 적용은 별 plan에서 진행. 본 PR 머지로 prod에 영향 없음
- **롤백 시 영향**: dev DB의 bulletin* 시드는 truncate 후 복구 불가 (의도된 정리). 코드 롤백 시 새 헬퍼 사용처 broken
- **먼저 볼 화면**: `/about/pastor` (사진+UI 통일), `/about/vision` (사진), `/news/bulletins` (빈 데이터 페이지)

---

## 📝 리뷰어를 위한 메모

- Console 업로드 시 Public ID를 fully-qualified로 입력 권장 (그렇지 않으면 rename 1단계 필요 — 운영 절차 후속 부채)
- 정적 자산 폴더 재배치(`site/welcome/` → `site/about/welcome/` 등)는 후속 PR
- 5개 비-cloudinary `*_url` 컬럼(notices/sermons/staff/preachers/sermon_series)은 본 PR 범위 밖 (실제 cloudinary 자산 아님)
- supabase migration 파일은 `.gitignore`로 제외 — apply_migration MCP history로 관리

---

## 🔁 리뷰 피드백 반영 (Update — commit `788f131`)

자동 리뷰(Gemini Code Assist + Codex bot) 피드백 7건 모두 반영. Codex 재검토 후 fix 설계 → 적용.

### P1 (잠재 버그)
- **`uploadImage` public_id 보존**: `cloudinary.uploader.upload`에 `public_id: \`${folder}/${filename}\``로 fully-qualified 명시 → fixed/dynamic folder mode 무관 안정 (Codex P1)
- **`toFullyQualifiedPublicId` URL guard 추가**: `^https?://` early return — `deleteImage`에 full URL 전달 시 `dnchurch-dev/https://...` 회피 (Gemini P1)

### P2 (즉시 깨질 케이스)
- **URL guard 구조 정정**: `normalizePublicId`의 URL guard 제거, `getCloudinaryUrl`/`createCloudinaryLoader`에서 early return으로 이동 — `${BASE_URL}/${normalize(url)}` 형태로 BASE_URL이 항상 prepend되어 `.../upload/https://...` 깨지던 문제 fix (Codex P2)
- **`/about/serving-people` 회귀 fix**: `staff.image_url`을 cloudinary public_id(`!startsWith('/')`)와 legacy public path(`startsWith('/')`)로 분기 처리 (`<CloudinaryImage>` vs `<img>`) — pastor staff.image_url 마이그레이션으로 발생한 다른 페이지 깨짐 회복 (Codex P2)

### P2 (품질)
- **`deleteImage` error log에 `publicId` 컨텍스트** (Gemini)
- **pastor SCSS 주석/grid 정합**: PC `grid-template-areas`를 `'profile content'`로 복원 — JSX 주석("좌측 profile / 우측 content")과 일치 (Gemini+Codex)
- **`.photo` gradient semantic 토큰**: `$beige-100/150` → `$bg-beige-subtle`/`$bg-secondary` (Gemini)

### Codex 재검토 결과
- ADR 0001 기준 객관 리뷰 위임 → 모든 fix 방향에 합의
- 검증: `verify-task.mjs` PASS, `yarn build` PASS
- 추가 commit: `788f131` (4 files, +69/-49)
