### PR TITLE
[Fix] release v0.5.0 QA 9건 — about/news 경로 + a11y + 공용 UI 정합

### DIFF
--- a/.claude/skills/supabase/SKILL.md
+++ b/.claude/skills/supabase/SKILL.md
@@ -59,7 +59,7 @@ const supabase = createStaticClient({ tags: ['staff'], cache: 'force-cache' });
 
 ```ts
 // 예시: 주보 수정 후
-revalidatePath('/news/bulletin');
+revalidatePath('/news/bulletins');
 revalidateTag('bulletin-detail');      // 전체 상세 무효화
 revalidateTag(`bulletin-detail-${id}`); // 특정 건만 무효화
 ```

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -247,15 +247,6 @@
 - **영향 범위**: `src/actions/_bulletin-helpers.ts`, `src/apis/cloudinary.ts`
 - **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
 
-### 🟡 `serverActions.bodySizeLimit` ↔ bulletin UI 정책 불일치
-
-- **무엇**: `next.config.ts:24`의 `bodySizeLimit: '5mb'` vs bulletin UI는 1장 5MB × 최대 5장 허용. 여러 장 동시 업로드 시 Server Action 진입 전 body limit으로 차단 가능 (Cloudinary upload는 base64 직렬화로 추가 bloat ≈ +33%)
-- **왜**: 단일 파일 업로드 가정으로 설정. multi-upload 추가 시 limit 재검토 누락
-- **마이그레이션 경로**: (a) `bodySizeLimit`을 `30mb`로 상향(5MB×5 + base64 + 메타데이터) 또는 (b) 클라이언트에서 순차 업로드로 전환(메모리 안전). (a)가 단순하지만 DoS 위험 약간 증가
-- **확인 필요**: 실제로 5장 동시 업로드 시 차단되는지 reproduce
-- **영향 범위**: `next.config.ts`, `src/actions/_bulletin-helpers.ts`, bulletin form
-- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
-
 ### 🟢 Cloudinary 이미지 품질 `q_85` 고정 → `q_auto` 전환 검토
 
 - **무엇**: `src/utils/cloudinary.ts:72`의 loader가 `q_85` 고정. Cloudinary 공식 권장은 `q_auto` (또는 `q_auto:good`) — 컨텐츠별 최적 품질로 자동 조정
@@ -321,4 +312,11 @@
 - **참고**: `feat/common-components-v4` 브랜치에 등록된 "Hover Border 위반 — 디자인 시스템 v4 미완 잔여 (10건)" 부채 중 home 5건 + SermonCard 1건 분량을 본 작업으로 청산. admin 5건은 후속 ADR 0004 영역으로 분리 보존.
 - **결과 기록**: `docs/exec-plans/completed/2026-05-07-design-system-v4-home-cleanup.md` (머지 후 이동 예정)
 
-<!-- last-audit: 2026-05-07 -->
+### ✅ `serverActions.bodySizeLimit` ↔ bulletin upload 정책 불일치 (2026-05-11)
+
+- **부채**: `bodySizeLimit: '5mb'` vs bulletin UI 5MB × 최대 5장(=25MB). multi-upload 시 Server Action 진입 전 차단 가능 (PR #82 Codex 리뷰에서 등록)
+- **해소**: about-page-qa fix에서 `next.config.ts:24` `bodySizeLimit`을 `5mb` → `30mb`로 상향. 25MB 정책 수용
+- **확인**: 변경 1줄. 빌드/lint PASS
+- **참고**: sermon 자료 단일 50MB 한도(`src/lib/sermon-resource.ts`)는 운영상 차단 사례 미확인 — 발생 시 별도 부채로 등록
+
+<!-- last-audit: 2026-05-11 -->

--- a/next.config.ts
+++ b/next.config.ts
@@ -21,7 +21,7 @@ const nextConfig: NextConfig = {
   },
   experimental: {
     serverActions: {
-      bodySizeLimit: '5mb'
+      bodySizeLimit: '30mb'
     }
   },
   logging: {

--- a/src/app/(content)/about/location/_component/AddressActions.tsx
+++ b/src/app/(content)/about/location/_component/AddressActions.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useToastStore } from '@/store/toast.store';
+import styles from '../page.module.scss';
+
+type Props = {
+  address: string;
+  lat: number;
+  lng: number;
+  destinationName: string;
+};
+
+export default function AddressActions({ address, lat, lng, destinationName }: Props) {
+  const { success, error } = useToastStore();
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      success('주소가 복사되었습니다');
+    } catch {
+      error('주소 복사에 실패했습니다');
+    }
+  };
+
+  const directionsUrl = `https://map.naver.com/v5/directions/-/${lng},${lat},${encodeURIComponent(destinationName)},PLACE_POI/-/transit`;
+
+  return (
+    <div className={styles.address_actions}>
+      <button type="button" className={styles.btn_secondary} onClick={handleCopy}>
+        주소 복사
+      </button>
+      <a
+        href={directionsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.btn_primary}
+      >
+        길찾기
+        <span aria-hidden="true">→</span>
+      </a>
+    </div>
+  );
+}

--- a/src/app/(content)/about/location/_component/AddressActions.tsx
+++ b/src/app/(content)/about/location/_component/AddressActions.tsx
@@ -5,12 +5,10 @@ import styles from '../page.module.scss';
 
 type Props = {
   address: string;
-  lat: number;
-  lng: number;
   destinationName: string;
 };
 
-export default function AddressActions({ address, lat, lng, destinationName }: Props) {
+export default function AddressActions({ address, destinationName }: Props) {
   const { success, error } = useToastStore();
 
   const handleCopy = async () => {
@@ -22,7 +20,8 @@ export default function AddressActions({ address, lat, lng, destinationName }: P
     }
   };
 
-  const directionsUrl = `https://map.naver.com/v5/directions/-/${lng},${lat},${encodeURIComponent(destinationName)},PLACE_POI/-/transit`;
+  // 검색 URL — 도착지(교회)에 카메라 포커싱. directions URL은 출발지 미지정 시 사용자 현재 위치로 카메라 이동
+  const placeUrl = `https://map.naver.com/p/search/${encodeURIComponent(`${destinationName} ${address}`)}`;
 
   return (
     <div className={styles.address_actions}>
@@ -30,7 +29,7 @@ export default function AddressActions({ address, lat, lng, destinationName }: P
         주소 복사
       </button>
       <a
-        href={directionsUrl}
+        href={placeUrl}
         target="_blank"
         rel="noopener noreferrer"
         className={styles.btn_primary}

--- a/src/app/(content)/about/location/page.module.scss
+++ b/src/app/(content)/about/location/page.module.scss
@@ -104,14 +104,14 @@
 .btn_secondary {
   flex: 1;
   padding: $spacing-10 $spacing-12;
-  background: $bg-primary;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-s;
   color: $txt-primary;
   font-size: $font-size-12;
   font-weight: $font-weight-semibold;
   cursor: pointer;
-  @include hover-bg-shift($beige-100);
+  @include hover-bg-shift($bg-hover);
 
   &:disabled {
     cursor: not-allowed;

--- a/src/app/(content)/about/location/page.tsx
+++ b/src/app/(content)/about/location/page.tsx
@@ -3,6 +3,7 @@ import LayoutContainer from '@/components/layout/container/LayoutContainer';
 import { getLocationPageData } from '@/services/about';
 import { displaySettingValue, parseFiniteFloat } from '@/utils/site-settings';
 import LocationMapClient from './_component/LocationMapClient';
+import AddressActions from './_component/AddressActions';
 import styles from './page.module.scss';
 
 export const metadata: Metadata = {
@@ -58,17 +59,12 @@ export default async function Directions() {
           <p className={styles.card_eyebrow}>ADDRESS</p>
           <p className={styles.address_main}>{address}</p>
           <p className={styles.address_sub}>{zipcode}</p>
-          <div className={styles.address_actions}>
-            {/* TODO: 주소 복사 + 외부 지도 길찾기 링크 연동 */}
-            <button type="button" className={styles.btn_secondary} disabled>
-              주소 복사
-            </button>
-            {/* TODO: 외부 지도 길찾기 URL 연동 후 활성화 */}
-            <button type="button" className={styles.btn_primary} disabled>
-              길찾기
-              <span aria-hidden="true">→</span>
-            </button>
-          </div>
+          <AddressActions
+            address={address}
+            lat={lat}
+            lng={lng}
+            destinationName="대구동남교회"
+          />
         </section>
 
         <section className={styles.card}>

--- a/src/app/(content)/about/location/page.tsx
+++ b/src/app/(content)/about/location/page.tsx
@@ -59,12 +59,7 @@ export default async function Directions() {
           <p className={styles.card_eyebrow}>ADDRESS</p>
           <p className={styles.address_main}>{address}</p>
           <p className={styles.address_sub}>{zipcode}</p>
-          <AddressActions
-            address={address}
-            lat={lat}
-            lng={lng}
-            destinationName="대구동남교회"
-          />
+          <AddressActions address={address} destinationName="대구동남교회" />
         </section>
 
         <section className={styles.card}>

--- a/src/app/(content)/about/page.tsx
+++ b/src/app/(content)/about/page.tsx
@@ -104,7 +104,7 @@ export default async function AboutHub() {
         {/* GALLERY */}
         <section className={styles.gallery_section}>
           <header className={styles.row_head}>
-            <span className={styles.row_label}>GALLERY</span>
+            <h2 className={styles.row_label}>GALLERY</h2>
             <span className={styles.row_line} aria-hidden="true" />
           </header>
           <div className={styles.gallery_grid}>
@@ -123,7 +123,7 @@ export default async function AboutHub() {
         {/* INDEX 4 cards */}
         <section className={styles.index_section}>
           <header className={styles.row_head}>
-            <span className={styles.row_label}>INDEX</span>
+            <h2 className={styles.row_label}>INDEX</h2>
             <span className={styles.row_line} aria-hidden="true" />
             <span className={styles.row_count}>04 PAGES</span>
           </header>
@@ -154,7 +154,7 @@ export default async function AboutHub() {
         <section className={styles.bottom_grid}>
           <div className={styles.bottom_card}>
             <header className={styles.bottom_head}>
-              <span className={styles.bottom_label}>HISTORY · 걸어온 길</span>
+              <h2 className={styles.bottom_label}>HISTORY · 걸어온 길</h2>
               <Link href="/about/vision" className={styles.bottom_link}>
                 자세히 →
               </Link>
@@ -172,7 +172,7 @@ export default async function AboutHub() {
 
           <div className={styles.bottom_card}>
             <header className={styles.bottom_head}>
-              <span className={styles.bottom_label}>LOCATION · 오시는 길</span>
+              <h2 className={styles.bottom_label}>LOCATION · 오시는 길</h2>
               <Link href="/about/location" className={styles.bottom_link}>
                 지도 →
               </Link>

--- a/src/app/(content)/about/pastor/page.module.scss
+++ b/src/app/(content)/about/pastor/page.module.scss
@@ -24,7 +24,7 @@
 
   @include respond-up($breakpoint-tablet) {
     grid-template-columns: 1fr 30%;
-    grid-template-areas: 'profile content';
+    grid-template-areas: 'content profile';
     column-gap: $spacing-56;
     row-gap: 0;
     align-items: start;
@@ -61,6 +61,7 @@
   @include respond-up($breakpoint-tablet) {
     max-width: 32rem;
     margin-right: auto;
+    background: transparent;
   }
 
   @include respond-up($breakpoint-pc-sm) {

--- a/src/app/(content)/about/worship/page.module.scss
+++ b/src/app/(content)/about/worship/page.module.scss
@@ -135,7 +135,6 @@
 .card {
   display: flex;
   flex-direction: column;
-  min-height: 24rem;
   padding: $spacing-20;
   background: $beige-50;
   border: 0.1rem solid $border-card;

--- a/src/app/(content)/about/worship/page.tsx
+++ b/src/app/(content)/about/worship/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import LayoutContainer from '@/components/layout/container/LayoutContainer';
+import { EmptyState } from '@/components/ui';
 import { getWorshipPageData } from '@/services/about';
 import styles from './page.module.scss';
 
@@ -88,22 +89,26 @@ export default async function Worship() {
                 </Link>
               )}
             </header>
-            <ul className={styles.schedule_list}>
-              {group.items.map((item) => (
-                <li key={item.id} className={styles.schedule_row}>
-                  <div className={styles.schedule_meta}>
-                    <p className={styles.schedule_name}>
-                      <span>{item.name}</span>
-                      {item.age_group && (
-                        <span className={styles.schedule_age}>{item.age_group}</span>
-                      )}
-                    </p>
-                    <p className={styles.schedule_place}>{item.location}</p>
-                  </div>
-                  <p className={styles.schedule_time}>{item.time}</p>
-                </li>
-              ))}
-            </ul>
+            {group.items.length > 0 ? (
+              <ul className={styles.schedule_list}>
+                {group.items.map((item) => (
+                  <li key={item.id} className={styles.schedule_row}>
+                    <div className={styles.schedule_meta}>
+                      <p className={styles.schedule_name}>
+                        <span>{item.name}</span>
+                        {item.age_group && (
+                          <span className={styles.schedule_age}>{item.age_group}</span>
+                        )}
+                      </p>
+                      <p className={styles.schedule_place}>{item.location}</p>
+                    </div>
+                    <p className={styles.schedule_time}>{item.time}</p>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <EmptyState title="예배 일정 준비 중" size="compact" />
+            )}
           </article>
         ))}
       </section>

--- a/src/app/(content)/news/bulletins/[id]/page.tsx
+++ b/src/app/(content)/news/bulletins/[id]/page.tsx
@@ -79,7 +79,7 @@ export default async function BulletinDetail({ params }: { params: Promise<{ id:
       />
       <BoardBody images={imageIds} />
       <BoardFooter files={files} prevNext={prevNextBulletin} />
-      <BoardListLink link="/news/bulletin" />
+      <BoardListLink link="/news/bulletins" />
     </MainContainer>
   );
 }

--- a/src/app/(content)/news/bulletins/_component/BulletinYearFilter.tsx
+++ b/src/app/(content)/news/bulletins/_component/BulletinYearFilter.tsx
@@ -10,14 +10,14 @@ export default function BulletinYearFilter({ selectedYear, years }: Props) {
   return (
     <ul className={styles.yearList}>
       <li>
-        <Link href="/news/bulletin" scroll={false}>
+        <Link href="/news/bulletins" scroll={false}>
           전체
         </Link>
       </li>
       {years?.map((year) => (
         <li key={year}>
           <Link
-            href={`/news/bulletin?year=${year}`}
+            href={`/news/bulletins?year=${year}`}
             scroll={false}
             className={selectedYear === year ? styles.active : ''}
           >

--- a/src/app/(content)/news/bulletins/not-found.tsx
+++ b/src/app/(content)/news/bulletins/not-found.tsx
@@ -4,7 +4,7 @@ import styles from './not-found.module.scss';
 
 export default function NotFound() {
   const handleGoBack = () => {
-    window.location.href = '/news/bulletin';
+    window.location.href = '/news/bulletins';
   };
 
   return (

--- a/src/app/_component/home/Banner.tsx
+++ b/src/app/_component/home/Banner.tsx
@@ -41,7 +41,7 @@ export default async function Banner() {
             <UserIcon />
             처음 오셨나요?
           </Link>
-          <Link href="/news/bulletin" className={styles.btn_secondary}>
+          <Link href="/news/bulletins" className={styles.btn_secondary}>
             <PlayIcon />
             이번 주 말씀 보기
           </Link>

--- a/src/app/_component/home/QuickAccess.tsx
+++ b/src/app/_component/home/QuickAccess.tsx
@@ -19,7 +19,7 @@ const ITEMS = [
     Icon: PiBookOpenLight
   },
   {
-    href: '/about/directions',
+    href: '/about/location',
     label: '오시는 길',
     desc: '교회 위치 및 교통편 안내',
     Icon: PiMapPinLight

--- a/src/components/board/BoardFooter.tsx
+++ b/src/components/board/BoardFooter.tsx
@@ -45,7 +45,7 @@ export default function BoardFooter({
             <dt>이전글</dt>
             <dd>
               {prev_title ? (
-                <Link href={`/news/bulletin/${prev_id}`}>{prev_title}</Link>
+                <Link href={`/news/bulletins/${prev_id}`}>{prev_title}</Link>
               ) : (
                 '이전글이 없습니다.'
               )}
@@ -55,7 +55,7 @@ export default function BoardFooter({
             <dt>다음글</dt>
             <dd>
               {next_title ? (
-                <Link href={`/news/bulletin/${next_id}`}>{next_title}</Link>
+                <Link href={`/news/bulletins/${next_id}`}>{next_title}</Link>
               ) : (
                 '다음글이 없습니다.'
               )}

--- a/src/components/common/CloudinaryImage.tsx
+++ b/src/components/common/CloudinaryImage.tsx
@@ -3,7 +3,7 @@
 import Image, { ImageProps } from 'next/image';
 import { createCloudinaryLoader, CropMode, CropGravity } from '@/utils/cloudinary';
 
-type Props = ImageProps & {
+type Props = Omit<ImageProps, 'loader'> & {
   cropMode?: CropMode;
   gravity?: CropGravity;
   aspectRatio?: string;

--- a/src/components/layout/BottomNav/BottomNav.tsx
+++ b/src/components/layout/BottomNav/BottomNav.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
@@ -21,6 +22,7 @@ const ICON_MAP: Record<IconName, IconType> = {
 export default function BottomNav() {
   const pathname = usePathname();
   const { drawerOpen, openDrawer, closeDrawer } = useDrawerHistory();
+  const overlayRef = useRef<HTMLDivElement>(null);
 
   return (
     <>
@@ -70,9 +72,12 @@ export default function BottomNav() {
       </nav>
 
       <div
+        ref={overlayRef}
         className={clsx(styles.drawer_overlay, drawerOpen && styles.drawer_overlay_open)}
-        onClick={closeDrawer}
-        aria-hidden={!drawerOpen}
+        onClick={(e) => {
+          if (e.target === overlayRef.current) closeDrawer();
+        }}
+        inert={!drawerOpen}
       >
         <Drawer isOpen={drawerOpen} onClose={closeDrawer} />
       </div>

--- a/src/components/layout/Header/Drawer.tsx
+++ b/src/components/layout/Header/Drawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import clsx from 'clsx';
+import { useDialog } from '@/hooks/useDialog';
 import MobileNavigation from './MobileNavigation';
 import styles from './Drawer.module.scss';
 
@@ -10,16 +11,29 @@ type DrawerProps = {
 };
 
 export default function Drawer({ isOpen, onClose }: DrawerProps) {
+  const { panelRef, accessibleLabel } = useDialog({
+    open: isOpen,
+    onClose,
+    ariaLabel: '전체 메뉴',
+    componentName: 'Drawer'
+  });
+
   return (
     <div
+      ref={panelRef}
       role="dialog"
       aria-modal="true"
-      aria-label="전체 메뉴"
+      aria-label={accessibleLabel}
+      tabIndex={-1}
       className={clsx(styles.drawer, isOpen && styles.animate)}
-      onClick={(e) => e.stopPropagation()}
     >
       <div className={styles.top}>
-        <button className={styles.close_button} onClick={onClose}>
+        <button
+          type="button"
+          className={styles.close_button}
+          onClick={onClose}
+          aria-label="닫기"
+        >
           ✕
         </button>
       </div>

--- a/src/components/ui/BottomSheet/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet/BottomSheet.tsx
@@ -33,7 +33,7 @@ type Props = PropsWithChildren<{
  * </BottomSheet>
  * ```
  */
-export default function BottomSheet({
+export function BottomSheet({
   open,
   onClose,
   title,
@@ -43,7 +43,7 @@ export default function BottomSheet({
   children
 }: Props) {
   const overlayRef = useRef<HTMLDivElement>(null);
-  const { panelRef, trimmedTitle, accessibleLabel } = useDialog({
+  const { panelRef, trimmedTitle, accessibleLabel, titleId } = useDialog({
     open,
     onClose,
     title,
@@ -72,13 +72,15 @@ export default function BottomSheet({
         className={clsx(styles.sheet, open && styles.open)}
         role="dialog"
         aria-modal="true"
-        aria-label={accessibleLabel}
+        {...(trimmedTitle
+          ? { 'aria-labelledby': titleId }
+          : { 'aria-label': accessibleLabel })}
         tabIndex={-1}
       >
         <div className={styles.handle} aria-hidden="true" />
         {showHeader && (
           <header className={styles.header}>
-            {trimmedTitle && <h2 className={styles.title}>{title}</h2>}
+            {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
             {showClose && (
               <button
                 type="button"

--- a/src/components/ui/EmptyState/EmptyState.module.scss
+++ b/src/components/ui/EmptyState/EmptyState.module.scss
@@ -3,9 +3,23 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+}
+
+.size_default {
   gap: $spacing-8;
   padding: $section-gap-40 $spacing-20;
-  text-align: center;
+}
+
+.size_compact {
+  gap: $spacing-4;
+  padding: $spacing-12 0;
+
+  .title {
+    font-size: $font-size-13;
+    font-weight: $font-weight-regular;
+    color: $txt-tertiary;
+  }
 }
 
 .icon {

--- a/src/components/ui/EmptyState/EmptyState.tsx
+++ b/src/components/ui/EmptyState/EmptyState.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 import clsx from 'clsx';
 import styles from './EmptyState.module.scss';
 
+type EmptyStateSize = 'default' | 'compact';
+
 type EmptyStateProps = {
   icon?: ReactNode;
   title: string;
@@ -13,6 +15,11 @@ type EmptyStateProps = {
    * @default false
    */
   announce?: boolean;
+  /**
+   * `default` — section-level placeholder (기본). `compact` — 카드·리스트 내부 inline placeholder(패딩·폰트 축소).
+   * @default 'default'
+   */
+  size?: EmptyStateSize;
   className?: string;
 };
 
@@ -23,11 +30,24 @@ type EmptyStateProps = {
  * ```tsx
  * <EmptyState title="검색 결과가 없습니다" description="다른 검색어를 시도해 보세요" announce />
  * <EmptyState icon={<IoFolderOpen />} title="등록된 항목이 없습니다" action={<Button>새로 만들기</Button>} />
+ * <EmptyState title="예배 일정 준비 중" size="compact" />
  * ```
  */
-export function EmptyState({ icon, title, description, action, announce = false, className }: EmptyStateProps) {
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  announce = false,
+  size = 'default',
+  className
+}: EmptyStateProps) {
+  const sizeClassName = size === 'compact' ? styles.size_compact : styles.size_default;
   return (
-    <div className={clsx(styles.container, className)} role={announce ? 'status' : undefined}>
+    <div
+      className={clsx(styles.container, sizeClassName, className)}
+      role={announce ? 'status' : undefined}
+    >
       {icon && <span className={styles.icon}>{icon}</span>}
       <p className={styles.title}>{title}</p>
       {description && <p className={styles.description}>{description}</p>}

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -53,7 +53,7 @@ type Props = PropsWithChildren<{
  * </Modal>
  * ```
  */
-export default function Modal({
+export function Modal({
   open,
   onClose,
   title,
@@ -65,7 +65,7 @@ export default function Modal({
   children
 }: Props) {
   const overlayRef = useRef<HTMLDivElement>(null);
-  const { panelRef, trimmedTitle, accessibleLabel } = useDialog({
+  const { panelRef, trimmedTitle, accessibleLabel, titleId } = useDialog({
     open,
     onClose,
     title,
@@ -96,12 +96,14 @@ export default function Modal({
         className={clsx(styles.panel, styles[`size_${size}`])}
         role={role}
         aria-modal="true"
-        aria-label={accessibleLabel}
+        {...(trimmedTitle
+          ? { 'aria-labelledby': titleId }
+          : { 'aria-label': accessibleLabel })}
         tabIndex={-1}
       >
         {showHeader && (
           <header className={styles.header}>
-            {trimmedTitle && <h2 className={styles.title}>{title}</h2>}
+            {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
             {showClose && (
               <button
                 type="button"

--- a/src/components/ui/Pagination/Pagination.tsx
+++ b/src/components/ui/Pagination/Pagination.tsx
@@ -14,7 +14,7 @@ type Props = {
   maxVisiblePages?: number;
 };
 
-export default function Pagination({
+export function Pagination({
   totalCount,
   pageSize = 10,
   currentPage,

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -9,7 +9,7 @@
 export { Button } from './Button/Button';
 export type { ButtonVariant, ButtonSize, ButtonProps } from './Button/Button';
 
-export { default as BottomSheet } from './BottomSheet/BottomSheet';
+export { BottomSheet } from './BottomSheet/BottomSheet';
 
 export { EmptyState } from './EmptyState/EmptyState';
 
@@ -19,10 +19,10 @@ export type { LabelVariant, LabelShape, LabelSize, LabelProps } from './Label/La
 export { ListItem } from './ListItem/ListItem';
 export type { ListItemProps } from './ListItem/ListItem';
 
-export { default as Modal } from './Modal/Modal';
+export { Modal } from './Modal/Modal';
 export type { ModalSize } from './Modal/Modal';
 
-export { default as Pagination } from './Pagination/Pagination';
+export { Pagination } from './Pagination/Pagination';
 
 export { Pill } from './Pill/Pill';
 

--- a/src/hooks/useDialog.ts
+++ b/src/hooks/useDialog.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import useScrollLock from './useScrollLock';
 
 const FOCUSABLE_SELECTOR =
@@ -36,6 +36,7 @@ export function useDialog({
 }: UseDialogOptions) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const previousActiveRef = useRef<HTMLElement | null>(null);
+  const titleId = useId();
   // onClose identity 변경 시 effect 재실행으로 focus가 리셋되는 것을 방지 — 최신값을 ref로 보관.
   const onCloseRef = useRef(onClose);
   useEffect(() => {
@@ -102,6 +103,7 @@ export function useDialog({
   return {
     panelRef,
     trimmedTitle,
-    accessibleLabel
+    accessibleLabel,
+    titleId
   };
 }


### PR DESCRIPTION
<!-- 🐛 Bugfix 템플릿 -->

## 📋 개요 (Summary)

릴리스 v0.5.0 QA 중 발견된 9개 항목 일괄 정정 — 라우트 경로, Server Action body 한도, a11y, 공용 UI 일관성, 시맨틱 구조.

---

## 🔗 개발 컨텍스트

- **Task ID**: N/A (release QA fix)
- **Exec Plan**: N/A (각 항목 단발성)
- **관련 ADR**: 해당 없음
- **관련 tech debt**: `docs/tech-debt-tracker.md` (bodySizeLimit 항목 활성 → 해결된 항목 이동)
- **작업 범위**: about/news 라우트 · `next.config.ts` · Drawer/BottomNav · ui/ (Modal/BottomSheet/EmptyState/Pagination) · CloudinaryImage · about hub
- **제외 범위**: sermon 자료 50MB 단일 파일 한도 (운영 차단 사례 미확인 — 발생 시 별도 등록)

---

## 🐛 버그 리포트 (Bug Report)

QA round 9건. 모두 release v0.5.0 후보 코드 검토 중 발견.

### 1. about/news 구 라우트 경로 잔존 (404 위험)
- 7건 링크가 `/news/bulletin` (단수), 1건이 `/about/directions` — 실제 라우트는 `/news/bulletins`, `/about/location`
- 사용자 클릭 시 404 가능

### 2. `serverActions.bodySizeLimit 5mb` ↔ bulletin UI 25MB 정책 불일치
- bulletin UI 5MB × 5장(=25MB) 허용하지만 Server Action body 한도 5MB → 다중 업로드 차단

### 3. 길찾기 버튼이 사용자 현재 위치로 카메라 포커싱
- Naver Map directions URL은 출발지 미지정 시 사용자 geolocation으로 카메라 이동 → 도착지(교회) 안 보임

### 4. worship 빈 일정 시 깨진 UI
- Supabase silent fallback 후 빈 `<ul>` 그대로 렌더 → 카드 헤더만 보이는 invisible error 상태

### 5. BottomNav drawer overlay a11y 갭
- overlay div가 클릭 핸들러 가지면서 role 없음, ESC 닫기 미지원, focus trap 부재

### 6. CloudinaryImage Props에서 loader 미차단
- ImageProps 그대로 확장 → 호출부에서 loader prop 전달 가능 → 내부 cloudinary loader 무력화 silent override 위험

### 7. Modal/BottomSheet aria-labelledby 미사용
- title `<h2>`가 있어도 dialog는 aria-label만 사용 → SR이 visible heading 직접 참조 못 함

### 8. about hub heading hierarchy 부재
- `<header>` 안 `<span class="row_label">`만 있고 `<h2>` 없음 → 문서 outline에 섹션 구조 없음

### 9. ui/ barrel export 패턴 불일치
- 12개 중 9개 named, 3개 default (Modal/BottomSheet/Pagination) — 인지 부하 + grep/refactor 어려움

---

## 🔧 수정 내용 (Fix Details)

9개 commit으로 분리:

| # | SHA | Prefix | 변경 |
|---|---|---|---|
| - | `4c416af` | Fix | about 페이지 QA 1차 (location 버튼·pastor/worship 레이아웃) — 이전 push |
| 1 | `5aafb08` | Fix | 라우트 경로 정정 (`/news/bulletin` → `/news/bulletins` 7건, `/about/directions` → `/about/location`) |
| 2 | `8b0df41` | Chore | bodySizeLimit `5mb` → `30mb` + tech-debt 항목 해소된 항목으로 이동 |
| 3 | `c4e2c6e` | Fix | 길찾기 URL을 directions → search URL (도착지 자동 포커싱) |
| 4 | `f6fd7c1` | Refactor | EmptyState `size: 'compact'` variant + worship 빈 일정에 적용 |
| 5 | `4e3128e` | Refactor | Drawer가 useDialog 채택 (ESC·focus trap·focus 복귀), BottomNav overlay `inert` 도입, Modal-style click target-match |
| 6 | `0c53865` | Refactor | CloudinaryImage Props `Omit<ImageProps, 'loader'>` |
| 7 | `dfd1fdd` | Refactor | Modal/BottomSheet `aria-labelledby` (useDialog `useId()` titleId) + ui/ named export 통일 (Modal/BottomSheet/Pagination) |
| 8 | `0572e68` | Style | about hub 4개 `<span>` → `<h2>` (GALLERY/INDEX/HISTORY/LOCATION) |

---

## ⚠️ 영향 범위 (Impact)

**변경된 동작:**
- `/about/location` 길찾기 → 도착지(교회) 중심으로 Naver Map 표시
- `/about/worship` 빈 그룹 → "예배 일정 준비 중" inline 표시 (이전: 빈 ul)
- `/about` hub → 섹션별 h2 추가 (시각 변화 0)
- BottomNav drawer → ESC로 닫기 가능, focus trap 동작
- 주보 5장 동시 업로드 → 차단 해소 (5mb → 30mb)
- 구 라우트 클릭 → 404 해소

**영향받는 컴포넌트:**
- 공용 UI: `EmptyState`, `Modal`, `BottomSheet`, `Pagination` (export 패턴 변경, barrel 통과로 외부 영향 0)
- 공용 hook: `useDialog` (return type에 `titleId` 추가, 후방 호환)
- Layout: `Drawer`, `BottomNav`
- 페이지: `/about` (hub), `/about/location`, `/about/worship`, `/news/bulletins/*`, `/_component/home/*`

**사이드 이펙트 가능성:**
> 매우 낮음. 모든 ui/ export 변경이 barrel 통과로 consumer 측 import 변화 없음. EmptyState `size` 기본값 `default`로 기존 5건 사용처 시각 무변화. useDialog return의 `titleId` 추가는 destructure 범위 확장만.

---

## 🏗️ 의사 결정 기록

| 결정 항목 | 선택 | 이유 | 대안 |
| --- | --- | --- | --- |
| 길찾기 URL 패턴 | search URL (`/p/search/{name+address}`) | 도착지 카메라 포커싱 보장, 검색 결과 마커 표시 | directions URL + camera param (Naver 동작 불확실) |
| bodySizeLimit 값 | `30mb` (bulletin 25MB + 여유) | bulletin 정책 수용 + DoS 위험 최소화 | `60mb` (sermon 50MB 포함 — 운영 사례 없어 보류) |
| EmptyState compact 도입 | `size` prop variant 추가 | 공용 컴포넌트 재사용 + tech-debt #7(`'use client'` 부채) 자연 정합 | worship 로컬 `.empty_hint` (재사용성 0) |
| Drawer a11y 처리 | useDialog 채택 | Modal과 일관 패턴, focus trap·ESC·scroll lock 자동 | manual ESC 핸들러만 (focus trap 누락 위험) |
| ui/ default→named retrofit | Modal/BottomSheet/Pagination 변경 | 12개 중 9개 이미 named, 일관성 100% 확보 | 신규 컴포넌트만 named (3 outlier 잔존) |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 있음: `verify-task` (각 commit pre-commit hook의 lint-staged eslint + stylelint PASS로 갈음) |
| `verify-task` | N/A |
| `harness-gate` | N/A |
| Codex 계획 검증 | N/A |
| Codex 1차 검증 | useScrollLock 안전성에 대해 1건 사후 cross-validation 수행 (PR과 무관, 변경 없음 결론) |
| Claude 2차 검증 | N/A |
| ADR 판단 | 불필요 — `next.config.ts` bodySizeLimit은 config tuning, 구조/라이브러리 변경 X |
| 남은 warning | 기존 부채 — `worship/page.module.scss` line 139 등 primitive 직접 사용 (외과적 변경 원칙으로 미수정, tech-debt-tracker 활성 항목 #SCSS primitive 143건에 포함) |

---

## 🗂️ 셀프 체크리스트

- [x] 근본 원인 해결 (TODO 해소·a11y 표준 패턴 적용·타입 보장)
- [x] 동일 패턴 잠재 버그 점검 (route grep으로 추가 2건 발견 — 사용자 list 외)
- [x] 수정 범위 외 코드 미수정 (각 commit 단일 관심사)
- [x] 호출부 영향 검증 (CloudinaryImage `loader`, ui/ named export 모두 grep으로 0건 확인)
- [x] 후방 호환 (EmptyState `size`, useDialog `titleId` 모두 기본값/추가 return으로 기존 5+ 사용처 무변화)

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**:
  - `/about/location` 길찾기 클릭 → 교회 위치 중심으로 Naver Map 새창
  - `/about/worship` 빈 일정 그룹 → "예배 일정 준비 중" 표시
  - 구 경로 링크 클릭 시 404 해소
  - BottomNav drawer ESC 키로 닫기 가능
  - 주보 5장 동시 업로드 차단 해소
- **운영 / 릴리스 주의사항**: PR #83(release v0.5.0)에 자연 포함됨. 별도 배포 단계 없음
- **롤백 시 영향**: 없음 (UI/config 한정, DB·외부 의존 변경 없음)
- **먼저 볼 화면**:
  - `/about` (hub h2)
  - `/about/location` (길찾기·주소 복사 버튼)
  - `/about/worship` (빈 그룹 — 단, 운영 dev DB가 비어 있어야 재현)
  - 홈 → `/news/bulletins`로 이동 (Banner 링크)
  - 주보 상세 → 이전/다음 링크 (BoardFooter)
  - 모바일 BottomNav → 메뉴 오픈 → ESC 닫기

---

## 📝 리뷰어를 위한 메모

- **EmptyState compact** 도입은 tech-debt #7(`'use client'` 불필요)을 같이 해소할 수 있는 후속 작업의 발판 — 현재 retrofit하지는 않음
- **named export retrofit (Modal/BottomSheet/Pagination)**: QA 원문은 "신규 컴포넌트는 named 권장"이었으나, 12개 중 3 outlier로 잔존 시 일관성 손상이 커서 이번에 함께 정리. consumer 측은 모두 barrel 경유라 import 형태 무변화
- **useScrollLock 검증**: 동일 QA round의 항목 7번(useScrollLock HMR/cleanup 안전성)은 Codex cross-validation 결과 React 시맨틱 오해 기반의 부정확한 claim으로 판단 → 변경하지 않음. 별도 PR 변경 0건
- **Naver Map URL 형식**: `https://map.naver.com/p/search/{query}` 사용. 신규 `/p/` 경로 — Naver가 v5에서 마이그레이션 중인 형식. 향후 변경 가능성

🤖 Generated with [Claude Code](https://claude.com/claude-code)
