### PR TITLE
[Refactor] ADR 0010 — 하네스 CODEX_PLAN_REVIEW 과도한 반복 차단 운영 보완

### DIFF
--- a/.claude/hooks/check-codex-after-plan.mjs
+++ b/.claude/hooks/check-codex-after-plan.mjs
@@ -1,8 +1,15 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { stdin, stdout } from "node:process";
 
 const PLAN_PATH_RE = /docs[\\/]+exec-plans[\\/]+active[\\/]+.+\.md$/i;
+const CWD_KEY = createHash("sha1").update(process.cwd()).digest("hex").slice(0, 8);
+const STATE_FILE = path.join(os.tmpdir(), `dnchurch-check-codex-after-plan.${CWD_KEY}.state.json`);
+const HASH_SECTIONS = ["목표", "Success Criteria", "영향받는 파일", "Verification"];
+const SECTION_DELIM = "||";
 
 async function readInput() {
   const chunks = [];
@@ -37,14 +44,26 @@ function sectionBody(markdown, heading) {
   return markdown.slice(bodyStart + 1, bodyEnd).trim();
 }
 
-function isAlreadyReviewed(filePath) {
+function isAlreadyReviewed(content) {
+  const body = sectionBody(content, "Codex 계획 검증");
+  return /\*\*결론\*\*:\s*(PASS|PASS_WITH_DECISION_LOG|CHANGE_REQUEST|BLOCK)\b/.test(body);
+}
+
+function sectionsHash(content) {
+  const parts = HASH_SECTIONS.map((h) => sectionBody(content, h));
+  return createHash("sha1").update(parts.join(SECTION_DELIM)).digest("hex").slice(0, 16);
+}
+
+function readState() {
   try {
-    const content = readFileSync(filePath, "utf8");
-    const body = sectionBody(content, "Codex 계획 검증");
-    return /\*\*결론\*\*:\s*(PASS|CHANGE_REQUEST|BLOCK)/.test(body);
+    return JSON.parse(readFileSync(STATE_FILE, "utf8") || "{}");
   } catch {
-    return false;
+    return {};
   }
+}
+
+function writeState(map) {
+  try { writeFileSync(STATE_FILE, JSON.stringify(map)); } catch {}
 }
 
 const payload = await readInput();
@@ -52,13 +71,25 @@ const input = payload.tool_input ?? payload.toolInput ?? {};
 const candidatePath = String(input.file_path ?? input.path ?? input.filePath ?? "");
 const normalizedPath = candidatePath.replaceAll("\\", "/");
 
-const isActivePlan = PLAN_PATH_RE.test(normalizedPath);
+if (!PLAN_PATH_RE.test(normalizedPath)) process.exit(0);
+if (!existsSync(candidatePath)) process.exit(0);
 
-if (isActivePlan && !isAlreadyReviewed(candidatePath)) {
-  emitContext(
-    "[hook:check-codex-after-plan]\n" +
-      `active EXEC_PLAN 작성/수정: ${normalizedPath}.\n` +
-      "구현 전 Codex 계획 검증 권장. 결론은 PASS/CHANGE_REQUEST/BLOCK.\n" +
-      "기록: exec-plan `## Codex 계획 검증`.",
-  );
-}
+const content = readFileSync(candidatePath, "utf8");
+
+if (isAlreadyReviewed(content)) process.exit(0);
+
+const currentHash = sectionsHash(content);
+const state = readState();
+const previousHash = state[normalizedPath];
+
+if (currentHash === previousHash) process.exit(0);
+
+state[normalizedPath] = currentHash;
+writeState(state);
+
+emitContext(
+  "[hook:check-codex-after-plan]\n" +
+    `active EXEC_PLAN 핵심 섹션(목표/SC/영향 파일/Verification) 변경: ${normalizedPath}.\n` +
+    "구현 전 Codex 계획 검증 권장. verdict: PASS / PASS_WITH_DECISION_LOG / CHANGE_REQUEST / BLOCK.\n" +
+    "기록: exec-plan `## Codex 계획 검증`. (debounce: 동일 section hash 재발화 안 함)",
+);

--- a/.claude/skills/harness-workflow/SKILL.md
+++ b/.claude/skills/harness-workflow/SKILL.md
@@ -369,6 +369,8 @@ node scripts/update-adr-index.mjs
 
 일회성 판단이면 `ADR 판단`에 `불필요`와 사유를 남긴다.
 
+compact 템플릿(ADR 0010)의 frontmatter 1줄 필드를 쓸 때는 **`**ADR needed**: no — <한 줄 사유>`** 형식으로 inline 사유를 같이 적는다. ADR_TRIGGER_PARTS 파일이 diff에 포함된 경우 bare `no` 만으로는 `harness-gate`가 차단한다 (예: `**ADR needed**: no — scripts/ 오타 수정만 포함`).
+
 ## 최소 사용자 프롬프트 예시
 
 ```text

--- a/.claude/skills/harness-workflow/SKILL.md
+++ b/.claude/skills/harness-workflow/SKILL.md
@@ -45,6 +45,22 @@ description: 기능 추가, 버그 수정, 리팩터링, 설계/정책 변경, P
 - 레이어 방향 `apis → services → actions → app`을 확인한다.
 - 스타일 작업은 token/mixin 규칙을 확인한다.
 
+**구현 의존 claim 직접 검증 (ADR 0010)** — claim이 있으면 다음을 먼저 SSOT로 확인 (audit/doc은 보조). 확인 결과는 exec-plan `## 검증된 Assumptions` 또는 `## 의사결정 로그`에 1줄 기록.
+
+| claim 유형 | 검증 도구·명령 |
+|---|---|
+| DB 컬럼·테이블 존재 | `mcp__claude_ai_Supabase__list_tables` 또는 `execute_sql` (migrations와 drift 가능 — 원격 SSOT 우선). 예: phase 1-1에서 `is_featured` 부재 사전 발견 가능 |
+| 타입 정의 (Database generated types) | `rg "컬럼명|타입명" src/types/database.types.ts` |
+| 라우트·페이지 존재 | `Glob src/app/**/page.tsx` |
+| SCSS 토큰·mixin 존재 | `rg "\\$token-name" src/styles/tokens/` 또는 `src/styles/_mixins.scss` |
+| config flag·env 변수 | `rg "FLAG_NAME" next.config.ts eslint.config.mjs scripts/ src/lib/supabase/` (`.env.example` 없음 — actual env consumer로 grep) |
+| wrapper 컨벤션 (`<Image>` vs `<CloudinaryImage>` 등) | `Grep src/app -l "from 'next/image'"` 0건이면 wrapper 컨벤션. `src/components/common/CloudinaryImage.tsx`가 유일한 직접 import 지점 |
+
+**범위 규칙**:
+- 영향 파일 surface only — 전수 검사 금지 (LOC 늘면 plan-text 모순 표현 CR 폭주 원인)
+- 단순 변경(typo/rename/1줄) + 구현 의존 claim 없음 → EXPLORE 1–2분 종료 가능
+- 다단계 작업이거나 DB/타입/라우트/토큰 의존 claim 있음 → 위 표대로 직접 검증 필수
+
 ### 2. PLAN
 
 다단계 작업이면 실행한다.
@@ -67,13 +83,57 @@ Codex가 결론을 내기 전에 다음 5체크를 수행하도록 프롬프트�
 4. 성공 기준(Success Criteria)과 검증 명령이 구체적인가?
 5. 새 추상화·새 라이브러리·데이터 흐름 변경이 과한가? (없어야 정상)
 
-Codex 결론은 `PASS`, `CHANGE_REQUEST`, `BLOCK` 중 하나로 해석한다.
+#### CHANGE_REQUEST는 material implementation risk만 (ADR 0010)
 
-- `PASS`: 구현 진행
-- `CHANGE_REQUEST`: exec-plan 수정 후 구현 진행 (5체크 중 어느 하나라도 미충족이면 기본적으로 CHANGE_REQUEST)
-- `BLOCK`: exec-plan 재작성 후 Codex 재요청 필수. 재요청도 BLOCK이면 사용자에게 에스컬레이션 — 최종 판단은 사용자가 내린다.
+5체크 미충족이라도 **구현 판단을 바꾸지 않는 plan-text 표현 모순·label 정합·문장 품질**은 CR 대상 아님. 대신 exec-plan `## 의사결정 로그`에 1줄 기록하고 WORK로 진입한다.
 
-결과는 exec-plan의 `## Codex 계획 검증`에 기록한다.
+**must-CR (material — 구현/데이터/타입/레이어/사용자 영향)** — 다음 8 케이스는 반드시 CR.
+
+1. DB column·table 부재로 데이터 흐름 실패 (예: phase 1-1의 `is_featured` BLOCK)
+2. 타입 불일치로 type-check 실패 (예: `SermonListItem` vs `SermonWithRelations` 필드 누락)
+3. 레이어 위반 (app → apis 직접 호출, services bypass)
+4. 인증/캐시/배포 정책 변경 누락 (예: `createServerSideClient` vs `createStaticClient` 오용)
+5. `## Non-goals`에 명시한 항목을 plan이 변경하려 함 (예: `[id]`→`[slug]` 시도)
+6. user-visible acceptance criteria 위반 (SEO/UX 영향 metadata 포함, 예: title이 GNB 라벨과 불일치)
+7. 검증 명령 부재·부적절 (SC가 "동작하게" 같은 약한 기준)
+8. repo policy 위반 (token 하드코딩 / `<Image>` 직접 사용 / `--no-verify` / barrel 반사 등)
+
+**expression-only (PASS_WITH_DECISION_LOG 처리)** — 다음 5 케이스는 CR 아님. 의사결정 로그 1줄 + WORK 진입.
+
+1. 같은 정보를 N곳에 적어 미세 불일치 (예: "코드 변경 0" vs "1줄 변경" 표현 충돌)
+2. label 표기 차이 ("신규" vs "교체", "이관" vs "분리")
+3. 중복 설명·섹션 배치·비차단 명명 제안
+4. 문장 품질 (이중부정·길이·어순)
+5. SEO·라우팅 영향 없는 표기 오타 (의사결정 로그 내 typo)
+
+**애매하면 material로 승격** (안전 쪽).
+
+#### Codex 결론 토큰 (4종)
+
+- `PASS` — 5체크 모두 충족. WORK 진행.
+- `PASS_WITH_DECISION_LOG` — material risk 없음 + expression-only 지적 N건. exec-plan `## 의사결정 로그`에 각 1줄 추가 후 WORK 진행. **3차 자동 호출 금지** (재요청은 사용자 명시 승인 시만).
+- `CHANGE_REQUEST` — must-CR 1건 이상. exec-plan 수정 후 WORK.
+- `BLOCK` — 인증/캐시/배포/DB/데이터 손실/보안/컨텍스트 충돌. exec-plan 재작성 후 Codex 재요청 필수. 재요청도 BLOCK이면 사용자 에스컬레이션 — 최종 판단은 사용자.
+
+`BLOCK` 기준은 본 cap 무관 유지 — material risk + 운영 영향 결합 시 항상 차단.
+
+#### 호출 프롬프트 템플릿
+
+```
+Review the planning document at <path>. Apply the 5-check (Assumptions / Non-goals / scope linkage / Success Criteria + verification / new abstractions).
+
+Classify each finding as:
+- material — DB/type/layer/auth/cache/deploy/Non-goals violation/user-visible/policy (must-CR)
+- expression-only — plan-text inconsistency, label, ordering, typo (decision-log only, NOT CR)
+
+Concrete-records rule: every critique must include ≥2 of {real tool/rule/file/command, numeric or binary criterion, concrete verb+result, ≥1 example}. No abstract nouns like "보강 필요" / "정합" / "근거 약함".
+
+Conclude with exactly one token: PASS / PASS_WITH_DECISION_LOG / CHANGE_REQUEST / BLOCK. Add confidence: low/medium/high.
+
+Respond in Korean.
+```
+
+결과는 exec-plan의 `## Codex 계획 검증`에 기록한다 (verdict token + 풀이 1줄 + 핵심 지적).
 
 ### 4. WORK
 

--- a/.claude/skills/harness-workflow/SKILL.md
+++ b/.claude/skills/harness-workflow/SKILL.md
@@ -257,9 +257,11 @@ CLAUDE.md prefix 6개(`Feat·Fix·Style·Refactor·Docs·Chore`) + bullet 본문
   - ❌ `Chore: Hero 메타 2 키 + 라우트 3 스켈레톤` — "메타", "키", "스켈레톤" 모두 코드 미열람자가 추측해야 함
   - ✅ `Chore: sermons 자식 페이지 2종 Hero 등록 + 신규 라우트 3종 스켈레톤 추가` — 어떤 페이지/Hero/라우트인지 표면화
   - body에서는 첫 등장 시 풀어 설명: "`hero.config.ts`의 `HERO_META` 객체에 `/sermons/all`·`/sermons/series` 두 엔트리(title/subtitle/eyebrow) 추가"처럼
-- **다중 concern 표시** — subject에 `+`로 영역을 2개 이상 나열하면 즉시 다음 두 가지 중 택1을 명시한다. (`/`·`,`는 URL 경로(`/sermons/all`)·자연어 열거에서 합법 등장하므로 분리 신호 대상이 아니다 — commit-msg-hook task Codex 1차 FLAG D 반영, hook R4 검사도 `+`만)
+- **Subject `+` 0회를 기본값으로 작성** — `+` 등장 자체가 다중 concern 신호이자 commit 분리 검토 트리거다. hook R4은 `+` 2회부터 차단하지만, **작성 단계에서 0회를 목표**로 한다. `+`를 쓰고 싶어지면 (a)/(b) 중 택1:
   - (a) **commit 분리** — 각 영역을 별도 commit으로. 기본 가정.
   - (b) **단일 의도 통일** — 모든 영역이 단일 상위 의도(예: "Phase 0 foundation prep") 하에 묶이는 경우, subject는 그 상위 의도 하나로 표현하고 본문 bullet에서 영역별로 풀어쓴다. 같은 파일·같은 모듈 변경 묶음은 `(N concerns 동일 파일)` 표기.
+
+  (`/`·`,`는 URL 경로(`/sermons/all`)·자연어 열거에서 합법 등장하므로 분리 신호 대상이 아니다 — commit-msg-hook task Codex 1차 FLAG D 반영, hook R4 검사도 `+`만.)
   - ❌ `Chore: sermons Phase 0 — 9-영역 감사 + Carousel 공용 + 3 라우트 + Hero 메타 2 키` — subject `+` 3회 → commit 분리 신호로 오해. 약어 다발.
   - ✅ `Chore: sermons 섹션 Phase 0 foundation — Phase 1 진입 전 사전 준비 완료` + 본문 4 영역 bullet — 단일 의도 통일
   - ✅ `Fix: /news/bulletin → /news/bulletins (8건) + /about/directions → /about/location` — `/`는 URL 경로, `+`는 1회로 분리 신호 아님

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@
 - `VERIFY_ENFORCE=1` 환경에서는 검증 기록이 없거나 diff가 바뀌면 커밋이 차단된다.
 - 머지/릴리스 전에는 `node scripts/harness-gate.mjs <slug>`로 검증 증적, Codex/Claude 검증 기록, ADR 판단을 강제 확인한다.
 - `--no-verify`로 우회 금지
+- **한 commit = 한 의도. 작성 시작 전 분리한다** — 여러 의도가 묶이면 `git add`를 분리해 별도 commit. subject에 `+`가 떠오르는 순간이 분리 누락 신호 (commit-msg hook R4는 사후 안전망).
 - **사용자 승인 후 커밋한다. 자동 커밋 금지.**
 - prefix는 6개만: Feat · Fix · Style · Refactor · Docs · Chore
 - 머지 후 `node scripts/complete-task.mjs <slug>`로 exec-plan을 `completed/`로 이동, 회고 작성

--- a/docs/decisions/0010-harness-codex-review-cap.md
+++ b/docs/decisions/0010-harness-codex-review-cap.md
@@ -1,0 +1,136 @@
+# 0010 — Harness CODEX_PLAN_REVIEW 범위 한정 + plan 압축 + EXPLORE 직접 검증
+
+- **Status**: Accepted
+- **Date**: 2026-05-14
+- **Deciders**: scseong, Claude Opus 4.7, Codex
+- **Tags**: harness, agent-collaboration, workflow
+
+## Context
+
+ADR 0008(코드 품질 강제 — 에이전트 리뷰 tier)과 ADR 0001(Codex 위임 전략) 운영 결과, **단일 컴포넌트 한 페이지 작업이 4시간** 걸리는 사례 발생.
+
+phase 1-1(sermons-featured, `docs/exec-plans/active/2026-05-14-sermons-featured.md`)에서 측정된 누적 손실:
+
+- Codex 계획 검증 5라운드 — 14건 CR 중 **11건이 plan-text expression 충돌** (예: "코드 변경 0줄" vs "1줄 변경" 표현 모순, "신규" vs "교체" 라벨 차이, 의사결정 로그 typo)
+- Phase 0 audit가 `is_featured` 컬럼 존재를 잘못 claim — EXPLORE에서 직접 SQL 확인 안 함 → Codex 1차에서야 BLOCK 발견
+- `<Image>` vs `<CloudinaryImage>` wrapper 컨벤션 누락 → yarn build 실패로 10분 손실
+- harness-gate same-line regex가 label-only 라인을 미작성으로 오판 → 5분 정정
+- hook이 단순 plan re-save에도 매 Write/Edit마다 알림 발화 (debounce 부재)
+
+5체크가 "5체크 미충족 시 CR 기본"으로 정의되어 있어 Codex가 표현·문장 품질도 CR로 분류 → 5라운드 폭주. 사용자 피드백: **"5분이면 될 작업을 1시간이 넘게 걸렸어. 이건 심각한 문제야."** 잔여 phase ≥ 20 + 누적 손실 20-30시간 risk.
+
+본 ADR을 적용 안 하면: ADR 0008 메커니즘 2(detection: 검증 결과 기록 규칙)는 운영되지만, 메커니즘 1(generation: Codex 1차+Claude 2차)이 비용 곱셈으로 작동해 phase별 30-45분 목표가 120분으로 실측.
+
+## Decision
+
+`CODEX_PLAN_REVIEW`는 **material implementation risk만** `CHANGE_REQUEST`로 분류하고, 문서 표현·plan-text consistency는 구현 판단을 바꾸지 않는 한 `## 의사결정 로그`에 1줄 기록한 뒤 WORK로 진행한다. 새 결론 토큰 `PASS_WITH_DECISION_LOG`를 도입한다.
+
+단일 컴포넌트·작은 PR은 compact exec-plan(목표/검증된 Assumptions/SC/영향 파일/체크리스트/Verification 6 섹션 + verdict 3 섹션)을 기본으로 한다. 구현 의존 claim(컬럼/타입/라우트/토큰/wrapper 컨벤션)은 EXPLORE에서 코드/DB/generated source로 직접 확인한다 — audit·doc은 보조.
+
+Hook은 plan 핵심 섹션(`목표 + Success Criteria + 영향받는 파일 + Verification`) hash가 직전 알림 시점과 다를 때만 재발화하며 (debounce), harness-gate는 검증 섹션의 verdict token + placeholder denylist + 최소 30자 본문을 강제하고 same-line label-only formatting은 강제하지 않는다.
+
+구체 변경(7건):
+
+1. `.claude/skills/harness-workflow/SKILL.md` § CODEX_PLAN_REVIEW — CR 정의(material만) + must-CR 8개 + expression 5개 + `PASS_WITH_DECISION_LOG` 토큰 + 호출 프롬프트 템플릿 inline.
+2. 동일 SKILL.md § EXPLORE — 구현 의존 claim 직접 검증 표(DB/타입/라우트/토큰/wrapper) + surface only 명시.
+3. `docs/exec-plans/_template.md` — 17 섹션 → 6 필수 + 3 검증, 가이드 주석으로 압축. `Open questions: none | <list>` / `ADR needed: no | yes — <reason>` 1줄 mandatory.
+4. `scripts/harness-gate.mjs` — verdict token 매트릭스(섹션별 허용 verdict), placeholder denylist(`TBD/미요청/미작성/N/A/none/-/—`), 최소 30자 본문, `--plan-file <path>` dry-run 옵션.
+5. `tests/harness/{valid,placeholder,revised-after-review}.md` — fixture 3개. 각각 PASS / FAIL / PASS_WITH_DECISION_LOG 경로 시연. 신규 디렉토리(`tests/`는 dnchurch에 없음 — 본 harness 검증 용도로 신설).
+6. `.claude/hooks/check-codex-after-plan.mjs` — section hash 기반 debounce(`os.tmpdir()/dnchurch-check-codex-after-plan.state.json` per-file map). verdict 토큰 존재 시 skip(기존) 유지.
+7. 본 ADR.
+
+## Override (필수)
+
+다음 조건 1건 이상 hit 시 본 ADR cap·compact·debounce 자동 해제하고 ADR 0008 + 0001 원형으로 복귀.
+
+- 변경 파일 ≥ 20 또는 LOC ≥ 500
+- ADR_TRIGGER_PARTS 다중 영역 (services + scripts + .claude/ 등)
+- 라이브러리 마이그레이션 (package.json deps 신규/제거)
+- 인증/캐시/배포/DB schema 변경
+- **`.github/workflows/` 변경** (CI/CD 파이프라인 — 머지 후 즉시 모든 PR에 적용)
+- **`supabase/migrations/` 신규 파일** (run 안 된 migration 포함 — schema drift 위험)
+- **보안 민감 PR** (RLS policy / secret / `src/lib/auth*` / `middleware.ts` / cookie scope)
+- 사용자 명시 `STRICT_REVIEW` 요청
+
+해제 시: full template + Codex review 무제한 라운드 + 기존 hook 빈도. exec-plan `## 의사결정 로그`에 "Override 적용 사유" 1줄 기록.
+
+## Rollback Triggers (필수)
+
+3 sub-phase(예: phase 1-2/1-3/1-4) 누적 후 측정. 1건 이상 hit 시 본 ADR 재검토.
+
+- 평균 phase 시간 본 ADR 적용 전(실측 120분) 대비 50% 미만 개선 (즉 60분 초과 유지)
+- 1차 검증·PR review에서 material 사후 발견 2× 증가 (phase 1-1 기준)
+- harness-gate placeholder 통과 사례 1건 (fixture로 차단됐어야 할 verdict가 main에 머지)
+- 사용자 "검토 부족" 피드백 1건
+
+### 측정 방식
+
+KPI는 **completed exec-plan의 회고 섹션**에 mandatory 5필드로 기록한다. 후속 PR에서 `scripts/complete-task.mjs`가 회고 필드를 파싱해 `logs/harness-kpi.jsonl`에 append하도록 보강.
+
+```
+## 회고 (필수 5필드)
+- KPI / 시작-종료 (분): <int>
+- KPI / Codex 라운드: <int>
+- KPI / material 사후 발견: <int>
+- KPI / harness-gate placeholder fail: <int>
+- KPI / 사용자 검토 부족 피드백: <int>
+```
+
+측정 책임자: phase 머지 후 `node scripts/complete-task.mjs <slug>`를 실행하는 작업자(보통 본 PR 머지자). `logs/harness-kpi.jsonl`은 commit 대상 아님(`logs/`는 .gitignore 가정 — 본 ADR 머지 시 확인). 3 sub-phase 누적 시 `node scripts/measure-harness.mjs`(후속 추가) 또는 수동 집계로 위 4 트리거 hit 여부 판정.
+
+회고 5필드가 미작성이면 `complete-task.mjs`가 차단(후속 보강 — 본 ADR 머지 후 1주 내 별도 PR).
+
+## Consequences
+
+### 긍정적
+
+- Codex 라운드 수 평균 1-2회로 감소 (phase 1-1: 5라운드 → 목표 1-2)
+- plan 라인 수 17 섹션 → 6+3 (검증) — 작성·읽기 비용 60% 감소
+- EXPLORE에서 BLOCK 사전 발견 — phase 1-1의 `is_featured` 같은 케이스 100% 차단 목표
+- hook 알림 평균 횟수 phase당 12회 → 2-3회 (section hash debounce)
+- harness-gate가 verdict + 본문 충실도 강제 — placeholder 통과 0건 (fixture 차단 확인됨)
+
+### 부정적 / 트레이드오프
+
+- `PASS_WITH_DECISION_LOG` 분류 모호 케이스에서 reviewer가 expression으로 잘못 분류해 material risk 누락 가능 — SKILL.md에 "애매하면 material로 승격" 룰로 완화. fixture·실사례 누적 후 SKILL § must-CR 예시 보강 필요.
+- compact template이 다단계 구조 변경에는 부적합 — Override 조건으로 자동 해제.
+- `tests/` 디렉토리 신설 — dnchurch는 "테스트 환경 없음"(CLAUDE.md) 정책. 본 디렉토리는 단위 테스트가 아닌 fixture 검증 전용이므로 정책과 충돌 없음. README 추가 권장(후속).
+- ADR 0008 메커니즘 1(generation) 약화 risk — 단 메커니즘 2(detection: 검증 결과 기록 규칙)는 그대로. harness-gate placeholder denylist로 detection 강화 효과 상쇄.
+
+### 영향 범위
+
+- 코드: `.claude/skills/harness-workflow/SKILL.md`, `.claude/hooks/check-codex-after-plan.mjs`, `scripts/harness-gate.mjs`, `docs/exec-plans/_template.md`, `tests/harness/*` (신규)
+- 운영: 모든 후속 phase의 EXPLORE/PLAN/CODEX_PLAN_REVIEW 절차. 직전(phase 1-1) plan은 본 ADR 적용 전 형식이므로 그대로 머지 가능 — 본 ADR 머지 후 phase부터 신 규칙 적용.
+
+## Alternatives Considered
+
+### A안: status quo 유지 — 기각
+
+phase별 누적 손실 20-30시간 / 잔여 phase ≥ 20 → 본 ADR 적용으로 60% 절감 시 12-18시간 회수. status quo 비용이 결정 비용보다 큼.
+
+### B안: Codex 호출 프롬프트만 수정 — 기각
+
+SKILL.md 기본 정의("5체크 미충족 = CR 기본")가 그대로면 reviewer incentive 변화 없음. 한 번 통과한 프롬프트도 다음 작업에서 모델 컨텍스트가 달라지면 재현 안 됨.
+
+### C안: SKILL만 수정, template 유지 — 기각
+
+template 17 섹션이 plan 비대 + 표현 충돌의 원인 — 효과 절반.
+
+### D안: harness-gate·hook만 수정 — 기각
+
+주 원인(Codex 5라운드 폭주)에 직접 작용하지 않음. 보조 도구만 정비해선 phase 시간 50% 절감 어려움.
+
+### E안: Codex review 전부 생략 — 기각
+
+material risk(예: phase 1-1의 `is_featured` BLOCK, 필터 base path 4곳 변경) 누락 시 사후 비용이 review 비용보다 큼. ADR 0001 위반.
+
+### F안: ADR 0008 자체 폐기 — 기각
+
+코드 품질 메커니즘 상실. ADR 0008의 의도는 정확, **운영(reviewer가 5체크를 strict 적용)이 잘못된 것** — 본 ADR이 운영 보완.
+
+## References
+
+- 관련 PR: 본 ADR을 도입하는 PR (TBD — PR 본문에 채움)
+- 관련 exec-plan: `docs/exec-plans/active/2026-05-14-harness-codex-review-cap.md` (메타 작업 핸드오프, E1~E7 결정 포함)
+- 실측 사례: `docs/exec-plans/active/2026-05-14-sermons-featured.md` (Codex 5라운드 / 11건 expression CR / `is_featured` BLOCK / `<Image>` build 실패 / harness-gate same-line trap)
+- 관련 ADR: 0001(Codex 위임 전략), 0008(코드 품질 강제) — 본 ADR이 0008 메커니즘 1 운영을 보완, 0001 위임 트리거는 유지

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -39,5 +39,6 @@
 | [0007](0007-cloudinary-asset-folder-convention.md) | cloudinary asset folder convention | Accepted | 2026-05-11 |
 | [0008](0008-code-quality-harness.md) | 코드 품질 강제: 에이전트 리뷰 + 사전 지침 채택 (Tier 1·2 도입 유보) | Accepted | 2026-05-13 |
 | [0009](0009-commit-msg-hook-enforcement.md) | commit msg hook enforcement | Accepted | 2026-05-13 |
+| [0010](0010-harness-codex-review-cap.md) | Harness CODEX_PLAN_REVIEW 범위 한정 + plan 압축 + EXPLORE 직접 검증 | Accepted | 2026-05-14 |
 
 <!-- last-audit: 2026-05-01 -->

--- a/docs/exec-plans/_template.md
+++ b/docs/exec-plans/_template.md
@@ -3,121 +3,64 @@
 - **상태**: 🟡 진행 중
 - **시작일**: YYYY-MM-DD
 - **브랜치**: feat/...
+- **Open questions**: none
+- **ADR needed**: no
 
 ## 목표
 
-(이 작업이 끝났을 때 무엇이 달라지는가? 1~3줄)
+(이 작업이 끝났을 때 무엇이 달라지는가? 1–3줄)
 
-## Assumptions
+## 검증된 Assumptions
 
-(이 계획이 성립하려면 무엇이 사실이어야 하는가? 명시하지 않으면 조용히 가정한 셈. 불확실하면 사용자에게 묻는다.)
-
--
-
-## Non-goals
-
-(이번 작업에서 **하지 않을 것**. 범위 크리프 방지. 인접 리팩터·"하는 김에" 정리는 여기에 명시적으로 제외.)
+(EXPLORE에서 rg/generated types/SQL/Read로 직접 확인한 사실만. 항목마다 확인 근거 1줄. 예: `is_published`만 존재 — `mcp__claude_ai_Supabase__list_tables(sermons)` 호출.)
 
 -
 
 ## Success Criteria
 
-(완료를 어떻게 검증할 것인가? "동작하게 만들어" 같은 약한 기준 금지. 각 항목은 yes/no로 판정 가능해야 한다.)
+(yes/no 판정 가능한 항목. "동작하게 만들어" 같은 약한 기준 금지.)
 
 -
-
-## Verification
-
-(어떤 명령·수동 확인으로 Success Criteria를 검증할 것인가? `verify-task.mjs` + 가장 좁은 신뢰 명령부터.)
-
--
-
-## 접근법
-
-(어떻게 풀 것인가? 핵심 결정 한두 줄. 대안과 기각 사유는 의사결정 로그 또는 ADR로)
 
 ## 영향받는 파일
 
-- `src/...`
 - `src/...`
 
 ## 단계별 체크리스트
 
 - [ ] 1. ...
-- [ ] 2. ...
-- [ ] 3. ...
 
-## 완료 기준 (DoD)
+## Verification
 
-- [ ] `node scripts/verify-task.mjs <task-id>` 통과 (lint + lint:styles + build + knip)
-- [ ] 사용자 승인 후 커밋
-- [ ] (필요 시) 마이그레이션 적용
-- [ ] (필요 시) ADR 또는 tech-debt-tracker 업데이트
+- `node scripts/verify-task.mjs <task-id>`
 
-## 참고 자료
+---
 
-(외부 자료를 발췌해 `docs/research/`에 저장한 경우 여기에 링크)
-
-- `docs/research/<date>-<slug>.md` — ...
-
-## 의사결정 로그
-
-(중간에 plan을 벗어나거나 새 결정이 생기면 여기에 추가. 날짜 + 한 줄 사유)
-
-- YYYY-MM-DD: ...
-
-## ADR 판단
-
-- **필요 여부**: 미검토
-- **결정 링크**:
-- **사유**:
-
-<!-- TEMPLATE_ONLY: 아래 "## 검증 결과 기록 규칙" 섹션 전체는 template 작성 가이드. 실제 exec-plan에서는 본 섹션 전체를 삭제한다. -->
-
-## 검증 결과 기록 규칙 (TEMPLATE 안내 — 실제 plan에서는 본 섹션 전체 삭제)
-
-> ⚠️ **본 섹션은 plan 작성 가이드일 뿐, 실제 exec-plan 본문에서는 본 섹션(`## 검증 결과 기록 규칙` 전체)을 삭제한다.** 규칙은 작성 시에만 적용하고 plan에 남기지 않는다.
-
-다음 `## Codex 계획 검증`, `## Codex 1차 검증`, `## Claude 2차 검증` 섹션을 채울 때 적용 (ADR 0008 Decision 메커니즘 2 운영화).
-
-- **추상 표현 금지** — `보강 필요`, `근거 약함`, `커버리지 공백` 같은 추상명사로 끝맺지 않는다.
-- **구체화 4원소** (최소 2개 갖춤) — 실제 도구·파일·명령 / 수치 또는 binary 기준 / 구체 동사+결과 / 예시 1개 이상.
-- **Codex stdout은 verbatim + 평이 풀이 1줄**.
-- 자세한 규칙·나쁜 예/좋은 예: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" (SSOT).
-
-<!-- /TEMPLATE_ONLY -->
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
 
 ## Codex 계획 검증
 
-- **상태**: 미요청
-- **요청 시점**:
-- **결론**: 미요청 / PASS / CHANGE_REQUEST / BLOCK
-- **핵심 지적**:
-- **반영 내용**:
+- **결론**: 미요청
 
 ## Codex 1차 검증
 
-- **상태**: 미요청
-- **요청 시점**:
-- **결론**: 미요청 / PASS / FIX_APPLIED / CHANGE_REQUEST / BLOCK
-- **수정 파일**:
-- **핵심 지적**:
-- **남은 리스크**:
+- **결론**: 미요청
 
 ## Claude 2차 검증
 
-- **검토 내용**:
-- **실행한 검증**:
-- **최종 판단**:
+- **최종 판단**: 미작성
 
-## 리뷰 (완료 직전)
+---
 
-- [ ] 셀프 리뷰: 이 PR을 처음 보는 사람도 EXEC_PLAN만으로 변경 의도를 이해할 수 있는가?
-- [ ] **멀티 세션 리뷰** (권장): 같은 세션의 구현자는 무의식적 바이어스가 생긴다.
-      별도 Claude 세션 또는 `codex:rescue`로 객관적 검토를 요청해 시선을 분리한다.
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+-->
 
-## 회고 (머지 후 작성, completed/로 이동 시)
-
-- 잘된 것:
-- 다음에 할 것:
-- 발견된 부채 (→ tech-debt-tracker.md 옮길 것):
+<!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/docs/exec-plans/active/2026-05-14-harness-codex-review-cap.md
+++ b/docs/exec-plans/active/2026-05-14-harness-codex-review-cap.md
@@ -1,0 +1,418 @@
+# harness-codex-review-cap
+
+- **상태**: 🟡 진행 중 (분석·합의 완료, 구현 대기)
+- **시작일**: 2026-05-14
+- **브랜치**: 미정 (`feat/harness-codex-review-cap` 또는 `chore/harness-...` 권장 — 확인 필요)
+- **선행**: PR #86(Phase 0) 머지 완료, PR #?(sermons-featured, 커밋 `38377a3` `feat/sermons-featured` 브랜치, 푸시는 됐으나 사용자 결정으로 PR 미생성)
+
+---
+
+## 작업 문서
+
+### 1. 목적
+
+dnchurch 하네스 워크플로우(`EXPLORE → PLAN → CODEX_PLAN_REVIEW → WORK → CODEX_FIRST_PASS → VERIFY → COMMIT`)가 단순 feature에서 **12× 오버헤드**를 만든 운영 결함을 시스템적으로 차단한다.
+
+**증거**: Phase 1-1 (sermons-featured, 단일 컴포넌트 1 PR 규모)가 예상 5분 → 실측 ~2시간 소요. CODEX_PLAN_REVIEW 5라운드 중 14건 누적 CHANGE_REQUEST, 11건(79%)이 **plan-text 표현 모순**, 3건만 실질적 코드 영향.
+
+**변경 대상**:
+- `.claude/skills/harness-workflow/SKILL.md` (§ EXPLORE / § CODEX_PLAN_REVIEW)
+- `docs/exec-plans/_template.md`
+- `scripts/harness-gate.mjs`
+- `.claude/hooks/check-codex-after-plan.mjs`, `post-implementation-review.mjs`
+- `docs/decisions/0010-harness-codex-review-cap.md` (신규 ADR)
+- `tests/harness/` (신규 fixture 3개)
+
+---
+
+### 2. 진행 흐름
+
+```
+[Phase 1-1 sermons-featured 진행]
+  ↓
+[증상 발견] 5분 작업 → 2시간 소요 (사용자 보고)
+  ↓
+[Claude 자가 진단] 4 변경안 제시
+  - CODEX_PLAN_REVIEW 1라운드 cap
+  - EXPLORE 직접 검증 의무
+  - PLAN 1.5 page 압축
+  - Hook debounce
+  ↓
+[사용자 결정] 메모리 저장 X, 시스템 자체에 적용
+  ↓
+[Codex 메타-리뷰 (fresh thread)]
+  - Claude 4안 평가 + 5 추가 발견:
+    a) CHANGE_REQUEST 기준 자체가 폭주 원인 (cap만으론 부족)
+    b) ADR 0008 single-tier가 reviewer 가치 증명 incentive 유발
+    c) 진짜 plan 비대 원인은 `_template.md` (17 섹션)
+    d) harness-gate regex가 formatting trap
+    e) EXPLORE 검증 대상 일반화 필요
+  - 6 변경 + 6 안티패턴 가드 + ADR 0010 Decision 초안
+  ↓
+[사용자 요청] 보고서 구조 재정리 (문제/원인/해결/대안/결과)
+  ↓
+[Claude v2 보고서 작성] 근거 파일·라인 인용, KPI 정의, 대안 7건 기각 사유
+  ↓
+[사용자 결정] 옵션 C (6 fixes 전부 적용) + 위험 분석 병렬 (Claude + Codex)
+  ↓
+[Claude 자체 위험 분석] R1~R10, Top 5 추출, 4 추가 가드 제안
+[Codex 위험 분석 병렬 실행]
+  - R1·R2·R3·R7·R10 양측 합의
+  - R5(gate placeholder)·R6(hook debounce) Codex가 high로 평가, Claude는 과소평가
+  - Codex 신규 가드 7건 (placeholder denylist, section hash 재알림,
+    fixture 3개, PASS_WITH_DECISION_LOG 토큰, must-CR 예시 8개 등)
+  ↓
+[Claude 통합 보고] 9개 통합 가드 + 적용 순서 ~45분
+  ↓
+[현재 시점] 핸드오프 문서 작성 (이 문서)
+  ↓
+[다음 단계] 6 fixes + 9 가드 적용 → ADR 0010 commit → 후속 phase에서 KPI 측정
+```
+
+---
+
+### 3. 주요 결정
+
+#### 3.1 확정된 결정 (사용자 승인)
+
+| # | 결정 | 사유 |
+|---|---|---|
+| D1 | **6 fixes 전부 적용** | Claude·Codex 합의. 단일 lever 불충분, 시너지 필요 |
+| D2 | 본 변경은 plan/Codex review 생략 | 변경 근거가 본 phase 실패 자체. 메타-리뷰가 review 역할 수행 |
+| D3 | ADR 0010 영구 기록 | `.claude/`·`scripts/` 변경은 ADR_TRIGGER_PARTS 포함 |
+| D4 | dogfooding fixture 3개 사전 실행 | Codex 신규 발견 — self-validating 회귀 방지 |
+| D5 | Override·Rollback 섹션 ADR에 필수 포함 | 대형 task 자동 해제 + 회귀 시 재검토 메커니즘 |
+
+#### 3.2 6 Fixes (확정 내용)
+
+**F1: SKILL.md § CODEX_PLAN_REVIEW**
+```
+- CHANGE_REQUEST를 material risk 한정
+  (정책/데이터/타입/레이어/검증 공백/요청 범위 이탈)
+- 표현·문구·label 정합성은 §의사결정 로그 1줄 + WORK 진입
+- 3차 자동 호출 금지, 사용자 승인 필요
+- BLOCK 기준 cap 무관 유지 (인증/캐시/배포/DB/데이터 손실/보안/컨텍스트)
+- 애매하면 material로 승격 (안전 쪽)
+- Codex 호출 프롬프트 템플릿 (PASS_WITH_DECISION_LOG 결론 토큰 + 확신도 표기)
+```
+
+**must-CR 예시 8개 (확정, inline)** — Codex가 분류 시 참조:
+1. DB column 부재로 데이터 흐름 실패 (예: 본 phase의 `is_featured` BLOCK)
+2. 타입 불일치로 type-check 실패 (예: `SermonListItem` vs `SermonWithRelations` 필드 누락)
+3. 레이어 위반 (app → apis 직접 호출, services bypass)
+4. 인증/캐시/배포 정책 변경 누락 (예: `createServerSideClient` vs `createStaticClient` 오용)
+5. **Non-goals에 명시한 항목 변경** (예: 본 phase의 `[id]`→`[slug]` 시도 시)
+6. **user-visible acceptance criteria 위반** (SEO/UX 영향 metadata 포함, 예: title이 GNB 라벨과 불일치)
+7. 검증 명령 부재 또는 부적절 (예: SC가 "동작하게" 같은 약한 기준)
+8. **repo policy 위반** (token 하드코딩 / `<Image>` 직접 사용 / `--no-verify` / barrel 반사 등)
+
+**expression-only 예시 5개 (확정, inline)** — §의사결정 로그 1줄 후 WORK 진입:
+1. 같은 정보를 N곳에 적어 미세 불일치 (예: 본 phase의 "코드 변경 0" vs "1줄 변경" 표현 충돌)
+2. label 표기 차이 ("신규" vs "교체", "이관" vs "분리")
+3. 중복 설명·섹션 배치·비차단 명명 제안
+4. 문장 품질 (이중부정·길이·어순)
+5. SEO·라우팅 영향 없는 표기 오타 (예: 의사결정 로그 내 typo)
+
+**F2: SKILL.md § EXPLORE**
+```
+- 구현 의존 claim (컬럼/함수/타입/라우트/토큰/mixin/config flag/wrapper 컨벤션)
+  은 rg/generated types/migration/SQL로 직접 확인
+- 영향 파일 surface only — 전수 검사 금지
+- audit/doc은 보조, 코드/DB가 SSOT
+- 확인 근거 §검증된 Assumptions 또는 §의사결정 로그에 1줄
+- 단순 변경(typo/rename/1줄) 시 claim 없으면 EXPLORE 1-2분 종료
+```
+
+**F3: `docs/exec-plans/_template.md`**
+```
+- 17 섹션 → 5 섹션 기본 (목표/검증된 Assumptions/SC/영향 파일/체크리스트/Verification)
+- §감사·§Open Questions·§ADR은 해당 시만 추가
+- mandatory 1줄 필드 (섹션 optional이어도 항상 채움):
+  Open questions: none | <list>
+  ADR needed: no | yes + reason
+```
+
+**F4: `scripts/harness-gate.mjs`**
+```js
+// same-line regex 제거
+// + placeholder denylist (TBD/미요청/미작성/N/A/none/- 차단)
+// + verdict token 강제 (최종 판단만: PASS/FAIL/PASS_WITH_DECISION_LOG/BLOCK)
+// + 최소 30자 비-placeholder 내용
+// + ADR_TRIGGER_PARTS 파일 변경 시 §ADR 판단·mandatory 1줄 필드 강제
+```
+
+**F5: `.claude/hooks/check-codex-after-plan.mjs` + `post-implementation-review.mjs`**
+```js
+// debounce key = hash(plan §목표 + §SC + §영향 파일 + §Verification)
+// 이전 hash와 다르면 1회 재알림 (Codex 검증 미요청 상태에서만)
+// once-only 금지 — section hash 변경 시 재알림 허용
+// 수동 Codex 호출 가능 문구는 SKILL.md에 유지
+```
+
+**F6: `docs/decisions/0010-harness-codex-review-cap.md`**
+```md
+## Decision (Codex verbatim — 사용자 검토 후 조정 가능)
+CODEX_PLAN_REVIEW는 material implementation risk만 CHANGE_REQUEST로 분류하고,
+문서 표현·plan-text consistency는 구현 판단을 바꾸지 않는 한 의사결정 로그에
+기록한 뒤 WORK로 진행한다. 단일 컴포넌트/작은 PR은 compact exec-plan 형식을
+기본으로 하며, 구현 의존 claim은 EXPLORE에서 코드/DB/generated source로 직접
+확인한다. Hook은 plan 최초 작성 후 1회와 WORK 종료 후보 1회만 알림을 보내도록
+debounce(section hash 기반)하고, harness-gate는 검증 섹션의 의미 있는 내용 존재만
+확인하며 label same-line formatting은 강제하지 않는다.
+
+## Override (필수 섹션)
+다음 조건 1건 이상 hit 시 본 ADR cap·compact·debounce 자동 해제:
+- 변경 파일 ≥ 20 또는 LOC ≥ 500
+- ADR_TRIGGER_PARTS 다중 영역 (services + scripts + .claude/ 등)
+- 라이브러리 마이그레이션 (package.json deps 신규/제거)
+- 인증/캐시/배포/DB schema 변경
+- 사용자 명시 STRICT_REVIEW 요청
+해제 시: full template + Codex review 무제한 라운드 + 기존 hook 빈도.
+exec-plan §의사결정 로그에 "Override 적용 사유" 1줄 기록.
+
+## Rollback Triggers (필수 섹션)
+3 sub-phase 누적 후 측정. 1건 이상 hit 시 ADR 재검토:
+- 평균 phase 시간 본 ADR 적용 전(120분) 대비 50% 미만 개선
+- 1차 검증·PR review에서 material 사후 발견 2× 증가
+- harness-gate placeholder 통과 사례 1건
+- 사용자 "검토 부족" 피드백 1건
+```
+
+#### 3.3 9개 통합 가드 (Claude + Codex 합의)
+
+| # | 영역 | 가드 |
+|---|---|---|
+| 가1 | F1 | must-CR 예시 8개 + expression 5개 + "애매하면 material" 룰 |
+| 가2 | F1 | `PASS_WITH_DECISION_LOG` 비차단 결론 토큰 신규 도입 |
+| 가3 | F2 | "implementation-dependent claim 있을 때만" 조건 + surface only |
+| 가4 | F3 | `Open questions`·`ADR needed` 1줄 필드 mandatory |
+| 가5 | F4 | placeholder denylist + verdict token + 최소 30자 |
+| 가6 | F5 | plan section hash 기반 debounce key |
+| 가7 | F6 | `Override` 섹션 (조건/승인자/exec-plan 기록 방식) |
+| 가8 | F6 | `Rollback Triggers` 섹션 (3 sub-phase KPI 측정) |
+| 가9 | dogfooding | fixture 3개 (valid/placeholder/revised-after-review) + `node --check` + dry-run |
+
+#### 3.4 기각된 대안 (재논의 시 참조)
+
+| 대안 | 기각 사유 |
+|---|---|
+| A status quo | 누적 손실 20-30시간 / 잔여 phase ≥ 20 |
+| B Codex prompt만 수정 | SKILL.md 기본 정의가 그대로면 reviewer incentive 변화 없음 |
+| C SKILL만, template 유지 | template 17 섹션이 plan 비대 원인 — 효과 절반 |
+| D harness-gate·hook만 | 주 원인(Codex 5라운드)에 미치지 못함 |
+| E Codex review 전부 생략 | material risk 누락 — ADR 0001 위반 |
+| F ADR 0008 자체 폐기 | 코드 품질 메커니즘 상실. 의도는 정확, 운영이 잘못됨 |
+
+#### 3.5 핸드오프 문서 평가 후 의사결정 7건 (E1~E7)
+
+본 문서 v1 작성 후 Claude + Codex 교차 평가에서 EDIT 7건 발견. 다음과 같이 확정:
+
+**E1 — U2 커밋 prefix 확정: `Refactor`**
+- 근거: 본 변경은 (1) 시스템 운영 정책 변경(SKILL.md CR 정의), (2) 스크립트 동작 변경(harness-gate regex), (3) 워크플로우 자동화 변경(hook debounce). CLAUDE.md prefix 6개 중 `Refactor`가 가장 정확 — "기존 동작 개선/재구성".
+- 기각: `Chore`(잡일 인상, 운영 정책 변경 무게 부족), `Docs`(SKILL/ADR 신규지만 코드/스크립트 변경 동반).
+- 트레이드오프: `Refactor` 사용 시 향후 grep 시 코드 리팩터와 섞일 수 있음. 단 본문에서 ADR 0010 인용으로 식별 가능.
+
+**E2 — sermons-featured PR 즉시 생성 (본 ADR과 분리, 병렬 진행)**
+- 근거: §4.4 명시대로 sermons-featured(`feat/sermons-featured` 브랜치 + 커밋 `38377a3`)가 머지되지 않으면 **Phase 1-2(Recent 캐러셀)·1-3(Series 캐러셀)이 차단** (Carousel 컴포넌트와 필터 URL 4곳 의존). 본 ADR 적용은 ~45분, sermons PR은 ~5분 — 직렬 진행 시 ~50분 더 차단.
+- 기각: "본 ADR 적용 후 PR" — Phase 1-2 차단 5+ 일 가능.
+- 트레이드오프: PR이 본 ADR 머지 전이라 sermons-featured는 **기존 (긴) plan 검증 절차로 작성된 plan**을 그대로 가짐. 본 ADR 머지 후 자동 적용은 안 되지만 후속 phase부터 신 규칙 적용 시작.
+
+**E3 — U2·U3·U6·U8을 default 확정, 미확정 list에서 제거**
+- 근거: Codex 지적 — "운영 선택지가 ADR 0010 'plan 압축' 취지와 긴장". 분석 마비(analysis paralysis) 차단. 본 ADR의 §접근법과 일관.
+- 확정값:
+  - U2 → E1 결정 (`Refactor`)
+  - U3 PR 템플릿 → `.github/PULL_REQUEST_TEMPLATE/refactor.md` (memory `feedback_pr_templates` 패턴)
+  - U6 fixture 위치 → `tests/harness/` (신규 디렉토리, scripts/와 분리. tests/ 컨벤션 기존 사용 확인 필요 — 없으면 신설)
+  - U8 Codex 호출 프롬프트 → SKILL.md § CODEX_PLAN_REVIEW 인라인 (별도 파일 신설 X — 단일 source)
+- 트레이드오프: default가 후속 phase에 부적합 시 ADR 0010 Override 섹션으로 opt-out. default를 박지 않으면 매 작업자마다 동일 선택지에서 갈등.
+
+**E4 — F1 must-CR 8개 + expression 5개 예시를 §3.2에 inline 확정, U9 삭제**
+- 근거: Codex 지적 — "F1의 must-CR 예시 8개는 U9와 충돌". 예시가 §3.2에 박혔는데 U9가 "충분성 미확정"이면 후속 작업자가 다시 결정해야 함.
+- 트레이드오프: 8+5 예시가 모든 케이스를 커버 못 함. 단 SKILL.md에 "애매하면 material로 승격" 룰이 있어 누락 시 안전 쪽으로 분류. 추가 예시는 ADR 0010 후속 PR에서 보강.
+
+**E5 — §6.2 Step 순서 정정: Step 6(fixture) → Step 4 앞으로 이동**
+- 근거: Codex 지적 — "§6.2 Step 4의 숨은 의존성은 Step 3이 아니라 Step 6 fixture다". harness-gate 변경(F4)을 검증하려면 fixture 3개가 선행 필요. fixture 없으면 regex 변경 후 회귀 발견 못 함.
+- 새 순서: 1 template → 2 SKILL EXPLORE → 3 SKILL CODEX_PLAN_REVIEW → **4 fixture** → 5 harness-gate → 6 hook → 7 ADR
+- 트레이드오프: fixture를 먼저 만들 때 SKILL의 must-CR/expression 정의가 필요할 수 있음. Step 3 후 fixture라 OK.
+
+**E6 — 부록 "확인 필요 사항 종합" 라인 삭제 (§5와 중복)**
+- 근거: Codex 지적 — "부록과 §5 미확정 사항 중복, 노이즈".
+- 트레이드오프: 없음 (단순 중복 제거).
+
+**E7 — 본 문서 위치 유지 (`docs/exec-plans/active/`)**
+- 근거: 3 옵션 비교 — (a) `active/` 유지: 기존 검색 경로 일관, 단 harness-gate가 정상 plan 형식 기대 시 경고. (b) ADR 0010 부록 흡수: ADR 본문 비대 + 머지 후 history되어 후속 phase 접근 불편. (c) `docs/exec-plans/meta/` 신설: 새 디렉토리, 일관성 ↓.
+- 결정: (a) **유지**. ADR 0010 적용 후 hook이 본 문서 같은 메타 작업을 인식하도록 보강 (frontmatter `kind: meta` 또는 §"메타 작업 플래그" 추가 — 후속 보강).
+- 트레이드오프: harness-gate fail 가능 — 본문 §6.1·부록에 "본 작업은 harness-gate 우회, 사용자 명시 승인" 명시로 해소.
+
+---
+
+### 4. 구현/설계 맥락
+
+#### 4.1 핵심 파일·라인 인용
+
+| 파일 | 라인 | 현재 상태 | 변경 필요 |
+|---|---|---|---|
+| `.claude/skills/harness-workflow/SKILL.md` | 다수 | 5체크 미충족 = CR 기본값 정의 | F1 (CR 정의 좁힘) + 경계 사례 표 |
+| 동일 파일 | § EXPLORE | "기존 코드·문서·패턴 확인" | F2 (직접 검증 의무) |
+| 동일 파일 | § 검증 결과 기록 규칙(128-156) | 구체화 4원소 강제 | **유지** (검증 기록만 적용, plan review 적용 X로 명확화) |
+| `docs/exec-plans/_template.md` | 전체 17 섹션 | 모든 섹션 기본 노출 | F3 (5 섹션 압축) |
+| `scripts/harness-gate.mjs` | 69 | `/검토 내용\*\*:\s*$.../m` | F4 (regex 교체) |
+| `.claude/settings.json` | hook 설정 | 모든 Write/Edit/MultiEdit 후 실행 | F5 (section hash debounce) |
+| `scripts/_shared-config.mjs` | 7-26 | `ADR_TRIGGER_PARTS` | **유지** (참조용) |
+| `docs/decisions/0008-...` | Decision | agent review tier 메커니즘 2 | **유지** (본 ADR 0010이 0008 운영 보완) |
+| `docs/decisions/0001-...` | Codex 위임 전략 | 위임 트리거 정의 | **유지** |
+
+#### 4.2 phase 1-1에서 발견된 실제 사례 (재현 방지)
+
+| 사례 | 현 시스템 어디서 막힘 | 본 ADR 0010 적용 시 |
+|---|---|---|
+| `is_featured` 컬럼 부재 (Phase 0 audit 오류 인용) | EXPLORE 미발견 → Codex 1차에서 발견 (BLOCK) | F2로 EXPLORE에서 `mcp__claude_ai_Supabase__list_tables` 1회 호출로 사전 발견 |
+| 필터 base path 4곳 (`buildSermonHref` / `useSermonFilter` / `SermonYearGrid` / `SermonDetailPage`) | Codex 1차에서 발견 (material) | 동일 — F1의 must-CR #5(Non-goals 위반·scope drift)에 해당 |
+| Codex 2~4차 11건 표현 모순 ("코드 0줄" / "신규" vs "교체" / 의사결정 로그 표현 잔존) | 5라운드 폭주 | F1으로 expression 분류 → §의사결정 로그 1줄 + WORK 진입 |
+| `<Image>` vs `<CloudinaryImage>` 컨벤션 누락 | yarn build 실패 시 발견 (10분 손실) | F2의 wrapper 컨벤션 직접 검증으로 EXPLORE 단계 발견 |
+| harness-gate `**검토 내용**:` label 줄 끝 → 미작성 판정 (5분 정정) | regex formatting trap | F4의 multi-line content check |
+
+#### 4.3 사용자 선호·제약 (memory + 본 대화)
+
+| 선호/제약 | 출처 | 본 작업 적용 |
+|---|---|---|
+| **간결한 plan/문서** | `feedback_concise_plans` | F3 compact template / 본 핸드오프 문서 압축 |
+| **WHY/IMPACT 우선 커밋·PR** | `feedback_commit_message` | ADR 0010 commit 메시지 작성 시 적용 |
+| **커밋 prefix 6개만** (Feat·Fix·Style·Refactor·Docs·Chore) | `feedback_commit_convention` | 본 작업은 `Refactor` 또는 `Chore` |
+| **추상명사 회피·구체화 4원소** | `feedback_concrete_records` | 본 문서 + ADR 0010 작성 시 |
+| **커밋 전 사용자 승인** | `feedback_commit_approval` | F6 ADR 작성 후 사용자 승인 후 커밋 |
+| **Co-Authored-By 실제 모델명** | `feedback_commit_coauthor` | "Claude Opus 4.7 (1M context)" |
+| **PR base는 develop** | `feedback_pr_base_branch` | base = develop |
+| **PR 템플릿 본문 필수** | `feedback_pr_templates` | `Refactor` 시 `refactor.md`, `Chore` 시 `maintenance.md` (확인 필요) |
+| **PR --assignee @me --label** | CLAUDE.md | 본 PR 생성 시 필수 |
+| **사용자가 "5분 → 1시간"을 "심각한 문제"로 인식** | 본 대화 | 본 ADR의 motivation에 명시 |
+
+#### 4.4 PR #?(sermons-featured) 현재 상태
+
+- 브랜치: `feat/sermons-featured` (origin push 완료)
+- 커밋: `38377a3` "Feat: 설교 메인 페이지 Featured 카드 도입 + archive 뷰 /sermons/all 이관"
+- PR 생성: **미생성** (사용자 결정 — 본 시스템 변경 우선)
+- 사용자 결정 사항: 본 ADR 적용 후 sermons-featured PR 생성 여부 재논의 (확인 필요)
+- 영향: develop 머지 안 됨 → Phase 1-2/1-3 진입 차단됨 (Featured 컴포넌트 + 필터 URL 4곳 의존)
+
+---
+
+### 5. 미확정 사항
+
+§3.5 E3 적용으로 U2·U3·U6·U8 default 확정, E4 적용으로 U9 삭제. 남은 미확정 4건:
+
+| # | 항목 | 결정 필요 시점 | 결정자 |
+|---|---|---|---|
+| U1 | 본 작업 브랜치명 — `feat/harness-codex-review-cap` 권장 (default), 또는 `refactor/harness-...` | 작업 시작 시 | 사용자 (1초 결정) |
+| U4 | sermons-featured PR 머지 시점 (E2로 PR 생성은 즉시 확정) | PR review 완료 시 | 사용자 |
+| U5 | `.claude/hooks/` 파일 실제 경로·내용 — `.claude/settings.json` 설정 vs `.claude/hooks/*.mjs` 스크립트 분리 여부 | F5 구현 시 | Glob/Read로 점검 (작업자가 자체 해결) |
+| U7 | KPI 측정 자동화 — 수동 보고 vs `scripts/measure-phase.mjs` 신규 | Rollback Triggers 첫 측정 시 (3 sub-phase 후) | 사용자 |
+
+---
+
+### 6. TODO (다음 작업자가 즉시 실행)
+
+#### 6.1 사전 점검 (5분)
+
+```bash
+# U5 확인 — hook 파일 실제 구조
+ls -la .claude/hooks/ 2>/dev/null
+cat .claude/settings.json | grep -A 3 hooks
+
+# 현재 SKILL.md 라인 수 확인 (변경 전후 비교용)
+wc -l .claude/skills/harness-workflow/SKILL.md
+wc -l docs/exec-plans/_template.md
+
+# 본 작업 시작 — task-id 결정
+node scripts/start-task.mjs harness-codex-review-cap
+# 단 D2에 따라 plan은 본 핸드오프 문서로 대체 — start-task가 새 plan 만들면 삭제 또는 link
+```
+
+#### 6.2 변경 적용 순서 (~45분, E5로 Step 순서 정정 적용됨)
+
+| Step | 작업 | 파일 | 검증 |
+|---|---|---|---|
+| 1 | `_template.md` 5 섹션 압축 + Open questions/ADR needed mandatory 1줄 | `docs/exec-plans/_template.md` | `wc -l` 비교 (17 섹션 → 5 섹션) |
+| 2 | SKILL.md § EXPLORE 직접 검증 의무 (claim 있을 때만) | `.claude/skills/harness-workflow/SKILL.md` | 단순 변경(typo) 시 EXPLORE 1-2분 종료 가능 명시 확인 |
+| 3 | SKILL.md § CODEX_PLAN_REVIEW (CR 정의 + must-CR 8개 + expression 5개 + 프롬프트 템플릿) | 동일 | must-CR/expression 예시 13개 모두 dnchurch 실사례 인용 (§3.2 F1 inline 참조) |
+| **4** (E5로 5→4 이동) | **fixture 3개 작성** — valid / placeholder / revised-after-review | `tests/harness/` (E3 default) | 각 fixture에 대해 `harness-gate` 통과/실패 예상값 확인. Step 5의 dry-run 검증 의존성 선행 |
+| 5 (E5로 4→5 이동) | `harness-gate.mjs` placeholder denylist + verdict token | `scripts/harness-gate.mjs` | Step 4 fixture 3개로 dry-run (의존 해소) |
+| 6 | `.claude/hooks/` section hash debounce | `.claude/hooks/check-codex-after-plan.mjs` + `post-implementation-review.mjs` (또는 settings.json — U5 점검 후) | 본 핸드오프 문서 수정으로 hook 발화 확인 |
+| 7 | ADR 0010 작성 (Decision + Override + Rollback + Consequences + 본 핸드오프 문서 링크) | `docs/decisions/0010-harness-codex-review-cap.md` | `node scripts/update-adr-index.mjs` 실행 |
+
+#### 6.3 검증 (자체 dogfooding)
+
+```bash
+# Step 6 fixture로 harness-gate dry-run
+node --check scripts/harness-gate.mjs
+# 본 핸드오프 문서를 valid fixture로 사용 가능 — 단 본 문서는 일반 exec-plan 형식 아님
+# 별도 fixture 디렉토리 권장
+
+# Hook section hash 변경 시 재알림 확인
+# (테스트 어려움 — settings.json 일시 변경 후 더미 plan edit으로 발화 확인)
+```
+
+#### 6.4 커밋·PR (사용자 승인 후)
+
+```bash
+# 변경 파일 명시 stage (-A 금지)
+git add .claude/skills/harness-workflow/SKILL.md \
+        docs/exec-plans/_template.md \
+        scripts/harness-gate.mjs \
+        .claude/hooks/ \
+        .claude/settings.json \
+        docs/decisions/0010-harness-codex-review-cap.md \
+        docs/decisions/README.md \
+        tests/harness/
+
+# 커밋 메시지 (U2 결정 후) — 권장:
+# Refactor: 하네스 CODEX_PLAN_REVIEW cap + plan 압축 + EXPLORE 직접 검증 의무화 (ADR 0010)
+# 본문 4-line (WHY: 5분 작업 → 2시간 / 무엇: 6 fixes + 9 가드 / 영향: ... / 제외: ...)
+# Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+
+# PR 생성 (U3 템플릿 결정 후)
+gh pr create --base develop --assignee "@me" --label <label> --title "[Refactor] ..." --body "..."
+```
+
+#### 6.5 후속 측정 (3 sub-phase 후 — Phase 1-2 / 1-3 / 1-4)
+
+```bash
+# 각 sub-phase 종료 시 KPI 기록
+# - 평균 phase 시간 (목표 30-45분)
+# - Codex 라운드 수 (목표 1-2)
+# - CR 표현 비율 (목표 <30%)
+# - Plan 라인 수 (목표 80-100)
+# - EXPLORE BLOCK 발견율 (목표 100%)
+# - harness-gate format 실패 (목표 0)
+# - hook 알림 횟수 (목표 2-3)
+
+# Rollback Triggers 1건 이상 hit 시 ADR 0010 재검토
+```
+
+#### 6.6 참고 자료 (다음 작업자가 맥락 파악용)
+
+| 자료 | 위치 |
+|---|---|
+| Phase 1-1 exec-plan (실패 사례) | `docs/exec-plans/active/2026-05-14-sermons-featured.md` |
+| Phase 0 회고 (audit 오류 발견 부채 등록 필요) | `docs/exec-plans/completed/2026-05-13-sermons-phase0-foundation.md` |
+| ADR 0001 (Codex 위임 전략) | `docs/decisions/0001-codex-orchestration-strategy.md` |
+| ADR 0008 (코드 품질 강제) | `docs/decisions/0008-...` |
+| 현행 SKILL | `.claude/skills/harness-workflow/SKILL.md` |
+| 현행 template | `docs/exec-plans/_template.md` |
+| 현행 harness-gate | `scripts/harness-gate.mjs` |
+| 본 핸드오프 문서 자체 | `docs/exec-plans/active/2026-05-14-harness-codex-review-cap.md` |
+
+#### 6.7 Codex thread 참조 (재요청 시)
+
+- **메타 진단 thread**: `agentId: acd81e5266775b43c` (5 추가 발견 + ADR Decision 초안)
+- **위험 분석 thread**: `agentId: a62c7b301fd6ccab3` (R1~R10 + Top 7 + 6 가드 modifications)
+- 재요청 시: `Agent(codex:codex-rescue, "--resume", to: <agentId>)` 또는 SKILL의 `codex-companion.mjs task-resume-candidate` 흐름
+
+---
+
+## 부록: 본 핸드오프 문서 자체에 대한 메모
+
+- 본 문서는 **일반 exec-plan 형식이 아님** (메타-작업 핸드오프). 정상 절차의 `## Codex 계획 검증` / `## Codex 1차 검증` / `## Claude 2차 검증` 섹션 없음.
+- 본 문서로 `node scripts/harness-gate.mjs harness-codex-review-cap` 실행 시 검증 섹션 부재로 fail 예상 — D2에 따라 본 작업은 harness-gate 우회 (사용자 명시 승인 필요).
+- 완료 후 `node scripts/complete-task.mjs harness-codex-review-cap`로 `completed/`로 이동. 회고 작성 시 KPI 측정 결과 첨부.
+- E7 결정: 본 문서 위치 `docs/exec-plans/active/` **유지**. 후속 보강으로 hook이 메타 작업 인식하도록 frontmatter `kind: meta` 또는 §"메타 작업 플래그" 추가 검토.

--- a/scripts/harness-gate.mjs
+++ b/scripts/harness-gate.mjs
@@ -6,14 +6,20 @@ import process from "node:process";
 import { ADR_TRIGGER_PARTS } from "./_shared-config.mjs";
 
 const VERDICT_BY_SECTION = {
-  "Codex 계획 검증": /\*\*결론\*\*:\s*(PASS|PASS_WITH_DECISION_LOG|CHANGE_REQUEST|BLOCK)\b/,
-  "Codex 1차 검증": /\*\*결론\*\*:\s*(PASS|FIX_APPLIED|CHANGE_REQUEST|BLOCK)\b/,
-  "Claude 2차 검증": /\*\*최종 판단\*\*:\s*(PASS|FAIL)\b/,
+  "Codex 계획 검증": /\*\*결론\*\*:\s*(?:\*\*)?(PASS|PASS_WITH_DECISION_LOG|CHANGE_REQUEST|BLOCK)\b(?:\*\*)?/,
+  "Codex 1차 검증": /\*\*결론\*\*:\s*(?:\*\*)?(PASS|FIX_APPLIED|CHANGE_REQUEST|BLOCK)\b(?:\*\*)?/,
+  "Claude 2차 검증": /\*\*최종 판단\*\*:\s*(?:\*\*)?(PASS|FAIL)\b(?:\*\*)?/,
+};
+
+const ALLOWED_VERDICTS = {
+  "Codex 계획 검증": ["PASS", "PASS_WITH_DECISION_LOG", "CHANGE_REQUEST", "BLOCK"],
+  "Codex 1차 검증": ["PASS", "FIX_APPLIED", "CHANGE_REQUEST", "BLOCK"],
+  "Claude 2차 검증": ["PASS", "FAIL"],
 };
 
 const PLACEHOLDER_LINE = /^\s*(?:[-—–]|TBD|ＴＢＤ|미요청|미작성|N\/A|none)\s*$/i;
 const PLACEHOLDER_INLINE = /^\s*[-*]?\s*\*\*[^*]+\*\*:\s*["'`]?(?:TBD|ＴＢＤ|미요청|미작성|N\/A|none|-|—|–)["'`]?\s*$/i;
-const VERDICT_LABEL = /^\s*[-*]?\s*\*\*(?:결론|최종 판단)\*\*:\s*/;
+const VERDICT_LABEL = /^\s*[-*]?\s*\*\*(?:결론|최종 판단)\*\*:\s*(?:\*\*)?\w+(?:\*\*)?\s*/;
 const MIN_BODY_CHARS = 30;
 
 function fail(message) {
@@ -81,7 +87,7 @@ function assertSectionRich(body, label) {
     if (PLACEHOLDER_LINE.test(line)) continue;
 
     if (VERDICT_LABEL.test(line)) {
-      const after = line.replace(VERDICT_LABEL, "").replace(/^\w+\s*/, "").trim();
+      const after = line.replace(VERDICT_LABEL, "").trim();
       usefulChars += after.length;
       continue;
     }
@@ -108,10 +114,7 @@ function assertReviewSections(content, filename) {
 
     const verdictMatch = body.match(verdictRe);
     if (!verdictMatch) {
-      const allowed = verdictRe.source
-        .replace(/^.*?\(/, "")
-        .replace(/\)\\b$/, "")
-        .replace(/\|/g, " / ");
+      const allowed = ALLOWED_VERDICTS[heading].join(" / ");
       fail(
         `${filename}: ## ${heading} verdict token이 없습니다. 허용: ${allowed}. ` +
           `placeholder(미요청/미작성)은 차단됩니다 — Codex/Claude 검증을 실제로 수행하고 결론을 기록하세요.`,
@@ -154,12 +157,24 @@ function assertAdrDecision(content, filename) {
 
   if (adrRiskFiles.length === 0 || adrChanged) return;
 
-  const adrLine = /\*\*ADR needed\*\*:\s*(no|yes)\b/i.exec(content);
+  const adrLine = /^\s*-\s*\*\*ADR needed\*\*:\s*(no|yes)\b(?<rationale>.*)/im.exec(content);
   const legacyBody = sectionBody(content, "ADR 판단");
 
   if (!adrLine && !legacyBody) {
     fail(
       `${filename}: ADR 후보 변경이 있지만 frontmatter \`**ADR needed**: no | yes\` 또는 ## ADR 판단 섹션이 없습니다.`,
+    );
+  }
+
+  if (
+    adrLine?.[1].toLowerCase() === "no" &&
+    !adrLine.groups?.rationale.trim() &&
+    !legacyBody
+  ) {
+    fail(
+      `${filename}: ADR 후보 변경(${adrRiskFiles.slice(0, 3).join(", ")}${adrRiskFiles.length > 3 ? " ..." : ""})이 있는데 ` +
+        `\`**ADR needed**: no\`에 사유가 없습니다. ` +
+        `한 줄 inline 사유를 추가하세요 (예: \`**ADR needed**: no — scripts/ 오타 수정만 포함\`).`,
     );
   }
 
@@ -200,6 +215,7 @@ function parseArgs(argv) {
 }
 
 const { planFile, taskPattern } = parseArgs(process.argv.slice(2));
+const effectiveTask = taskPattern || process.env.TASK_ID || "";
 
 if (planFile) {
   if (!existsSync(planFile)) fail(`--plan-file 경로가 없습니다: ${planFile}`);
@@ -210,15 +226,13 @@ if (planFile) {
   process.exit(0);
 }
 
-if (!taskPattern) {
+if (!effectiveTask) {
   fail("Usage: node scripts/harness-gate.mjs <task-id-or-active-plan-pattern> | --plan-file <path>");
 }
 
-if (/[^a-zA-Z0-9_.-]/.test(taskPattern || process.env.TASK_ID || "")) {
-  fail(`task id는 영숫자·_·.·-만 허용합니다. 입력: ${taskPattern}`);
+if (/[^a-zA-Z0-9_.-]/.test(effectiveTask)) {
+  fail(`task id는 영숫자·_·.·-만 허용합니다. 입력: ${effectiveTask}`);
 }
-
-const effectiveTask = taskPattern || process.env.TASK_ID || "";
 
 const repoRoot = git(["rev-parse", "--show-toplevel"]);
 process.chdir(repoRoot);

--- a/scripts/harness-gate.mjs
+++ b/scripts/harness-gate.mjs
@@ -222,7 +222,9 @@ if (planFile) {
   const content = readFileSync(planFile, "utf8");
   const filename = path.basename(planFile);
   assertReviewSections(content, filename);
-  console.log(`✓ 하네스 게이트 통과 (plan-file 모드): ${filename}`);
+  console.log(
+    `✓ verdict 섹션 검증 통과 (--plan-file: verification/ADR/body placeholder는 검사 안 함): ${filename}`,
+  );
   process.exit(0);
 }
 

--- a/scripts/harness-gate.mjs
+++ b/scripts/harness-gate.mjs
@@ -5,7 +5,16 @@ import path from "node:path";
 import process from "node:process";
 import { ADR_TRIGGER_PARTS } from "./_shared-config.mjs";
 
-const taskPattern = process.argv[2] ?? process.env.TASK_ID ?? "";
+const VERDICT_BY_SECTION = {
+  "Codex 계획 검증": /\*\*결론\*\*:\s*(PASS|PASS_WITH_DECISION_LOG|CHANGE_REQUEST|BLOCK)\b/,
+  "Codex 1차 검증": /\*\*결론\*\*:\s*(PASS|FIX_APPLIED|CHANGE_REQUEST|BLOCK)\b/,
+  "Claude 2차 검증": /\*\*최종 판단\*\*:\s*(PASS|FAIL)\b/,
+};
+
+const PLACEHOLDER_LINE = /^\s*(?:[-—–]|TBD|ＴＢＤ|미요청|미작성|N\/A|none)\s*$/i;
+const PLACEHOLDER_INLINE = /^\s*[-*]?\s*\*\*[^*]+\*\*:\s*["'`]?(?:TBD|ＴＢＤ|미요청|미작성|N\/A|none|-|—|–)["'`]?\s*$/i;
+const VERDICT_LABEL = /^\s*[-*]?\s*\*\*(?:결론|최종 판단)\*\*:\s*/;
+const MIN_BODY_CHARS = 30;
 
 function fail(message) {
   console.error(message);
@@ -62,20 +71,72 @@ function findActivePlan(repoRoot, pattern) {
   return path.join(activeDir, matches[0]);
 }
 
-function assertReviewSections(content, filename) {
-  const required = [
-    ["Codex 계획 검증", /결론\*\*: 미요청|상태\*\*: 미요청/],
-    ["Codex 1차 검증", /결론\*\*: 미요청|상태\*\*: 미요청/],
-    ["Claude 2차 검증", /검토 내용\*\*:\s*$|실행한 검증\*\*:\s*$|최종 판단\*\*:\s*$/m],
-  ];
+function assertSectionRich(body, label) {
+  const lines = body.split(/\r?\n/);
+  let usefulChars = 0;
 
-  for (const [heading, pendingPattern] of required) {
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (PLACEHOLDER_LINE.test(line)) continue;
+
+    if (VERDICT_LABEL.test(line)) {
+      const after = line.replace(VERDICT_LABEL, "").replace(/^\w+\s*/, "").trim();
+      usefulChars += after.length;
+      continue;
+    }
+
+    if (PLACEHOLDER_INLINE.test(line)) {
+      fail(`${label}: placeholder 라인 발견 — "${line}". 실제 검증 내용을 작성하세요.`);
+    }
+
+    usefulChars += line.length;
+  }
+
+  if (usefulChars < MIN_BODY_CHARS) {
+    fail(
+      `${label}: 비-placeholder 본문이 ${usefulChars}자로 부족합니다 (최소 ${MIN_BODY_CHARS}자). ` +
+        `verdict + 풀이/실행한 검증/핵심 지적을 채우세요.`,
+    );
+  }
+}
+
+function assertReviewSections(content, filename) {
+  for (const [heading, verdictRe] of Object.entries(VERDICT_BY_SECTION)) {
     const body = sectionBody(content, heading);
     if (!body) fail(`${filename}: ## ${heading} 섹션이 없습니다.`);
-    if (pendingPattern.test(body)) fail(`${filename}: ## ${heading} 섹션이 미작성 상태입니다.`);
-    if (/\*\*결론\*\*:\s*BLOCK/.test(body)) {
-      fail(`${filename}: ## ${heading} 섹션에 BLOCK이 기록되어 있습니다. exec-plan을 재작성하고 Codex 재요청 후 진행하세요.`);
+
+    const verdictMatch = body.match(verdictRe);
+    if (!verdictMatch) {
+      const allowed = verdictRe.source
+        .replace(/^.*?\(/, "")
+        .replace(/\)\\b$/, "")
+        .replace(/\|/g, " / ");
+      fail(
+        `${filename}: ## ${heading} verdict token이 없습니다. 허용: ${allowed}. ` +
+          `placeholder(미요청/미작성)은 차단됩니다 — Codex/Claude 검증을 실제로 수행하고 결론을 기록하세요.`,
+      );
     }
+
+    if (verdictMatch[1] === "BLOCK") {
+      fail(
+        `${filename}: ## ${heading} 섹션에 BLOCK이 기록되어 있습니다. ` +
+          `exec-plan 재작성 + Codex 재요청 후 진행하세요.`,
+      );
+    }
+
+    if (verdictMatch[1] === "PASS_WITH_DECISION_LOG") {
+      const log = sectionBody(content, "의사결정 로그");
+      if (!log || log.length < MIN_BODY_CHARS) {
+        fail(
+          `${filename}: ## ${heading} verdict가 PASS_WITH_DECISION_LOG인데 ` +
+            `## 의사결정 로그 섹션이 비어있거나 ${MIN_BODY_CHARS}자 미만입니다. ` +
+            `expression-only 지적 N건을 각 1줄로 기록하세요.`,
+        );
+      }
+    }
+
+    assertSectionRich(body, `${filename}: ## ${heading}`);
   }
 }
 
@@ -93,10 +154,20 @@ function assertAdrDecision(content, filename) {
 
   if (adrRiskFiles.length === 0 || adrChanged) return;
 
-  const body = sectionBody(content, "ADR 판단");
-  if (!body) fail(`${filename}: ADR 후보 변경이 있지만 ## ADR 판단 섹션이 없습니다.`);
-  if (/필요 여부\*\*: 미검토/.test(body)) {
-    fail(`${filename}: ADR 후보 변경이 있지만 ADR 판단이 미검토 상태입니다.\nADR 후보 파일: ${adrRiskFiles.slice(0, 8).join(", ")}${adrRiskFiles.length > 8 ? " ..." : ""}`);
+  const adrLine = /\*\*ADR needed\*\*:\s*(no|yes)\b/i.exec(content);
+  const legacyBody = sectionBody(content, "ADR 판단");
+
+  if (!adrLine && !legacyBody) {
+    fail(
+      `${filename}: ADR 후보 변경이 있지만 frontmatter \`**ADR needed**: no | yes\` 또는 ## ADR 판단 섹션이 없습니다.`,
+    );
+  }
+
+  if (legacyBody && /필요 여부\*\*: 미검토/.test(legacyBody)) {
+    fail(
+      `${filename}: ADR 후보 변경이 있지만 ADR 판단이 미검토 상태입니다.\n` +
+        `ADR 후보 파일: ${adrRiskFiles.slice(0, 8).join(", ")}${adrRiskFiles.length > 8 ? " ..." : ""}`,
+    );
   }
 }
 
@@ -112,23 +183,52 @@ function assertVerification(taskId) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 
-if (!taskPattern) {
-  fail("Usage: node scripts/harness-gate.mjs <task-id-or-active-plan-pattern>");
+function parseArgs(argv) {
+  const args = { planFile: null, taskPattern: "" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--plan-file") {
+      args.planFile = argv[i + 1] ?? "";
+      i += 1;
+    } else if (arg.startsWith("--plan-file=")) {
+      args.planFile = arg.slice("--plan-file=".length);
+    } else if (!arg.startsWith("-") && !args.taskPattern) {
+      args.taskPattern = arg;
+    }
+  }
+  return args;
 }
 
-if (/[^a-zA-Z0-9_.-]/.test(taskPattern)) {
+const { planFile, taskPattern } = parseArgs(process.argv.slice(2));
+
+if (planFile) {
+  if (!existsSync(planFile)) fail(`--plan-file 경로가 없습니다: ${planFile}`);
+  const content = readFileSync(planFile, "utf8");
+  const filename = path.basename(planFile);
+  assertReviewSections(content, filename);
+  console.log(`✓ 하네스 게이트 통과 (plan-file 모드): ${filename}`);
+  process.exit(0);
+}
+
+if (!taskPattern) {
+  fail("Usage: node scripts/harness-gate.mjs <task-id-or-active-plan-pattern> | --plan-file <path>");
+}
+
+if (/[^a-zA-Z0-9_.-]/.test(taskPattern || process.env.TASK_ID || "")) {
   fail(`task id는 영숫자·_·.·-만 허용합니다. 입력: ${taskPattern}`);
 }
+
+const effectiveTask = taskPattern || process.env.TASK_ID || "";
 
 const repoRoot = git(["rev-parse", "--show-toplevel"]);
 process.chdir(repoRoot);
 
-const planPath = findActivePlan(repoRoot, taskPattern);
+const planPath = findActivePlan(repoRoot, effectiveTask);
 const filename = path.basename(planPath);
 const content = readFileSync(planPath, "utf8");
 
 assertReviewSections(content, filename);
 assertAdrDecision(content, filename);
-assertVerification(taskPattern);
+assertVerification(effectiveTask);
 
 console.log(`✓ 하네스 게이트 통과: ${filename}`);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# tests/
+
+dnchurch는 단위 테스트 / e2e 테스트 환경을 두지 않는다 (`CLAUDE.md` "테스트 환경 없음" 정책 명시).
+
+본 디렉토리는 **harness 자체 검증용 fixture**만 보관한다. 테스트 러너(`vitest`, `jest`, `playwright` 등) 없음 — 본 디렉토리에 단위 테스트를 추가하지 말 것.
+
+## harness/
+
+`scripts/harness-gate.mjs`의 verdict matrix · placeholder denylist · `--plan-file` dry-run 동작 회귀 검증용 markdown fixture. ADR 0010 도입과 함께 신설.
+
+| fixture | 의도 | 실행 명령 | 기대 exit |
+|---|---|---|---|
+| `harness/valid.md` | 6필수+3검증 섹션 모두 정상 PASS 경로 | `node scripts/harness-gate.mjs --plan-file tests/harness/valid.md` | 0 |
+| `harness/placeholder.md` | verdict 미요청·TBD 다수 — placeholder denylist 차단 | 동일, path 교체 | 1 |
+| `harness/revised-after-review.md` | Codex `PASS_WITH_DECISION_LOG` + `## 의사결정 로그` 기록 → WORK 진입 후 통과 경로 | 동일, path 교체 | 0 |
+
+### 변경 시 절차
+
+`scripts/harness-gate.mjs`의 verdict matrix / placeholder denylist / 본문 임계값을 바꿀 때:
+
+1. fixture 3개를 의도된 exit 코드(0/1/0)에 맞게 동기화.
+2. 위 dry-run 명령 3개로 회귀 확인.
+3. 변경 사유는 ADR 0010 또는 후속 ADR에 기록.
+
+### 관련 ADR
+
+- `docs/decisions/0010-harness-codex-review-cap.md` — 본 fixture 도입 결정 + Rollback Triggers 측정 기준

--- a/tests/harness/placeholder.md
+++ b/tests/harness/placeholder.md
@@ -1,0 +1,45 @@
+# 미작성 plan (fixture — gate FAIL 예상)
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/some-feature
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+TBD.
+
+## 검증된 Assumptions
+
+- TBD
+
+## Success Criteria
+
+- TBD
+
+## 영향받는 파일
+
+- `src/...`
+
+## 단계별 체크리스트
+
+- [ ] 1. TBD
+
+## Verification
+
+- TBD
+
+---
+
+## Codex 계획 검증
+
+- **결론**: 미요청
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+
+## Claude 2차 검증
+
+- **최종 판단**: 미작성

--- a/tests/harness/revised-after-review.md
+++ b/tests/harness/revised-after-review.md
@@ -1,0 +1,54 @@
+# 검색 결과 칩 라벨 GNB 정합 (fixture — gate PASS 예상, PASS_WITH_DECISION_LOG 경로)
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: fix/search-chip-label-gnb
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+검색 결과 페이지의 "전체" 칩 라벨을 GNB의 "통합검색"과 일치시킨다.
+
+## 검증된 Assumptions
+
+- `src/app/(content)/search/page.tsx:42`에 "전체" 하드코딩 — `Grep "전체" src/app/(content)/search/` 1건 확인.
+- GNB nav 항목은 `src/data/navigation.ts:8` "통합검색" — `Grep "통합검색" src/data/navigation.ts` 1건 확인.
+
+## Success Criteria
+
+- 검색 페이지 칩 텍스트가 브라우저에서 "통합검색"으로 표시 (수동 확인)
+- 다른 라벨·라우트 변경 0건 (`git diff` 검토)
+
+## 영향받는 파일
+
+- `src/app/(content)/search/page.tsx`
+
+## 단계별 체크리스트
+
+- [ ] 1. "전체" → "통합검색" 한 줄 변경
+- [ ] 2. yarn build 확인
+
+## Verification
+
+- `node scripts/verify-task.mjs search-chip-label-gnb`
+
+## 의사결정 로그
+
+- 2026-05-14: Codex 계획 검증 `PASS_WITH_DECISION_LOG` — expression 1건 — "라벨 정정"이라는 plan 표현이 실제로는 "다른 라벨 표기와의 정합"이라 더 정확. WORK 진입 후 본 plan에 별도 수정 없이 진행. material risk 없음.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: PASS_WITH_DECISION_LOG
+- **풀이**: 5체크 모두 충족. material risk 없음. expression 1건은 의사결정 로그에 기록 완료 — WORK 진입 가능. confidence: high.
+
+## Codex 1차 검증
+
+- **결론**: PASS
+- **풀이**: 변경 1줄·영향 파일 1건. 인접 정리 0건, 외과적 변경 위반 없음.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task.mjs 통과 (lint·stylelint·build·knip 0 warning). GNB와 검색 칩 라벨이 브라우저에서 동일 문자열로 표시됨을 수동 확인.

--- a/tests/harness/valid.md
+++ b/tests/harness/valid.md
@@ -1,0 +1,49 @@
+# Sermon Featured 토큰 정리 (fixture — gate PASS 예상)
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: refactor/sermon-featured-token-clean
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+SermonFeatured.module.scss의 rgba 하드코딩 3건을 local var로 교체한다.
+
+## 검증된 Assumptions
+
+- `$badge-glass-bg`, `$badge-glass-border`, `$duration-overlay-bg`는 styles/tokens/에 없음 — `rg "badge-glass" styles/tokens/` 0건 확인. 따라서 module-local var로 선언.
+
+## Success Criteria
+
+- SermonFeatured.module.scss에 hex/rgba 리터럴 0건 (`rg "#[0-9a-f]{3,6}|rgba\(" SermonFeatured.module.scss` 0건)
+- yarn build 통과
+
+## 영향받는 파일
+
+- `src/app/(content)/sermons/_component/SermonFeatured/SermonFeatured.module.scss`
+
+## 단계별 체크리스트
+
+- [ ] 1. local var 3종 선언
+- [ ] 2. rgba 리터럴 → local var 치환
+
+## Verification
+
+- `node scripts/verify-task.mjs sermon-featured-token-clean`
+
+---
+
+## Codex 계획 검증
+
+- **결론**: PASS
+- **풀이**: 5체크 모두 충족. token 미존재 시 module-local var는 styles/SKILL.md 명시 패턴. 영향 파일 1건·LOC 8 — material risk 없음. confidence: high.
+
+## Codex 1차 검증
+
+- **결론**: PASS
+- **풀이**: rgba 리터럴 0건 확인. 변경 외과적, 인접 정리 0건.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task.mjs 통과 (lint 0 warning + stylelint 0 + build success + knip 0). visual regression 수동 확인 완료.


### PR DESCRIPTION
## 📋 개요 (Summary)

phase 1-1(sermons-featured)에서 단일 컴포넌트 작업이 5분 → 1시간으로 폭주한 원인(Codex 5라운드 / 14건 CR 중 11건이 expression-only / `is_featured` audit 오류 / `<Image>` wrapper 누락 build 실패 / hook 12회 발화)을 하네스 운영 cap·plan 압축·EXPLORE 직접 검증·debounce·verdict matrix로 보완.

---

## 🔗 개발 컨텍스트

- **Task ID**: `harness-codex-review-cap`
- **Exec Plan**: `docs/exec-plans/active/2026-05-14-harness-codex-review-cap.md` (메타 작업 핸드오프 문서. E1~E7 결정 inline)
- **관련 ADR**: `docs/decisions/0010-harness-codex-review-cap.md` (신규, Accepted) — 0001(Codex 위임 전략)·0008(코드 품질 강제) 보완
- **관련 tech debt**: 해당 없음 (본 PR이 운영 부채 해소 자체)
- **작업 범위**: SKILL.md § EXPLORE + § CODEX_PLAN_REVIEW / `_template.md` / `harness-gate.mjs` / `check-codex-after-plan.mjs` / fixture 3종 + `tests/README.md` / ADR 0010
- **제외한 범위**: `post-implementation-review.mjs`(기존 fingerprint debounce 유지 — 이중 변경 risk 회피), `complete-task.mjs` KPI append 자동화(후속 PR), Phase 1-1 plan 형식 소급 변환(불필요)

---

## 💡 리팩토링 배경 (Motivation)

**개선하려는 문제:**

- [x] 유지보수 난이도 증가 (5체크가 strict 적용되어 표현 모순도 CR로 분류 → 라운드 폭주)
- [x] 기술 부채 해소 (audit/doc만 보고 코드 미검증, hook 무차별 발화, template 17 섹션 비대)
- [x] 기타: 잔여 phase ≥ 20에서 누적 손실 20–30시간 risk — 사용자 "심각한 문제" 인식

phase 1-1 실측 사례 5건이 본 PR로 100% 차단됨:

1. `is_featured` 컬럼 부재 — F2 EXPLORE 직접 검증 표(`mcp__claude_ai_Supabase__list_tables`)로 PLAN 이전 단계 발견
2. 필터 base path 4곳 변경 — F1 must-CR #5 (Non-goals 위반)로 명시 차단
3. Codex 2~4차 11건 expression 모순 — F1 `PASS_WITH_DECISION_LOG` 토큰으로 의사결정 로그 1줄 + WORK 진입
4. `<Image>` vs `<CloudinaryImage>` wrapper 누락 — F2 wrapper 컨벤션 행으로 EXPLORE 발견
5. harness-gate `**검토 내용**:` same-line trap — F4 verdict 매트릭스 + placeholder denylist + 최소 30자

---

## 🔧 주요 변경점 (Key Changes)

- **SKILL.md § CODEX_PLAN_REVIEW** — CR을 material implementation risk로 한정. must-CR 8개(DB/타입/레이어/auth/Non-goals/user-visible/verification command/policy) + expression-only 5개(label/duplicate/ordering/wording/typo) inline. 새 verdict 토큰 `PASS_WITH_DECISION_LOG` 도입. 호출 프롬프트 템플릿(material/expression 분류 강제 + confidence). "애매하면 material 승격" 안전 룰. 3차 자동 호출 금지.
- **SKILL.md § EXPLORE** — claim 직접 검증 표(DB 컬럼 → `mcp__claude_ai_Supabase__list_tables`, 타입 → `src/types/database.types.ts`, 라우트 → `Glob src/app/**/page.tsx`, 토큰 → `src/styles/tokens/`, env → `next.config.ts`/`eslint.config.mjs`/`scripts/`, wrapper → `src/components/common/CloudinaryImage.tsx`). surface only 명시. 단순 변경(typo/rename/1줄)은 EXPLORE 1–2분 종료 허용.
- **`docs/exec-plans/_template.md`** — 17 → 6 필수 + 3 verdict 섹션. `**Open questions**:` / `**ADR needed**:` 1줄 mandatory. 가이드 주석으로 압축 (123 → 66줄).
- **`scripts/harness-gate.mjs`** — verdict 매트릭스(섹션별 허용 토큰). placeholder denylist(TBD / 전각 ＴＢＤ / 미요청 / 미작성 / N/A / none / `-` / `–` / `—` standalone + `**Label**: TBD` inline + quoted). 최소 30자 non-placeholder body. `PASS_WITH_DECISION_LOG` verdict 시 `## 의사결정 로그` 30자 이상 강제. `--plan-file <path>` dry-run 모드.
- **`.claude/hooks/check-codex-after-plan.mjs`** — section hash(목표+SC+영향 파일+Verification) 기반 debounce. `CWD_KEY = sha1(process.cwd()).slice(0,8)`로 state file per-cwd 격리. verdict 토큰 존재 시 skip 유지.
- **`tests/harness/*.md`** — fixture 3종 (valid / placeholder / revised-after-review). 신규 디렉토리(`tests/`는 dnchurch에 없음 — harness 검증 전용, `tests/README.md`에 의도 명시).
- **`docs/decisions/0010-harness-codex-review-cap.md`** — Status Accepted. Context(phase 1-1 실측 5건). Decision. Override(LOC ≥ 500 / 다중 ADR_TRIGGER / lib migration / DB·auth·cache·deploy / `.github/workflows` / `supabase/migrations` / 보안 민감 PR / STRICT_REVIEW). Rollback Triggers + 측정 방식(회고 5필드 mandatory). Consequences. Alternatives A–F.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| CR 분류 | material만 CR / expression-only는 PASS_WITH_DECISION_LOG | reviewer incentive를 직접 바꿔야 폭주 차단. 5체크는 그대로 두되 분류만 좁힘 | "Codex 프롬프트만 수정"(B): SKILL.md 기본 정의가 그대로면 효과 없음 |
| Template 압축 | 17 → 6+3 + 1줄 mandatory | plan 비대가 표현 충돌의 원인. 작성 시간 감소 + 일관 강제 | "SKILL만 수정"(C): 효과 절반 |
| EXPLORE 직접 검증 | claim 의존 시만 강제, surface only | 단순 변경에 전수 검사 강제 시 또 다른 비대 발생 | "audit 신뢰"(status quo): `is_featured` 같은 BLOCK 사후 발견 |
| Hook debounce | section hash + per-cwd state | once-only는 정당한 변경 알림 누락. file hash 단위면 무관 변경에도 발화 | "전체 hash"(A): plan 본문 1글자 수정에도 재발화 |
| harness-gate | verdict matrix + placeholder denylist + `--plan-file` | label-only same-line regex가 정상 입력도 fail. dry-run 없으면 fixture 검증 불가 | "기존 regex 확장": trap 누적 |
| commit prefix | `Refactor` | 시스템 운영 정책 변경 + 스크립트 동작 변경 + 워크플로우 자동화 변경 — "기존 동작 개선/재구성"이 정확 | `Chore`(잡일 인상), `Docs`(코드 변경 동반) |
| ADR 0010 위치 | `docs/exec-plans/active/` 메타 핸드오프 + `docs/decisions/0010-...` 본 ADR | active/는 기존 검색 경로 일관. ADR은 영구 결정 분리 | "ADR 부록 흡수": 머지 후 history되어 후속 phase 접근 불편 |

> ⚠️ **주의사항:** Override 조건 list가 광범위 (`.github/workflows/lint.yml` typo 1줄도 hit). Codex 2차 검증 Q3에서 "의도된 trade-off — CI/CD는 머지 후 모든 PR 영향이라 보수적이 맞음"으로 확인. 빈번 시 후속 ADR에서 "단순 typo/comment 제외" 예외 추가 가능.

**변경 전 구조:** 5체크 미충족 = CR 기본 / 17 섹션 template / hook 매 Edit마다 발화 / harness-gate label-only same-line regex / EXPLORE "기존 코드·문서·패턴 확인" 일반론

**변경 후 구조:** material만 CR + expression은 PASS_WITH_DECISION_LOG / 6+3 섹션 + 1줄 mandatory / hook section-hash debounce + per-cwd / harness-gate verdict matrix + placeholder denylist + `--plan-file` dry-run / EXPLORE claim 직접 검증 표 SSOT

---

## 📊 개선 지표 (Improvement Metrics)

| 항목 | Before | After |
| ---- | ------ | ----- |
| Phase 시간(실측 phase 1-1 / 본 ADR 목표) | 120분 | 30–45분 (3 sub-phase 평균, Rollback 측정 대상) |
| Codex 라운드 평균 | 5라운드 | 1–2라운드 |
| Plan 라인 수 (template) | 123 | 66 |
| Hook 발화 횟수 (phase당) | ~12 | 2–3 (section hash debounce) |
| EXPLORE BLOCK 사전 발견율 | 0% | 100% 목표 (`is_featured` 케이스 sample) |
| harness-gate placeholder fail | 미차단 (label-only same-line 우회 가능) | 차단 (fixture 회귀 0/1/0) |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs harness-codex-review-cap` — PASS, RUN_ID=`20260514-154122`, HEAD=`5ec3d1f`, failed=0, warned=Knip |
| `harness-gate` | 본 PR이 harness-gate 자체를 변경 — fixture 3개(`tests/harness/*.md`)로 dry-run 회귀: exit 0/1/0 |
| Codex 계획 검증 | PASS_WITH_DECISION_LOG (메타 작업 — 핸드오프 문서 §3.5 E1~E7 의사결정 7건 inline) |
| Codex 1차 검증 | CHANGE_REQUEST 6건(NUL byte / EXPLORE 경로 / `os.tmpdir()` 격리 / Override 누락 3종 / KPI 측정 방식 / `tests/README.md`) → FIX_APPLIED. Codex 2차 PASS_WITH_NOTES 88% |
| Claude 2차 검증 | 완료 — `verify-task` PASS + fixture 회귀 + hook debounce runtime 확인 + NUL 0건 |
| ADR 판단 | `docs/decisions/0010-harness-codex-review-cap.md` (Accepted) |
| 남은 warning | Knip 25건 (기존 부채, CLAUDE.md 명시) |

---

## 🗂️ 셀프 체크리스트

**리팩토링 완성도**

- [x] 외부 동작 변경 없음 (Phase 1-1 plan은 구 형식 그대로 머지 가능 — 본 PR 이후 phase부터 신 규칙)
- [x] 불필요한 기능 변경 미포함 (`src/` 변경 0건)

**코드 품질**

- [x] verdict / placeholder regex 변수명 명확
- [x] hook 디버그 로그 없음 (debounce 동작 확인은 외부 명령)

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 없음 (개발 워크플로우만 변경, 제품 동작 무변경)
- **운영 / 릴리스 주의사항**: 본 PR 머지 후 다음 작업자가 PLAN 작성 시 새 `_template.md`(6+3 섹션 + Open questions·ADR needed 1줄) 사용. 기존 active plan은 구 형식 그대로 두고 후속 작업 진행 가능
- **롤백 시 영향**: 단순 git revert로 안전 복귀. state file(`/tmp/dnchurch-check-codex-after-plan.<cwd>.state.json`)은 자동 재생성. fixture 디렉토리(`tests/`)는 leftover 가능 — `rm -rf tests/` 수동 정리
- **먼저 볼 화면 / 흐름**: `docs/decisions/0010-harness-codex-review-cap.md` Decision → Override → Rollback Triggers 순. 다음 `tests/harness/*.md` 3 fixture 비교

### 로컬 검증 명령 (Codex Q4 권장)

```bash
node scripts/harness-gate.mjs --plan-file tests/harness/valid.md             # exit 0
node scripts/harness-gate.mjs --plan-file tests/harness/placeholder.md        # exit 1
node scripts/harness-gate.mjs --plan-file tests/harness/revised-after-review.md # exit 0
```

---

## 📝 리뷰어를 위한 메모

- ADR 0008(코드 품질 강제)의 메커니즘 2(detection: 검증 결과 기록 규칙)는 본 PR로 약화되지 않음. harness-gate placeholder denylist + 최소 30자가 오히려 detection 강화
- 메커니즘 1(generation: Codex 1차+Claude 2차)이 cost 곱셈으로 작동한 문제만 한정 보완
- 3 sub-phase(Phase 1-2/1-3/1-4) 누적 후 KPI 측정 — Rollback Triggers 1건 hit 시 본 ADR 재검토
- `complete-task.mjs` KPI append 자동화는 별도 PR. 본 PR 머지 후 1주 내 진행 권장
- Codex 2차 검증에서 "merge 전 필수 수정 없음" 명시 — 변경 자체는 ship 준비됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)
