### PR TITLE
[Feat] 설교 메인 페이지 — 최근/시리즈 캐러셀 2종 + 섹션 spacing

### DIFF
--- a/docs/exec-plans/active/2026-05-14-sermons-main-layout.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-main-layout.md
@@ -1,0 +1,100 @@
+# sermons-main-layout
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons
+- **Open questions**: none
+- **ADR needed**: no — `src/app/(content)/sermons/page.tsx` 1줄 + 신규 SCSS 1개 (ADR_TRIGGER_PARTS 미해당)
+
+## 목표
+
+`/sermons` 메인 페이지 3 섹션(Featured / Recent 캐러셀 / Series 캐러셀) 사이에 vertical spacing + page top/bottom padding 적용. mockup `ListPCBody` PC 40-44px / 모바일 22-24px 섹션 간격 + PC 32px top/48px bottom 패딩 의도 반영. Hero는 `(content)` route group이 자동 적용 — 본 task 신규 X.
+
+## 검증된 Assumptions
+
+- `(content)/layout.tsx`(line 1-30)가 `<Hero />`를 자동 렌더 + `resolveHeroMeta('/sermons')` `hero.config.ts:14` 매핑 (`{title: '설교', subtitle: '주일 말씀과 강해 설교를 만나보세요', eyebrow: 'SERMONS'}`) → mockup `ListPCHero`(WORD/설교) `MListBanner` 의도와 동일. 본 task에서 Hero 컴포넌트 신규 X.
+- `LayoutContainer.tsx` `LayoutContainer.module.scss`(line 1-5): horizontal padding만 (`$container-padding`) + max-width (`$container-max`). vertical padding/section spacing 없음 — 페이지 단에서 책임.
+- `LayoutContainer` props: `{ children, className? }` — `clsx(styles.container, className)` (확인됨). 외부에서 `className` 주입 시 모듈 SCSS 추가 스타일 가능.
+- `$section-gap-40`(40px), `$section-gap-64`(64px), `$section-gap-80`(80px) 토큰 존재(styles SKILL). 모바일 22-24px용 토큰은 별도 없음 — `$spacing-24` 또는 `$content-gap-xl`(32px) 또는 `$section-gap-40` 통일 사용.
+- 현재 `/sermons/page.tsx`(`191a635` HEAD): `<LayoutContainer>` 직속 자식 `<SermonFeatured>` / `<SermonRecentCarousel>` / `<SermonSeriesCarousel>` 3개. 섹션 간 margin 0.
+
+## Non-goals
+
+- Hero 컴포넌트 신규/수정 (기존 자동 적용 그대로)
+- `LayoutContainer` 자체 수정 (page-specific spacing이라 외과적 차단)
+- `(content)/layout.tsx` 변경
+- Phase 2-8 (상세 페이지·전체 시리즈·시리즈 상세 등)
+- 모바일 풀폭 캐러셀 padding 재조정 (`mobileFullBleed` prop은 이미 작동)
+- 새 spacing 토큰 추가 (`$section-gap-24` 등 — 기존 토큰 재사용)
+
+## Success Criteria
+
+1. **신규 SCSS** `src/app/(content)/sermons/page.module.scss` (또는 동등 위치) — `.sections { display: flex; flex-direction: column; gap: $section-gap-40; padding-block: $spacing-24 $spacing-40; }` (또는 동등). 모바일/PC 모두 동일 토큰 사용(40 + 24/40 패딩).
+2. **page.tsx 수정** — `<LayoutContainer className={styles.sections}>` 한 줄 적용. import `styles from './page.module.scss'` 추가.
+3. **vertical layout 결과** — `yarn dev` 수동: Featured ↔ Recent 사이 + Recent ↔ Series 사이 가시적 spacing 발생. 페이지 top(Hero 아래) ↔ 첫 섹션 사이 + 마지막 섹션 ↔ Footer 사이 spacing 발생.
+4. **Hero 그대로** — `/sermons` 진입 시 기존 Hero(`설교` / `SERMONS` / `주일 말씀과 강해 설교를 만나보세요`) 정상 표시, 본 task로 영향 0.
+5. **모바일/PC 호환** — `<` $breakpoint-tablet (모바일) 진입에서도 섹션 간격 + 패딩 동작. 캐러셀 `mobileFullBleed` 좌우 -16px와 충돌 X (page padding은 vertical만, horizontal은 LayoutContainer 그대로).
+6. **검증 통과** — `node scripts/verify-task.mjs sermons-main-layout` (lint + lint:styles + build + knip) 통과.
+
+## 영향받는 파일
+
+- 신규: `src/app/(content)/sermons/page.module.scss`
+- 수정: `src/app/(content)/sermons/page.tsx` — `styles` import 1줄 + `className={styles.sections}` 1 attr
+
+## 단계별 체크리스트
+
+- [ ] 1. `page.module.scss` 신규 — `.sections { display:flex; flex-direction:column; gap: $section-gap-40; padding-block: $spacing-24 $spacing-40 }` 1 클래스만
+- [ ] 2. `page.tsx` 수정 — `import styles from './page.module.scss'` + `<LayoutContainer className={styles.sections}>` 적용
+- [ ] 3. `yarn dev` 수동 — `/sermons` Hero + 섹션 spacing 가시적 + 모바일 풀폭 캐러셀 정상
+- [ ] 4. `node scripts/verify-task.mjs sermons-main-layout` 통과
+
+## Verification
+
+```bash
+yarn lint
+yarn lint:styles
+yarn build
+yarn knip
+
+# 수동 (yarn dev)
+# → http://localhost:3000/sermons   Hero + Featured + Recent + Series, 섹션 간 40px gap, 페이지 top 24px / bottom 40px padding
+# → 모바일: 동일 토큰 적용 — 캐러셀 mobileFullBleed 좌우 -16px와 horizontal 충돌 0
+
+node scripts/verify-task.mjs sermons-main-layout
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS_WITH_DECISION_LOG** (2026-05-14, fresh thread `a0cff5d12a855dcfd`)
+- **5체크**: 1·2·3·4 OK, 5 새 추상화 사실상 없음(`SCSS class 1개 + className 1개`).
+
+**Codex verdict** (verbatim 발췌):
+> a) PASS_WITH_DECISION_LOG: fixed 40px가 mobile에서 무거울 수 있어 Phase 1 허용 결정이 필요합니다.
+> b) PASS_WITH_DECISION_LOG: 기존 사용례 불명확하므로 `LayoutContainer className` 사용 결정 1줄을 남기면 충분합니다.
+> c) PASS: 제공된 관찰 기준상 `page.module.scss` 인접 배치는 일관됩니다.
+
+**평이 풀이**: 5체크 모두 PASS — 새 추상화 0건, 외과적 변경, 검증 가능 SC. 두 expression-only 사항(모바일 40px gap 허용 결정 / `LayoutContainer className` 사용 결정)은 의사결정 로그 분리 + WORK 진입 가능.
+
+## 의사결정 로그
+
+- **2026-05-14 D1 — 모바일/PC gap 단일 토큰 (`$section-gap-40`)**: mockup PC 40-44 / 모바일 22-24로 명시 차이 존재. 본 task는 단일 토큰 채택 — (a) 신규 spacing 토큰 도입 회피(Non-goals), (b) `$section-gap-40`가 _spacing.scss 기준 `var(--spacing-40)` 반응형이라 globals.scss에서 모바일 값이 자동 축소될 가능성. (c) 만약 모바일에서도 고정 40px이면 시각적 부담은 있으나 Phase 1 MVP 허용 범위 — Phase 1 회고 후 사용자 피드백 누적 시 별도 토큰 도입 가능. 운영 트레이드오프 명시.
+- **2026-05-14 D2 — `<LayoutContainer className>` 외부 주입 패턴 채택**: `LayoutContainer.tsx:10`이 `clsx(styles.container, className)`로 외부 className을 기본 spec에 합치도록 이미 설계됨. 기존 호출처 대다수가 className 없이 호출하지만, 본 task가 page-specific 섹션 spacing을 LayoutContainer 자체 SCSS에 합치는 대신 page.module.scss에 분리해 LayoutContainer를 page 무관 컴포넌트로 유지. 새 호출 패턴이 아닌 기존 props 활용. 향후 다른 페이지에서도 동일 패턴 가능.
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+
+## Claude 2차 검증
+
+- **최종 판단**: 미작성
+
+---
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 1-4 (line 222-243)
+- `docs/references/sermons/ChurchSermonAll.jsx` — `ListPCHero`(line 795-803), `ListPCBody`(line 968-986), `MListBanner`(line 2207-2213), `MListBody`(line 2352-2370)
+- `src/components/layout/Hero/hero.config.ts:14` — 기존 `/sermons` HeroMeta 자동 적용
+- `src/components/layout/container/LayoutContainer.tsx` + `.module.scss` — horizontal padding/max-width만, vertical은 page 책임

--- a/docs/exec-plans/active/2026-05-14-sermons-recent-carousel.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-recent-carousel.md
@@ -1,0 +1,136 @@
+# sermons-recent-carousel
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons (Phase 1-2~1-4 통합)
+- **Open questions**: none
+- **ADR needed**: no — 변경 파일 모두 `src/app/(content)/sermons/_component/` + `src/app/(content)/sermons/page.tsx` 1줄 (`ADR_TRIGGER_PARTS` 미해당)
+
+## 목표
+
+Sermon 섹션 Phase 1-2 — `/sermons` 메인 페이지 Featured 카드 아래에 "최근 설교" 가로 캐러셀(8건) 추가. mockup `ListPCRecent`(PC 카드 240px) + `MListRecent`(모바일 210px / full-bleed) 디자인 그대로 — `src/components/ui/Carousel` 재사용, 신규 컴포넌트 2개(`SermonRecentCarousel` + `SermonCarouselCard`).
+
+## 검증된 Assumptions
+
+- `src/components/ui/Carousel/Carousel.tsx` 3 export(`useCarousel`/`<CarouselArrows>`/`<Carousel>`) + drag/swipe/clickGuard/scroll edge detection + `mobileFullBleed` prop 모두 Phase 0에서 구현됨 — Read 결과 line 1-143 확인.
+- `getSermons({ pageSize: 8 })` 호출 시 `sermon-service.ts:68` `.order('sermon_date', { ascending: false })`에 의해 최신 8건 반환 — Phase 1-1 Featured와 동일 패턴.
+- `SermonListItem` light fieldset(`types/sermon.ts:17-28`)은 `duration` + `sermon_series` 누락 — 캐러셀 카드는 mockup line 754(`duration` overlay) + line 765(`series.title` or `service_type`) 둘 다 필요. 따라서 `getRecentSermons` 대신 `getSermons` 사용해 `SermonWithRelations[]` 받음 (Phase 1-1 의사결정 로그와 동일 이유).
+- mockup `SermonCarouselCard`(line 728-789) vs `_component/home/SermonCard.tsx`(line 1-71) layout 다름 — home은 horizontal meta_bar, mockup은 vertical(썸네일 + label + title 2줄 + scripture + 메타 border-top). 재사용 불가, 신규 컴포넌트 필요.
+- `SermonCarouselCard`는 Carousel의 onClickCapture clickGuard와 부모 `<Link>`/`onClick`이 충돌할 수 있어 mockup 패턴(`<Link>` 래핑)을 따르되 useCarousel.clickGuard가 drag 시 stopPropagation으로 차단 — Carousel.tsx:72-78 확인.
+- 데이터 패치는 server component(`page.tsx`)에서, 캐러셀 렌더는 client component(`'use client'` — useCarousel hook). props로 전달.
+
+## Non-goals
+
+- 시리즈 캐러셀 (Phase 1-3 — `SermonRecentCarousel`과 동일 패턴이나 데이터·카드 구조 다름, 별도 컴포넌트)
+- Hero 배너 (Phase 1-4 통합 시 — 본 task는 Featured + Recent 캐러셀 2개만)
+- 캐러셀 자동 재생/페이드 전환/swiper.js — drag + arrow 스크롤만, Carousel.tsx 기존 동작 유지
+- `getRecentSermons` 시그니처 변경 — home `RecentSermons.tsx`도 함께 영향 받으므로 본 task 범위 외 (Phase 1-1과 동일 회피)
+- `Carousel.tsx` 자체 수정 — 본 task는 consumer만 추가
+- `app/(content)/sermons/all` 변경 — archive는 별도
+
+## Success Criteria
+
+1. **신규 컴포넌트** `src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.tsx` + `.module.scss`. props: `{ sermons: SermonWithRelations[] }`. `sermons.length === 0`이면 영역 미렌더(`return null`). 'use client'.
+2. **신규 컴포넌트** `src/app/(content)/sermons/_component/SermonRecentCarousel/SermonCarouselCard.tsx` (같은 디렉토리). props: `{ sermon: SermonWithRelations }`. `<Link href={\`/sermons/${id}\`}>` 래핑, vertical layout(썸네일 16:9 + label + title + scripture + 메타 border-top). 카드 width PC 240px / 모바일 210px — `respond-up($breakpoint-tablet)` 분기.
+3. **page.tsx 수정** `src/app/(content)/sermons/page.tsx` — `getSermons({ pageSize: 8 })` 호출 추가, 결과를 `<SermonRecentCarousel sermons={...} />`에 prop으로 전달. `<SermonFeatured>` 아래에 배치. redirect 분기(C-1 회귀 보존)는 그대로 유지.
+4. **썸네일 helper** — 카드 썸네일은 `getSermonThumbnail(sermon)` + `cloudinaryFetchUrl()` + `<CloudinaryImage>` 패턴 (Phase 1-1 SermonFeatured와 동일). null이면 dark gradient placeholder.
+5. **시리즈 라벨/service_type 분기** — `sermon.sermon_series?.title`이 truthy면 `$accent`(gold) + letter-spacing wide / falsy면 `$txt-tertiary` + letter-spacing normal. mockup line 759-764 패턴.
+6. **카드 height 통일** — title `minHeight: 2.8em` + line-clamp 2로 단독·시리즈 설교 카드 동일 높이 (mockup line 770).
+7. **검증 통과** — `node scripts/verify-task.mjs sermons-recent-carousel` (lint + lint:styles + build + knip) 통과. `yarn dev` → `/sermons` 200 + Featured 카드 + Recent 캐러셀 8개 렌더. 캐러셀 좌우 화살표 활성/비활성 토글(스크롤 edge), drag 후 카드 클릭 차단(clickGuard), 모바일 left -16px full-bleed.
+
+## 영향받는 파일
+
+- 신규: `src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.tsx` (client)
+- 신규: `src/app/(content)/sermons/_component/SermonRecentCarousel/SermonCarouselCard.tsx` (client, 부모가 client라 자동)
+- 신규: `src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.module.scss` (캐러셀 1개에 통합 — feedback_consolidate_module_scss)
+- 수정: `src/app/(content)/sermons/page.tsx` — `getSermons({pageSize: 8})` 호출 + `<SermonRecentCarousel>` 배치 (+5줄 이내)
+
+## 단계별 체크리스트
+
+- [ ] 1. `SermonCarouselCard.tsx` 신규 — props `{ sermon }`, `<Link>` 래핑, 썸네일 (`CloudinaryImage` + null fallback gradient + play overlay + duration), 시리즈 라벨/service_type 분기, title 2줄 line-clamp, scripture, 메타 border-top (preacher · 날짜)
+- [ ] 2. `SermonRecentCarousel.tsx` 신규 — `'use client'`, props `{ sermons }`, `useCarousel()` 호출, 섹션 헤더(h2 "최근 설교" + `<CarouselArrows>` + "더 보기 →" `<Link href="/sermons/all">`), `<Carousel ariaLabel mobileFullBleed carousel>` + `sermons.map(s => <SermonCarouselCard key={s.id} sermon={s} />)`
+- [ ] 3. `SermonRecentCarousel.module.scss` 신규 — semantic 토큰만(`$bg-card`/`$border-card`/`$radius-s`/`$accent`/`$primary`/`$txt-*`/`$content-gap-s`). 카드 width는 로컬 변수 `$card-width-pc: 24rem` / `$card-width-mobile: 21rem` (mockup 240/210px 근거 주석).
+- [ ] 4. `page.tsx` 수정 — `getSermons({pageSize: 8})` 호출 + `<SermonRecentCarousel sermons={result.sermons} />` 배치 (Featured 아래)
+- [ ] 5. `yarn dev` 수동 — `/sermons` 200, Featured + 캐러셀 렌더, drag 동작, 화살표 edge detection, 모바일 full-bleed
+- [ ] 6. `node scripts/verify-task.mjs sermons-recent-carousel` 통과
+
+## Verification
+
+```bash
+# 좁은 신뢰 명령 순
+yarn lint          # ESLint
+yarn lint:styles   # stylelint
+yarn build         # next build (Image 도메인 + type check)
+yarn knip          # 미사용 코드
+
+# 수동 (yarn dev)
+# → http://localhost:3000/sermons        Featured + 최근 캐러셀 8개
+# → 드래그/스와이프 → 카드 클릭 안 됨 (clickGuard) / 정지 상태 카드 클릭 → /sermons/[id] 이동 (D3)
+# → 좌측 끝 → 좌 화살표 disabled / 우측 끝 → 우 화살표 disabled
+# → 모바일(< $breakpoint-tablet) → 캐러셀 좌우 -16px (mobileFullBleed)
+# → "더 보기 →" 클릭 → /sermons/all 이동
+
+# 전체
+node scripts/verify-task.mjs sermons-recent-carousel
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS_WITH_DECISION_LOG** (2026-05-14, fresh thread `a53154d6afa737242`)
+- **5체크**: 1·2·3·4 YES, 5 NO(과한 추상화 없음). 핵심 잠재 리스크 3건은 material 아닌 expression — 의사결정 로그로 분리.
+
+**Codex verdict** (verbatim 발췌):
+> a) Data layer: `getSermons({pageSize:8})`는 `sermon-service.ts:68` 최신순 8건을 반환하므로 Phase 1-1의 `pageSize:1` 패턴과 일관됨. 다만 `count:exact` + `list(1day)` 대신 `recent(1hour)` 미사용은 "최근" UI에서 갱신 지연 60분→24시간 결과를 만들 수 있어 decision log 필요.
+> c) Server/client: `SermonRecentCarousel.tsx`가 `use client`면 `SermonCarouselCard`도 client 번들에 포함되어 Link 사용은 OK. `CloudinaryImage`가 server-only API를 호출하지 않는다는 근거가 계획에 없으므로, 예: `window`/server util 의존 여부 확인 SC가 필요.
+> d) clickGuard vs Link: `Carousel.tsx:72-78`의 `stopPropagation+preventDefault`는 drag end 뒤 Link navigation을 막는 의도와 맞음. mockup은 `onClick`이고 실제는 `/sermons/` Link라서, drag 후 클릭 1회 suppress / 일반 클릭 nav 성공을 수동 검증에 명시해야 함.
+
+**평이 풀이**: data layer는 Phase 1-1과 일관해 material 아님 — 단 캐시 신선도(24h vs 1h)는 미래 운영 고려사항. CloudinaryImage는 phase 1-1에서 client 컴포넌트로 이미 동작 확인됨(client 전용). clickGuard는 의도대로 작동하나 일반 클릭 nav도 수동 검증에 추가 권장.
+
+## 의사결정 로그
+
+- **2026-05-14 D1 — 데이터 캐시 신선도**: `getSermons({pageSize:8})` 채택으로 `sermon-cache.ts:9-12 list()`(revalidate 1day) 사용. `recent()`(1hour) 미사용은 Phase 1-1 Featured와 일관성 우선 + `SermonListItem` light fieldset이 `duration`/`sermon_series` 누락 회피 위함. 트레이드오프: "최근 설교" UI가 1시간이 아닌 24시간 단위로 revalidate — 새 설교 등록 후 main `/sermons` 갱신까지 최대 24h. 운영 시 새 설교 등록 액션에서 `sermon-list` tag revalidate 호출되면 즉시 반영(`sermon-cache.ts:10` tags `[ROOT, 'sermon-list']` 확인됨), 따라서 운영 영향 미미. 별도 SC 변경 X — 향후 admin publish action에서 revalidate 누락 발견 시 별도 task.
+- **2026-05-14 D2 — CloudinaryImage client 호환**: Codex c) 지적 — SC에 `CloudinaryImage`가 server-only API 미의존 명시 권장. 본 plan: Phase 1-1 `SermonFeatured.tsx`(`'use client'`)에서 이미 동일 컴포넌트를 client 환경에서 사용·검증 완료 (sermons-featured exec-plan §Claude 2차 검증 발견 항목 6). `CloudinaryImage`(`src/components/common/CloudinaryImage.tsx`)는 `next/image` wrapper로 server util 의존 0 — 별도 SC 추가 X.
+- **2026-05-14 D3 — clickGuard 일반 클릭 nav 검증**: Codex d) 지적 — SC#7 수동 검증에 "drag 후 카드 클릭 차단" 외 "일반 클릭 시 `/sermons/[id]` 정상 nav" 추가. 본 plan §Verification 수동 항목에 "정지 상태 카드 클릭 → 상세 페이지 이동" 1줄 추가 (별도 SC 갱신은 §Verification 주석으로 갈음).
+- **2026-05-14 D4 — Featured 중복 회피**: Phase 1-1 `getFeaturedSermon`은 최신 1건, 본 task `getSermons({pageSize:8})`도 최신 8건 → 첫 카드가 Featured와 동일하여 UX 중복. 해결: `pageSize: RECENT_CAROUSEL_COUNT + 1`(=9)로 1건 더 받아 `featured?.id`로 filter 후 `slice(0, 8)`로 최대 8건 보장. `page.tsx`에 `RECENT_CAROUSEL_COUNT` 상수 1개 + filter/slice 3줄. Featured 없거나 캐러셀 9건 미만일 때도 동작(`.filter`가 무조건 통과/`.slice`는 안전).
+- **2026-05-14 D5 — PC drag ghost 차단**: 사용자 수동 검증 발견 — PC `<Link>` 카드 드래그 시 브라우저 native HTML5 anchor drag가 ghost image로 작동해 캐러셀 스크롤이 버벅임. 해결 2종 적용: (a) `<Link draggable={false}>` prop으로 anchor 자체 native drag 차단, (b) `SermonRecentCarousel.module.scss .card { user-select: none; -webkit-user-drag: none; }` + `.thumb { -webkit-user-drag: none; pointer-events: none; }` — 카드 내부 텍스트 selection + 이미지 ghost 모두 차단. Carousel.tsx 자체는 미수정(Non-goals 유지) — consumer 단에서 해소.
+
+## Codex 1차 검증
+
+- **결론**: **PASS** (2026-05-14, fresh thread `aebe800f1dbce5518` → resume `aa657e5dd98186de9`)
+- **요청 시점**: 구현 4 파일 staged 직후 (page.tsx M + SermonRecentCarousel/* 3건 신규 A)
+- **1차 BLOCK 원인**: `git diff` (unstaged 제외)로 page.tsx만 노출 → 신규 파일 3개 미검토. resume에서 `git diff --cached`로 재요청해 해소.
+
+**Codex verdict** (verbatim 발췌):
+> `service_type` 컬럼: `database.types.ts:313` — Row 타입에서 `service_type: Database["public"]["Enums"]["service_type_enum"]` (nullable 없음, NOT NULL). `SermonWithRelations`의 Pick에 `service_type` 포함(`src/types/sermon.ts:27`). 따라서 `labelText`는 항상 string. **null 위험 없음.**
+> P1: useCarousel carousel 전달 OK. service_type NOT NULL 확인 → null 위험 없음. clsx className 룰 충족. OK.
+> P2: 'use client' 없이 client 부모 import로 자동 포함. Link + CloudinaryImage 작동. OK.
+> P4: rgba() 리터럴 3개는 local var + mockup 주석 패턴으로 정당화. 나머지 전부 semantic 토큰. min-height 2.8em 의도적 OK. border-subtle 적합. OK.
+> P5-D3: capture phase preventDefault + stopPropagation이 Link click + Next.js nav 모두 차단. drag 중 false navigation 없음. OK.
+
+**평이 풀이**: 4 우선순위(버그/타입, 레이어 경계, SCSS 토큰, clickGuard 동작) 모두 PASS. `sermons.service_type`은 enum NOT NULL이라 `labelText`는 항상 string — null fallback 불필요. capture phase `preventDefault`가 `<Link>` Next.js client nav를 정상 차단해 drag 후 false navigation 0건 보장. SCSS는 semantic 토큰 + 정당화된 local var 4개 + 의도적 em 1건만으로 구성 — Phase 1-1 SermonFeatured와 동일 패턴.
+
+**수정 파일**: 0건 (Codex 직접 수정 없음, Claude 추가 반영 없음).
+
+## Claude 2차 검증
+
+- **검토 내용**: 4 파일 staged diff(`git diff --cached`) 교차 확인 + Codex 1차 PASS verbatim 검토.
+  - `SermonCarouselCard.tsx`(53줄): Phase 1-1 `SermonFeatured.tsx` 패턴과 import·helpers 일치 (`cloudinaryFetchUrl`, `getSermonThumbnail`, `formatPreacherLabel`, `formatSermonDuration`, `formattedDate`). `<Link>` 래핑, `<CloudinaryImage fill sizes>`, play SVG + duration overlay, label 분기(`hasSeries` boolean으로 `styles.label_series`/`styles.label_type`), title `<h3>`(Featured는 `<h2>`라 heading 위계 일치), `meta_bar` border-top.
+  - `SermonRecentCarousel.tsx`(35줄): `'use client'`, `useCarousel()` unconditional 호출 후 `sermons.length === 0` 분기로 rules-of-hooks 충족. 헤더 = h2 + `<CarouselArrows>` + `<Link href="/sermons/all">`. `<Carousel ariaLabel mobileFullBleed carousel>` 그대로 wrap.
+  - `SermonRecentCarousel.module.scss`(~150줄): semantic 토큰 매핑 — `$bg-card`/`$border-card`/`$radius-s`/`$accent`/`$primary`/`$txt-primary`/`$txt-tertiary`/`$txt-inverse`/`$primary-hover`/`$border-subtle`/`$overlay-image`/`$spacing-*`/`$font-size-*`/`$font-weight-*`/`$letter-spacing-*`/`$line-height-snug`. Local 변수 4개(`$card-width-mobile|pc`, `$badge-glass-bg|border`, `$duration-overlay-bg`) 모두 파일 상단 + mockup 인용 주석. `min-height: 2.8em`은 카드 높이 통일용 의도적 em(mockup line 770).
+  - `page.tsx`(+10줄): `getSermons` + `SermonRecentCarousel` import, `RECENT_CAROUSEL_COUNT = 8` 상수, `Promise.all([getFeaturedSermon(), getSermons({pageSize: 9})])`, `recent.sermons.filter(s => s.id !== featured?.id).slice(0, 8)` (D4), `<SermonRecentCarousel sermons={recentList} />`. redirect 분기(C-1) 유지, 기존 import 제거 0건.
+- **실행한 검증**: `node scripts/verify-task.mjs sermons-recent-carousel` (run-id `20260514-172747`) → ✓ 필수 검증 통과 (ESLint / stylelint / Build (next) / Knip).
+  - `logs/sermons-recent-carousel/20260514-172747/summary.log`: `✓ 필수 검증 통과 (⚠ 경고: Knip — 기존 부채, 커밋 차단 안 됨)`.
+  - `git status -s`: A 3 + M 1 + ?? 1(exec-plan untracked) — plan §영향받는 파일과 정확히 일치.
+- **남은 항목**: `yarn dev` 수동 검증 (`/sermons` 200, 캐러셀 8개 렌더, drag clickGuard, 화살표 edge detect, 모바일 full-bleed, D3 정지 클릭 → 상세 nav, D4 첫 카드 ≠ Featured). 사용자 수동 확인 대기.
+- **최종 판단**: ✅ **PASS** — verify-task PASS + Codex 1차 PASS + diff 교차 확인 일치. 사용자 yarn dev 수동 검증 후 commit 진행 가능.
+
+---
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 1-2 (line 166-191)
+- `docs/references/sermons/ChurchSermonAll.jsx` — `SermonCarouselCard`(line 728-789), `ListPCRecent`(line 894-928), `MListRecent`(line 2272-2304)
+- `src/components/ui/Carousel/Carousel.tsx` (Phase 0 산출) — `useCarousel`/`<CarouselArrows>`/`<Carousel>` 3 export
+- Phase 1-1 completed: `docs/exec-plans/completed/2026-05-14-sermons-featured.md` — `getSermons({pageSize:1})` 의사결정 로그(동일 이유로 본 plan도 `getSermons({pageSize:8})` 채택)

--- a/docs/exec-plans/active/2026-05-14-sermons-series-carousel.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-series-carousel.md
@@ -1,0 +1,152 @@
+# sermons-series-carousel
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons
+- **Open questions**: none
+- **ADR needed**: no — `src/app/(content)/sermons/_component/` + `page.tsx` 1줄 (ADR_TRIGGER_PARTS 미해당)
+
+## 목표
+
+`/sermons` 메인 페이지 최근 설교 캐러셀 아래에 "진행 중인 시리즈" 가로 캐러셀 추가. mockup `ListPCSeriesPreview`(PC 3분할) + `MListSeriesPreview`(모바일 260px) 디자인. `getAllSeries()` 재사용, 신규 컴포넌트 2개(`SermonSeriesCarousel` + `SeriesCard`).
+
+## 검증된 Assumptions
+
+- `getAllSeries()`(`services/sermon/index.ts:24-27`)는 이미 `is_active=true` + `sort_order` 정렬 + `sermon_count` 포함 `SeriesWithSermonCount[]` 반환 — sermon-service.ts:119-135 직접 확인.
+- `sermon_series` 컬럼은 `cover_image_url`/`description`/`started_at`(NOT NULL)/`ended_at`(nullable)/`is_active`/`slug`/`title`/`sort_order`/`year` — `database.types.ts:258-296` 직접 확인.
+- **mockup 가정 필드 부재 2건** — `series.preacher` 직접 컬럼 없음 (preacher는 sermon 단위 관계), `series.cover_tone` 없음 (mockup line 602 `getCoverGradient` 가정). Phase 1-1 `is_featured` 케이스와 동일 클래스.
+- "진행 중인 시리즈" 정의 — mockup `SERIES_PREVIEW = filter(s => s.is_active)` (`ChurchSermonAll.jsx:155`). `ended_at`은 진행/완료 시각 표시용이지 필터 기준 아님. `getAllSeries()`가 이미 일치.
+- mockup PC 카드 width = `calc((100% - 32px) / 3)`(line 959) — 부모 폭 기준 3분할. 모바일 width = 260px(line 2344 영역). gap PC 16px / 모바일 16px (mockup line 953).
+- `<Carousel>`의 `track { gap: $content-gap-s }`(12px) — mockup 16과 mismatch. Carousel.tsx 자체 수정은 Non-goals → 컴포넌트 단에서 의사결정 로그로 차이 흡수.
+- Phase 1-2 D5 패턴(clickGuard + preventDefault + `<Link draggable={false}>` + `-webkit-user-drag: none`)은 검증 완료 — 동일 적용.
+
+## Non-goals
+
+- 메인 페이지 통합(Hero + 섹션 간 spacing 토큰화) — 다음 작업
+- `Carousel.tsx` 자체 수정 (gap prop 추가 등)
+- 신규 service method 추가 (`getActiveSeries`, `getOngoingSeries` 등)
+- `sermon_series.cover_tone` / `series.preacher` 컬럼 추가 또는 시리즈-설교자 관계 쿼리 — 별도 task
+- `cover_image_url` 정적 자산 업로드/관리 UI
+- `/series` `/series/[slug]` 페이지 변경
+
+## Success Criteria
+
+1. **신규 컴포넌트** `src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.tsx` + `.module.scss`. props: `{ series: SeriesWithSermonCount[] }`. `length === 0`이면 `return null`. 'use client', `useCarousel`.
+2. **신규 컴포넌트** `src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx`. props: `{ series: SeriesWithSermonCount }`. `<Link href={\`/series/${slug}\`} draggable={false}>` 래핑, 16:9 커버 영역 + **ON-GOING 배지만** + 텍스트 영역(title/description 2줄/메타 border-top: started_at ~ "진행 중" · N편). COMPLETED 분기는 미구현 — 본 task의 데이터 자체가 ended_at IS NULL 시리즈만 (D5).
+3. **카드 width** — 모바일 `flex: 0 0 26rem`(=260px), PC(`respond-up($breakpoint-tablet)`) `flex-basis: calc((100% - 2 * #{$content-gap-s}) / 3)` (3분할, Carousel 기본 gap 12px 기준).
+4. **카드 height 통일** — `display:flex; flex-direction:column` + description `flex:1` + `-webkit-line-clamp:2`로 description 길이 차이 흡수, 메타 bar는 카드 하단 고정.
+5. **커버 영역 background** — `cover_image_url`이 truthy면 `<CloudinaryImage fill>` 배경 + 그 위에 `background: $overlay-scrim` 다크 overlay div(배지·텍스트 가독성 확보, scrim 토큰=rgba 흑색 0.4-0.5 영역). null이면 `$overlay-image` dark gradient만. cover_tone 분기는 만들지 않음 (D1). 배지 텍스트 색은 `$txt-inverse`.
+6. **preacher 표시 생략** — mockup line 617-619 `series.preacher` 영역은 본 task에서 미렌더. 컬럼 부재가 회복되거나 시리즈-설교자 관계 쿼리가 추가되는 task에서 보강 (의사결정 로그 D2).
+7. **page.tsx 수정** — `getAllSeries()` 호출(`Promise.all`에 추가), 결과를 `.filter((s) => s.ended_at === null)` 적용 후 `<SermonSeriesCarousel series={ongoing} />`로 전달. 섹션 제목 "진행 중인 시리즈"와 데이터 의미 일치(D5). Featured/Recent 아래 배치.
+8. **검증 통과** — `node scripts/verify-task.mjs sermons-series-carousel` 통과 + `yarn dev` 수동: `/sermons` 200, 시리즈 캐러셀 N건 렌더, drag clickGuard, 화살표 edge detect, PC 정확히 3카드 표시, 모바일 1.3카드 보임, "모든 시리즈 →" → `/series` 이동.
+
+## 영향받는 파일
+
+- 신규: `src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.tsx` (client)
+- 신규: `src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx`
+- 신규: `src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.module.scss`
+- 수정: `src/app/(content)/sermons/page.tsx` — `getAllSeries` import + `Promise.all`에 추가 + `<SermonSeriesCarousel>` 배치 (+4줄)
+
+## 단계별 체크리스트
+
+- [ ] 1. `SeriesCard.tsx` — `<Link href={\`/series/${slug}\`} draggable={false}>` 래핑, 커버(cover_image_url 분기, scrim overlay), **ON-GOING 배지 단일**(데이터가 이미 filter 후 ended_at null만), title h3, description 2줄 클램프, 메타 border-top(`formattedDate(started_at)` ~ "진행 중" · `sermon_count`편)
+- [ ] 2. `SermonSeriesCarousel.tsx` — `'use client'`, `useCarousel`, 헤더(h2 "진행 중인 시리즈" + `<CarouselArrows>` + `<Link href="/series">` "모든 시리즈 →"), `<Carousel ariaLabel mobileFullBleed carousel>` + `series.map(SeriesCard)`
+- [ ] 3. `SermonSeriesCarousel.module.scss` — semantic 토큰만(`$bg-card`/`$border-card`/`$radius-s`/`$accent`/`$primary`/`$txt-*`/`$overlay-image`). PC `flex-basis: calc(...)`로 3분할. D5 drag-ghost 차단 패턴 동일 적용
+- [ ] 4. `page.tsx` 수정 — `getAllSeries` import, `Promise.all`에 추가, `<SermonSeriesCarousel series={result} />` 배치
+- [ ] 5. `yarn dev` 수동 — `/sermons` 200, 캐러셀 렌더, drag/arrow 동작, PC 3카드/모바일 1.3카드, "모든 시리즈 →" → `/series`
+- [ ] 6. `node scripts/verify-task.mjs sermons-series-carousel` 통과
+
+## Verification
+
+```bash
+yarn lint
+yarn lint:styles
+yarn build
+yarn knip
+
+# 수동 (yarn dev)
+# → http://localhost:3000/sermons   Featured + 최근 캐러셀 + 시리즈 캐러셀 3 섹션
+# → PC: 시리즈 카드 정확히 3개 표시 (calc((100% - 24px) / 3))
+# → 모바일: 시리즈 카드 1.3개 정도 보임 (26rem)
+# → drag → 카드 클릭 차단 / 정지 클릭 → /series/${slug}
+# → ON-GOING 배지 단일 (filter 결과는 모두 ended_at null이므로 COMPLETED 미발생)
+# → "모든 시리즈 →" → /series
+
+node scripts/verify-task.mjs sermons-series-carousel
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS** (2026-05-14, 2차 PASS in thread `a9d3bc3928c93c4b8`. 1차 CHANGE_REQUEST thread `a0eeb1aac434fdf5f`)
+
+### 1차 — CHANGE_REQUEST (2026-05-14)
+
+**Codex verdict** (verbatim):
+> a) `is_active` 포함 + `ended_at`으로 `COMPLETED` 배지(SC8)는 "진행 중" 제목과 충돌 가능. material.
+> b) overlay는 명시됐지만 텍스트 가독성 보장 수치/스타일은 미명시. minor-material.
+> c) `calc((100% - 2*gap)/3)`는 overflow track에서 실제 3분할 수동검증 필요.
+
+**평이 풀이**: a) "진행 중인 시리즈" 섹션 제목과 mockup의 ON-GOING/COMPLETED 배지 동시 노출이 UX 부정합 — material. b) cover overlay의 토큰·rgba 수치 미명시 — gradient만으로는 텍스트 가독성 보장 못 함. c) calc 3분할이 overflow flex track에서 의도대로 작동하는지 실측 필요.
+
+**반영**:
+- (a) SC#7에 `.filter((s) => s.ended_at === null)` 추가, SC#2/체크리스트#1에 "ON-GOING 배지 단일" 명시, 의사결정 로그 D5 신규
+- (b) SC#5에 `$overlay-scrim` 토큰 + `$txt-inverse` 배지 텍스트색 명시, 의사결정 로그 D6 신규
+- (c) SC#3에 `flex-basis: calc((100% - 2 * #{$content-gap-s}) / 3)` 정의 + SC#8 "yarn dev: PC 정확히 3카드 표시" 수동 검증으로 cover (plan 변경 없이 흡수)
+
+### 2차 — PASS (2026-05-14)
+
+**Codex verdict** (verbatim):
+> a) 해소됨: `ended_at === null` 필터로 ongoing만 전달하고 `ON-GOING` 단일 배지만 구현하므로 "진행 중인 시리즈" 제목과 `COMPLETED` 동시 노출 충돌이 제거됨.
+> b) 해소됨: cover truthy 시 `rgba(0.4-0.5)` scrim overlay + `-inverse` 텍스트색을 명시해 최소 가독성 기준이 계획에 들어감. null 이미지는 dark gradient로 동일 목적을 처리함.
+> c) 해소됨: `calc((100% - 2 * gap) / 3)` 공식과 "PC 정확히 3카드 표시" 수동 검증이 SC#8에 들어가 overflow 리스크를 검증 항목으로 닫음.
+> 추가 mismatch: 없음.
+
+**평이 풀이**: 1차 CR 3건 모두 plan 수정으로 해소. 추가 plan-text mismatch 0건. WORK 진입 가능.
+
+## Codex 1차 검증
+
+- **결론**: **CHANGE_REQUEST → FIX_APPLIED** (Claude 반영 1건, 2026-05-14, fresh thread `a6f62440a99b8c889`)
+
+**Codex verdict** (verbatim 발췌):
+> P1-3 CHANGE_REQUEST — `description` null이면 flex spacer가 없어 `meta_bar` 하단 고정 불가: `SeriesCard.tsx:29`, `module.scss:94-122`.
+> 나머지 12개 점검 모두 OK (P1-1/2/4 + P2-5/6 + P3-7/8/9 + P4-10/11/12/13)
+> 결론: CHANGE_REQUEST — `SeriesCard.tsx:29` / `module.scss:94-122` — null description spacer 추가해 meta 하단 고정 필요.
+
+**평이 풀이**: 13개 점검 항목 중 12개 PASS, 1건만 CR — description이 null인 시리즈에서 `<p>` 미렌더 → flex spacer 부재 → 메타바가 위로 붙어 카드 height 통일 깨짐. 카드들이 가로로 늘어서면 메타바 baseline 어긋남.
+
+**반영** (Claude, SCSS 1줄): `SermonSeriesCarousel.module.scss .meta_bar`에 `margin-top: auto` 추가. flexbox 트릭 — description이 있든 없든 meta_bar가 카드 하단으로 push됨. description의 `flex: 1`은 유지 (description 있을 때 남은 공간 차지).
+
+**수정 파일**: `SermonSeriesCarousel.module.scss` 1줄 (Claude 반영, Codex 직접 수정 0).
+
+## Claude 2차 검증
+
+- **검토 내용**: 5 파일 staged diff(`git diff --cached`) + Codex 1차 13개 점검(12 OK + 1 CR `meta_bar` margin-top 누락) + CR fix 적용 후 SCSS 교차 확인.
+  - `SeriesCard.tsx`(41줄): `<Link draggable={false}>` 래핑, CloudinaryImage cover(cover_image_url 분기) + `.cover_scrim` overlay + ON-GOING 배지 단일, title h3, description 2줄 클램프, 메타 border-top(`started_at` ~ "진행 중" · `sermon_count`편). preacher 미렌더(D2). COMPLETED 분기 0건(D5).
+  - `SermonSeriesCarousel.tsx`(35줄): `'use client'`, `useCarousel()` unconditional 호출 후 `series.length === 0` 분기로 rules-of-hooks 충족. 헤더 = h2 + `<CarouselArrows>` + `<Link href="/series">` "모든 시리즈 →".
+  - `SermonSeriesCarousel.module.scss`(~145줄): semantic 토큰 + local var 2 (`$card-width-mobile: 26rem` mockup 260px 근거 / `$badge-glass-bg` 토큰 미존재). PC `flex-basis: calc((100% - 2 * #{$content-gap-s}) / 3)` (D3 gap 12 유지). 커버 absolute scrim + z-index:1 badge. D5 drag-ghost 패턴 4개 (`user-select`/`-webkit-user-drag`/`pointer-events`). **CR 반영: `.meta_bar { margin-top: auto }` 추가** — description 없어도 카드 height 통일.
+  - `page.tsx`(+5줄): `getAllSeries` import, `Promise.all` 3-tuple로 확장, `allSeries.filter(s => s.ended_at === null)` (D5), `<SermonSeriesCarousel series={ongoingSeries} />` 배치. 기존 redirect(C-1) + Recent dedup(Phase 1-2 D4) 모두 유지.
+- **실행한 검증**: `node scripts/verify-task.mjs sermons-series-carousel` 재실행 (run-id `20260514-183403`) → ✓ 필수 검증 통과 (ESLint / stylelint / Build (next) / Knip).
+  - `logs/sermons-series-carousel/20260514-183403/summary.log`: `✓ 필수 검증 통과 (⚠ 경고: Knip — 기존 부채, 커밋 차단 안 됨)`.
+  - `git status -s`: A 4 + M 1 — plan §영향받는 파일과 정확히 일치 (exec-plan 1 + 컴포넌트 3 + page.tsx 1).
+- **남은 항목**: `yarn dev` 수동 검증 (3 섹션 렌더, drag/arrow 동작, PC 3카드/모바일 1.3카드 영역, ON-GOING 배지, description 없는 시리즈 카드도 메타바 하단 고정, "모든 시리즈 →" → `/series`).
+- **최종 판단**: ✅ **PASS** — verify-task PASS + Codex 1차 13개 점검 통과(1 CR 반영) + diff 교차 확인 일치. 사용자 yarn dev 수동 검증 후 commit 진행 가능.
+
+---
+
+## 의사결정 로그
+
+- **2026-05-14 D1 — cover_tone 부재**: `sermon_series.cover_tone` 컬럼이 DB에 없음(`database.types.ts:258-296` 직접 확인). mockup `getCoverGradient(cover_tone)`은 가정 필드. 본 task는 `cover_image_url`이 truthy면 `<CloudinaryImage>` 배경 + 다크 overlay, null이면 정적 `$overlay-image` dark gradient. cover_tone 분기는 만들지 않음 — 컬럼 추가 + 운영 UI 추가는 별도 task (Phase 5 후보).
+- **2026-05-14 D2 — preacher 직접 컬럼 부재**: `sermon_series` Row에 `preacher` 컬럼 없음 — preacher는 sermon 단위 관계. mockup line 617-619 표시 영역 본 task에서 미렌더. 시리즈-설교자 집계 쿼리 또는 컬럼 추가는 별도 task.
+- **2026-05-14 D3 — gap mockup 16 → Carousel 기본 12 유지**: mockup `ListPCSeriesPreview` line 953 gap 16. `Carousel.module.scss .track { gap: $content-gap-s }` (12). Carousel.tsx 수정은 Non-goals(외과적 변경 차단). 시각적 차이 4px는 mockup 디자인 의도(섹션 간 호흡)와 거의 동일 — 동일 캐러셀 컴포넌트 일관성 우선. Carousel에 gap prop 도입이 필요한 후속 use case 누적되면 별도 task.
+- **2026-05-14 D4 — D5 drag-ghost 차단 패턴 재적용**: Phase 1-2(sermons-recent-carousel) §의사결정 로그 D5에서 PC `<Link>` ghost image로 캐러셀 스크롤 버벅임 발견·해소. 본 시리즈 카드도 `<Link>` 래핑 → 동일 처리: `<Link draggable={false}>` + SCSS `.card { user-select: none; -webkit-user-drag: none; }` + 커버 `.cover { -webkit-user-drag: none; pointer-events: none; }`.
+- **2026-05-14 D5 — "진행 중" 정의 강화 (Codex CR-a 반영)**: 1차 plan은 mockup 그대로 `getAllSeries()` 결과 전체(`is_active=true`) 표시 + COMPLETED/ON-GOING 배지로 시각 구분이었으나, Codex CR — 섹션 제목 "진행 중인 시리즈"와 COMPLETED 배지 동시 노출이 UX 부정합 지적. 해결: page.tsx에서 `getAllSeries()` 결과를 `.filter((s) => s.ended_at === null)`로 좁힘 + SeriesCard에서 COMPLETED 분기/배지 코드 미구현 (ON-GOING 배지만). 결과 0건이면 `return null`로 섹션 자체 미렌더. completed 시리즈 표시는 `/series` archive page 책임. Non-goals 유지(신규 service method 없음, 클라이언트 filter).
+- **2026-05-14 D6 — cover overlay scrim 명시 (Codex CR-b 반영)**: 1차 SC#5에 "다크 overlay" 추상 표현. Codex 지적 — 텍스트(배지·title) 가독성 확보 수치/토큰 미명시. 해결: SC#5에 `$overlay-scrim` 토큰 명시 (semantic scrim, styles `tokens/_semantic.scss` 정의). 배지/텍스트 색 `$txt-inverse`. cover_image_url null이면 기존 `$overlay-image` dark gradient만으로도 충분 (mockup의 dark gradient와 동일 의도).
+- **2026-05-14 D7 — `/sermons/series` 경로 정정 + path param 컨벤션**: 사용자 검증 발견 — 1차 plan은 `/series` 루트 경로 가정이었으나 dnchurch는 sermons 하위 라우트 사용. `/sermons/series/page.tsx` + `/sermons/series/[id]/page.tsx` 디렉토리 이미 존재 (Phase 0 skeleton). 카드 link `/sermons/series/${series.id}` 채택 — `[id]` 디렉토리 컨벤션 + 기존 `/sermons/${sermon.id}` 패턴 일관성. mockup의 slug URL은 Phase 4-5에서 컨벤션 결정 시 마이그레이션. 임시 404는 page.tsx가 skeleton(h1만)이라 200 응답이지만 의미 있는 콘텐츠는 Phase 4-5에서.
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 1-3 (line 195-219)
+- `docs/references/sermons/ChurchSermonAll.jsx` — `SeriesGridCard`(line 594-642), `ListPCSeriesPreview`(line 930-966)
+- Phase 1-2: `docs/exec-plans/completed/2026-05-14-sermons-recent-carousel.md`(머지 후 이동) — Carousel 사용 패턴 + D5 drag-ghost 차단 (본 plan D4 재사용)

--- a/docs/exec-plans/completed/2026-05-14-sermons-featured.md
+++ b/docs/exec-plans/completed/2026-05-14-sermons-featured.md
@@ -307,8 +307,26 @@ node scripts/verify-task.mjs sermons-featured
 - [ ] 셀프 리뷰: 이 PR을 처음 보는 사람도 EXEC_PLAN만으로 변경 의도를 이해할 수 있는가?
 - [ ] **멀티 세션 리뷰** (권장): 같은 세션의 구현자는 무의식적 바이어스가 생긴다. 별도 Claude 세션 또는 `codex:rescue`로 객관적 검토를 요청해 시선을 분리한다.
 
-## 회고 (머지 후 작성, completed/로 이동 시)
+## 회고 (필수 5필드)
+
+- KPI / 시작-종료 (분): ~240 (2026-05-14 — Phase 0 머지 직후 시작, PR #87 머지 07:55 UTC; 사용자 피드백 "5분이면 될 작업을 1시간이 넘게 걸렸어"가 본 phase에서 발화 → ADR 0010 도입 트리거가 됨. **본 phase는 ADR 0010 적용 전이라 baseline 측정치**)
+- KPI / Codex 라운드: 7 (계획 검증 5라운드 + 구현 1차 검증 1라운드 + PR #87 리뷰 fix 검증 1라운드)
+- KPI / material 사후 발견: 3 (PR #87 review G-2 cloudinary public ID 깨짐 잠재 버그, C-1 `/sermons?series=…` 구 URL 회귀, C-2 홈 CTA archive 경로 — Codex 1차 검증에서 잡지 못하고 PR 자동 리뷰 단계에서 검출)
+- KPI / harness-gate placeholder fail: 0
+- KPI / 사용자 검토 부족 피드백: 0
+
+## 회고
 
 - 잘된 것:
+  - EXPLORE 단계에서 `is_featured` 컬럼 부재를 dev/prod DB + `database.types.ts:300-322`로 직접 검증해 Phase 0 audit 오류를 사전 차단 (BLOCK 발견).
+  - 1차 Codex 1차 검증에서 cloudinary helper `CLOUD_NAME` guard 부재를 Codex가 직접 수정 (FIX_APPLIED), SCSS 하드코딩 5건은 Claude가 로컬 변수로 반영.
+  - PR review 4건을 4 파일 1 commit으로 묶되 subject `+` 0회 / `,` 열거 / 80자 한도 준수 — commit-msg hook R2/R4 통과.
+
 - 다음에 할 것:
+  - Phase 1-2(Recent 설교 캐러셀)부터 ADR 0010 적용 — compact exec-plan 6 필수 + 3 검증, 계획 검증 1-2 라운드 목표.
+  - Codex 1차 검증 프롬프트에 "archive 이관 후 구 URL 회귀"·"홈/외부 진입점 link 정합성" 항목을 명시 추가 — 본 phase에서 PR review 단계까지 미발견된 C-1·C-2 클래스 차단.
+
 - 발견된 부채 (→ tech-debt-tracker.md 옮길 것):
+  - `sermons.is_featured` 컬럼 미존재 — 어드민 수동 마킹 UI 필요 시 별도 task (Phase 5 후보).
+  - Phase 0 audit §4 인용 오류 (`database.types.ts:483` ← 실제 부재) — Phase 0 회고 부채와 sync.
+  - `cloudinaryFetchUrl`의 public ID 입력은 현재 미사용이나 가드 추가로 미래 안전 — 사용처 추가 시 호출부 정책 재확인.

--- a/src/app/(content)/sermons/_component/SermonRecentCarousel/SermonCarouselCard.tsx
+++ b/src/app/(content)/sermons/_component/SermonRecentCarousel/SermonCarouselCard.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+import clsx from 'clsx';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import type { SermonWithRelations } from '@/types/sermon';
+import { cloudinaryFetchUrl } from '@/utils/cloudinary';
+import { getSermonThumbnail, formatPreacherLabel, formatSermonDuration } from '@/utils/sermon';
+import { formattedDate } from '@/utils/date';
+import styles from './SermonRecentCarousel.module.scss';
+
+type Props = {
+  sermon: SermonWithRelations;
+};
+
+export default function SermonCarouselCard({ sermon }: Props) {
+  const thumb = cloudinaryFetchUrl(getSermonThumbnail(sermon));
+  const duration = formatSermonDuration(sermon.duration);
+  const preacherLabel = formatPreacherLabel(sermon.preacher);
+  const hasSeries = Boolean(sermon.sermon_series);
+  const labelText = sermon.sermon_series?.title ?? sermon.service_type;
+
+  return (
+    <Link href={`/sermons/${sermon.id}`} className={styles.card} draggable={false}>
+      <div className={styles.thumb_box}>
+        {thumb && (
+          <CloudinaryImage
+            src={thumb}
+            alt={sermon.title}
+            fill
+            sizes="(min-width: 768px) 240px, 210px"
+            className={styles.thumb}
+          />
+        )}
+        <span className={styles.play_circle} aria-hidden>
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </span>
+        {duration && <span className={styles.duration}>{duration}</span>}
+      </div>
+      <div className={styles.body}>
+        <span className={clsx(styles.label, hasSeries ? styles.label_series : styles.label_type)}>
+          {labelText}
+        </span>
+        <h3 className={styles.title}>{sermon.title}</h3>
+        {sermon.scripture && <p className={styles.scripture}>{sermon.scripture}</p>}
+        <div className={styles.meta_bar}>
+          <span>{preacherLabel}</span>
+          <span className={styles.dot} aria-hidden>·</span>
+          <span>{formattedDate(sermon.sermon_date, 'YYYY.MM.DD')}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.module.scss
+++ b/src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.module.scss
@@ -1,0 +1,172 @@
+// 캐러셀 카드 폭 — mockup `SermonCarouselCard` PC 240px / 모바일 210px
+$card-width-mobile: 21rem;
+$card-width-pc: 24rem;
+// 다크 미디어 영역의 유리감 배지 (play 버튼) — 토큰 미존재 (mockup `rgba(255,255,255,.14|.22)`)
+$badge-glass-bg: rgba(255, 255, 255, 0.14);
+$badge-glass-border: rgba(255, 255, 255, 0.22);
+// 영상 우하단 duration overlay — 토큰 미존재 (mockup `rgba(0,0,0,.7)`)
+$duration-overlay-bg: rgba(0, 0, 0, 0.7);
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-16;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-12;
+}
+
+.section_title {
+  margin: 0;
+  font-size: $font-size-18;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+  letter-spacing: $letter-spacing-body;
+}
+
+.header_actions {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-12;
+}
+
+.more_link {
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $primary;
+  text-decoration: none;
+
+  @include hover-color-shift($primary-hover);
+}
+
+.card {
+  flex: 0 0 $card-width-mobile;
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  // PC drag 시 anchor ghost image · 텍스트 selection 차단 (의사결정 로그 D5)
+  user-select: none;
+  -webkit-user-drag: none;
+
+  @include respond-up($breakpoint-tablet) {
+    flex-basis: $card-width-pc;
+  }
+}
+
+.thumb_box {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: $overlay-image;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.thumb {
+  object-fit: cover;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+
+.play_circle {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $spacing-32;
+  height: $spacing-32;
+  border-radius: $radius-circle;
+  background-color: $badge-glass-bg;
+  border: 1px solid $badge-glass-border;
+  color: $accent;
+
+  svg {
+    margin-left: $spacing-1;
+  }
+}
+
+.duration {
+  position: absolute;
+  bottom: $spacing-6;
+  right: $spacing-6;
+  padding: $spacing-2 $spacing-6;
+  border-radius: $radius-xxs;
+  background-color: $duration-overlay-bg;
+  color: $txt-inverse;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  font-variant-numeric: tabular-nums;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  padding: $spacing-12 $spacing-12 $spacing-12;
+}
+
+.label {
+  margin-bottom: $spacing-6;
+  font-size: $font-size-11;
+  text-transform: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.label_series {
+  color: $accent;
+  font-weight: $font-weight-bold;
+}
+
+.label_type {
+  color: $txt-tertiary;
+  font-weight: $font-weight-semibold;
+}
+
+.title {
+  margin: 0 0 $spacing-2;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: 2.8em;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $txt-primary;
+  line-height: $line-height-snug;
+  letter-spacing: $letter-spacing-body;
+  word-break: keep-all;
+}
+
+.scripture {
+  margin: 0 0 $spacing-8;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  color: $primary;
+}
+
+.meta_bar {
+  display: flex;
+  align-items: center;
+  gap: $spacing-4;
+  padding-top: $spacing-8;
+  border-top: 1px solid $border-subtle;
+  font-size: $font-size-11;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+}
+
+.dot {
+  opacity: 0.4;
+}

--- a/src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.tsx
+++ b/src/app/(content)/sermons/_component/SermonRecentCarousel/SermonRecentCarousel.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import type { SermonWithRelations } from '@/types/sermon';
+import { Carousel, CarouselArrows, useCarousel } from '@/components/ui/Carousel/Carousel';
+import SermonCarouselCard from './SermonCarouselCard';
+import styles from './SermonRecentCarousel.module.scss';
+
+type Props = {
+  sermons: SermonWithRelations[];
+};
+
+export default function SermonRecentCarousel({ sermons }: Props) {
+  const carousel = useCarousel();
+
+  if (sermons.length === 0) return null;
+
+  return (
+    <section className={styles.section}>
+      <header className={styles.header}>
+        <h2 className={styles.section_title}>최근 설교</h2>
+        <div className={styles.header_actions}>
+          <CarouselArrows canL={carousel.canL} canR={carousel.canR} onScroll={carousel.scroll} />
+          <Link href="/sermons/all" className={styles.more_link}>
+            더 보기 →
+          </Link>
+        </div>
+      </header>
+      <Carousel ariaLabel="최근 설교 캐러셀" mobileFullBleed carousel={carousel}>
+        {sermons.map((sermon) => (
+          <SermonCarouselCard key={sermon.id} sermon={sermon} />
+        ))}
+      </Carousel>
+    </section>
+  );
+}

--- a/src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx
+++ b/src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import { formattedDate } from '@/utils/date';
+import styles from './SermonSeriesCarousel.module.scss';
+
+type Props = {
+  series: SeriesWithSermonCount;
+};
+
+export default function SeriesCard({ series }: Props) {
+  const cover = series.cover_image_url;
+
+  return (
+    <Link href={`/sermons/series/${series.id}`} className={styles.card} draggable={false}>
+      <div className={styles.cover}>
+        {cover && (
+          <CloudinaryImage
+            src={cover}
+            alt={series.title}
+            fill
+            sizes="(min-width: 768px) 33vw, 260px"
+            className={styles.cover_image}
+          />
+        )}
+        <div className={styles.cover_scrim} aria-hidden />
+        <span className={styles.badge}>ON-GOING</span>
+      </div>
+      <div className={styles.body}>
+        <h3 className={styles.title}>{series.title}</h3>
+        {series.description && <p className={styles.description}>{series.description}</p>}
+        <div className={styles.meta_bar}>
+          <span>{formattedDate(series.started_at, 'YYYY.MM.DD')}</span>
+          <span className={styles.dot} aria-hidden>~</span>
+          <span className={styles.ongoing}>진행 중</span>
+          <span className={styles.dot} aria-hidden>·</span>
+          <span className={styles.count}>{series.sermon_count}편</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.module.scss
+++ b/src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.module.scss
@@ -1,0 +1,154 @@
+// 모바일 카드 폭 — mockup `SeriesGridCard` 모바일 260px (`MListSeriesPreview` 영역)
+$card-width-mobile: 26rem;
+// 다크 커버 위 배지 유리감 — 토큰 미존재 (mockup `rgba(0,0,0,.32)` + backdrop-filter)
+$badge-glass-bg: rgba(0, 0, 0, 0.32);
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-16;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-12;
+}
+
+.section_title {
+  margin: 0;
+  font-size: $font-size-18;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+  letter-spacing: $letter-spacing-body;
+}
+
+.header_actions {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-12;
+}
+
+.more_link {
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $primary;
+  text-decoration: none;
+
+  @include hover-color-shift($primary-hover);
+}
+
+.card {
+  flex: 0 0 $card-width-mobile;
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  // PC drag 시 anchor ghost image · 텍스트 selection 차단 (Phase 1-2 D5 패턴 재적용)
+  user-select: none;
+  -webkit-user-drag: none;
+
+  @include respond-up($breakpoint-tablet) {
+    // mockup ListPCSeriesPreview line 959: calc((100% - 32px) / 3). Carousel 기본 gap 12px 기준 (의사결정 D3)
+    flex-basis: calc((100% - 2 * #{$content-gap-s}) / 3);
+  }
+}
+
+.cover {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: $overlay-image;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+  padding: $spacing-12;
+}
+
+.cover_image {
+  object-fit: cover;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+
+.cover_scrim {
+  position: absolute;
+  inset: 0;
+  background-color: $overlay-scrim;
+  pointer-events: none;
+}
+
+.badge {
+  position: relative;
+  z-index: 1;
+  padding: $spacing-2 $spacing-8;
+  border-radius: $radius-circle;
+  background-color: $badge-glass-bg;
+  color: $txt-inverse;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  letter-spacing: $letter-spacing-wide;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: $spacing-16;
+}
+
+.title {
+  margin: 0 0 $spacing-6;
+  font-size: $font-size-16;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+  letter-spacing: $letter-spacing-body;
+  line-height: $line-height-snug;
+  word-break: keep-all;
+}
+
+.description {
+  margin: 0 0 $spacing-12;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  flex: 1;
+  font-size: $font-size-12;
+  color: $txt-secondary;
+  line-height: $line-height-body-reading;
+  word-break: keep-all;
+}
+
+.meta_bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: $spacing-4;
+  // description이 null일 때도 카드 height 통일 — auto가 flex spacer 역할 (Codex 1차 CR 반영)
+  margin-top: auto;
+  padding-top: $spacing-8;
+  border-top: 1px solid $border-subtle;
+  font-size: $font-size-11;
+  color: $txt-secondary;
+  font-variant-numeric: tabular-nums;
+}
+
+.dot {
+  opacity: 0.4;
+}
+
+.ongoing {
+  color: $primary;
+  font-weight: $font-weight-bold;
+}
+
+.count {
+  color: $txt-primary;
+  font-weight: $font-weight-bold;
+}

--- a/src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.tsx
+++ b/src/app/(content)/sermons/_component/SermonSeriesCarousel/SermonSeriesCarousel.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import { Carousel, CarouselArrows, useCarousel } from '@/components/ui/Carousel/Carousel';
+import SeriesCard from './SeriesCard';
+import styles from './SermonSeriesCarousel.module.scss';
+
+type Props = {
+  series: SeriesWithSermonCount[];
+};
+
+export default function SermonSeriesCarousel({ series }: Props) {
+  const carousel = useCarousel();
+
+  if (series.length === 0) return null;
+
+  return (
+    <section className={styles.section}>
+      <header className={styles.header}>
+        <h2 className={styles.section_title}>진행 중인 시리즈</h2>
+        <div className={styles.header_actions}>
+          <CarouselArrows canL={carousel.canL} canR={carousel.canR} onScroll={carousel.scroll} />
+          <Link href="/sermons/series" className={styles.more_link}>
+            모든 시리즈 →
+          </Link>
+        </div>
+      </header>
+      <Carousel ariaLabel="진행 중인 시리즈 캐러셀" mobileFullBleed carousel={carousel}>
+        {series.map((item) => (
+          <SeriesCard key={item.id} series={item} />
+        ))}
+      </Carousel>
+    </section>
+  );
+}

--- a/src/app/(content)/sermons/page.module.scss
+++ b/src/app/(content)/sermons/page.module.scss
@@ -1,0 +1,6 @@
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: $section-gap-40;
+  padding-block: $spacing-24 $spacing-40;
+}

--- a/src/app/(content)/sermons/page.tsx
+++ b/src/app/(content)/sermons/page.tsx
@@ -5,6 +5,7 @@ import { getAllSeries, getFeaturedSermon, getSermons } from '@/services/sermon';
 import SermonFeatured from './_component/SermonFeatured/SermonFeatured';
 import SermonRecentCarousel from './_component/SermonRecentCarousel/SermonRecentCarousel';
 import SermonSeriesCarousel from './_component/SermonSeriesCarousel/SermonSeriesCarousel';
+import styles from './page.module.scss';
 
 const RECENT_CAROUSEL_COUNT = 8;
 
@@ -44,7 +45,7 @@ export default async function SermonsPage({ searchParams }: SermonsPageProps) {
   const ongoingSeries = allSeries.filter((series) => series.ended_at === null);
 
   return (
-    <LayoutContainer>
+    <LayoutContainer className={styles.sections}>
       <SermonFeatured sermon={featured} />
       <SermonRecentCarousel sermons={recentList} />
       <SermonSeriesCarousel series={ongoingSeries} />

--- a/src/app/(content)/sermons/page.tsx
+++ b/src/app/(content)/sermons/page.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { LayoutContainer } from '@/components/layout';
-import { getFeaturedSermon, getSermons } from '@/services/sermon';
+import { getAllSeries, getFeaturedSermon, getSermons } from '@/services/sermon';
 import SermonFeatured from './_component/SermonFeatured/SermonFeatured';
 import SermonRecentCarousel from './_component/SermonRecentCarousel/SermonRecentCarousel';
+import SermonSeriesCarousel from './_component/SermonSeriesCarousel/SermonSeriesCarousel';
 
 const RECENT_CAROUSEL_COUNT = 8;
 
@@ -30,19 +31,23 @@ export default async function SermonsPage({ searchParams }: SermonsPageProps) {
   const query = qs.toString();
   if (query) redirect(`/sermons/all?${query}`);
 
-  // Featured 1건이 캐러셀 첫 카드와 중복되지 않도록 pageSize +1 후 Featured ID 필터링 (의사결정 로그 D4).
-  const [featured, recent] = await Promise.all([
+  // Featured 1건이 캐러셀 첫 카드와 중복되지 않도록 pageSize +1 후 Featured ID 필터링 (sermons-recent-carousel D4).
+  // 시리즈는 ended_at이 null인 진행 중만 메인 노출 (sermons-series-carousel D5).
+  const [featured, recent, allSeries] = await Promise.all([
     getFeaturedSermon(),
-    getSermons({ pageSize: RECENT_CAROUSEL_COUNT + 1 })
+    getSermons({ pageSize: RECENT_CAROUSEL_COUNT + 1 }),
+    getAllSeries()
   ]);
   const recentList = recent.sermons
     .filter((sermon) => sermon.id !== featured?.id)
     .slice(0, RECENT_CAROUSEL_COUNT);
+  const ongoingSeries = allSeries.filter((series) => series.ended_at === null);
 
   return (
     <LayoutContainer>
       <SermonFeatured sermon={featured} />
       <SermonRecentCarousel sermons={recentList} />
+      <SermonSeriesCarousel series={ongoingSeries} />
     </LayoutContainer>
   );
 }

--- a/src/app/(content)/sermons/page.tsx
+++ b/src/app/(content)/sermons/page.tsx
@@ -1,8 +1,11 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { LayoutContainer } from '@/components/layout';
-import { getFeaturedSermon } from '@/services/sermon';
+import { getFeaturedSermon, getSermons } from '@/services/sermon';
 import SermonFeatured from './_component/SermonFeatured/SermonFeatured';
+import SermonRecentCarousel from './_component/SermonRecentCarousel/SermonRecentCarousel';
+
+const RECENT_CAROUSEL_COUNT = 8;
 
 export const metadata: Metadata = {
   title: '설교',
@@ -27,11 +30,19 @@ export default async function SermonsPage({ searchParams }: SermonsPageProps) {
   const query = qs.toString();
   if (query) redirect(`/sermons/all?${query}`);
 
-  const featured = await getFeaturedSermon();
+  // Featured 1건이 캐러셀 첫 카드와 중복되지 않도록 pageSize +1 후 Featured ID 필터링 (의사결정 로그 D4).
+  const [featured, recent] = await Promise.all([
+    getFeaturedSermon(),
+    getSermons({ pageSize: RECENT_CAROUSEL_COUNT + 1 })
+  ]);
+  const recentList = recent.sermons
+    .filter((sermon) => sermon.id !== featured?.id)
+    .slice(0, RECENT_CAROUSEL_COUNT);
 
   return (
     <LayoutContainer>
       <SermonFeatured sermon={featured} />
+      <SermonRecentCarousel sermons={recentList} />
     </LayoutContainer>
   );
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

설교 메인 페이지(`/sermons`)에 "최근 설교" 가로 캐러셀 + "진행 중인 시리즈" 가로 캐러셀 2섹션을 추가하고, 3섹션(Featured / Recent / Series) 간 vertical spacing을 통일했습니다. 메인 페이지 디자인 mockup(`ChurchSermonAll.jsx` ListPCBody / MListBody) 의도 반영.

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermons-recent-carousel` / `sermons-series-carousel` / `sermons-main-layout` (3 sub-task 묶음)
- **Exec Plan**:
  - `docs/exec-plans/active/2026-05-14-sermons-recent-carousel.md`
  - `docs/exec-plans/active/2026-05-14-sermons-series-carousel.md`
  - `docs/exec-plans/active/2026-05-14-sermons-main-layout.md`
- **관련 ADR**: `docs/decisions/0010-harness-codex-review-cap.md` (본 PR은 ADR 0010 compact plan 첫 적용 2건 + 3건 합계)
- **관련 tech debt**: `docs/tech-debt-tracker.md` — `sermon_series.cover_tone` 컬럼 부재 + `sermon_series.preacher` 직접 컬럼 부재 (Phase 5 후보)
- **작업 범위**: `/sermons` 메인 페이지의 최근 설교 캐러셀 + 진행 중 시리즈 캐러셀 + 섹션 간 spacing + Featured ID dedup
- **제외한 범위**: `/sermons/series` `/sermons/series/[id]` 본문 구현 (skeleton 그대로) / `Carousel.tsx` 자체 수정 / 신규 spacing 토큰 / Phase 2 이후

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- 이전 PR #87로 `/sermons` 메인이 Featured 카드 1개만 표시되어 contents thin → "지난 설교 다시 보기" "진행 중 시리즈"로 진입 동선 부재
- Phase 0 mockup이 정한 3섹션 layout(Featured / 최근 캐러셀 / 시리즈 캐러셀)의 1·2번째 단계 완성도 미달
- 섹션 간 spacing이 0px라 시각적 호흡 부재

**관련 이슈:**

- Issue: 없음 (mockup 기반 직접 진행)

---

## 🔧 주요 변경점 (Key Changes)

- **신규 컴포넌트 6종** (`/sermons/_component/` 하위):
  - `SermonRecentCarousel/SermonRecentCarousel.tsx` (`'use client'`, useCarousel + 헤더 + Carousel wrap)
  - `SermonRecentCarousel/SermonCarouselCard.tsx` (vertical 카드, 16:9 썸네일 + duration overlay + 시리즈/service_type 라벨 분기)
  - `SermonRecentCarousel/SermonRecentCarousel.module.scss` (PC 240px / 모바일 210px 카드 / drag-ghost 차단)
  - `SermonSeriesCarousel/SermonSeriesCarousel.tsx` (`'use client'`, useCarousel + 헤더 "진행 중인 시리즈")
  - `SermonSeriesCarousel/SeriesCard.tsx` (16:9 커버 + scrim overlay + ON-GOING 배지 + 메타 border-top)
  - `SermonSeriesCarousel/SermonSeriesCarousel.module.scss` (PC `calc((100% - 2*gap)/3)` 3분할 / 모바일 26rem / meta_bar margin-top auto로 description 없어도 카드 height 통일)
- **신규 SCSS** `app/(content)/sermons/page.module.scss` — `.sections { display:flex; flex-direction:column; gap:$section-gap-40; padding-block:$spacing-24 $spacing-40 }`
- **page.tsx 수정** — `Promise.all` 3-tuple로 확장(featured/recent/allSeries), Featured ID로 캐러셀 첫 카드 dedup, `ended_at === null`로 진행 중 시리즈만 메인 노출, `<LayoutContainer className={styles.sections}>`로 page-level layout

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 |
| --- | --- | --- | --- |
| Recent 데이터 | `getSermons({pageSize:9})` + filter dedup | `SermonListItem` light fieldset이 duration/sermon_series 누락 → SermonWithRelations 필요. Phase 1-1 Featured와 동일 패턴 | `getRecentSermons` 시그니처 확장 (home RecentSermons 영향) |
| Series filter | `.filter(s => s.ended_at === null)` 클라이언트 | 신규 service method 없이 ADR 0010 외과적. "진행 중인 시리즈" 섹션 제목과 의미 일치 | DB 단 쿼리(getOngoingSeries 신규) |
| 카드 link path | `/sermons/series/${id}` | 사용자 수동 검증 정정 — dnchurch는 `[id]` 디렉토리 + `/sermons/${sermon.id}` 컨벤션 일관성 | mockup의 slug URL (Phase 5에서 컨벤션 결정) |
| Series cover_tone 부재 | cover_image_url 분기 + `$overlay-scrim` 다크 overlay | DB에 `cover_tone` 컬럼 없음 (mockup 가정 오류) | 컬럼 추가 + 마이그레이션 (Phase 5) |
| Series preacher 부재 | 미렌더 | sermon_series에 preacher 직접 컬럼 없음 — preacher는 sermon 단위 관계 | 시리즈-설교자 집계 쿼리 (Phase 5) |
| PC drag UX | `<Link draggable={false}>` + SCSS user-select/-webkit-user-drag/pointer-events | 사용자 검증 — PC anchor native drag ghost로 캐러셀 버벅임 | Carousel.tsx 자체 수정 (Non-goals) |
| 섹션 spacing | `$section-gap-40` 단일 토큰 (모바일/PC 동일) | 신규 토큰 추가 회피 + `$section-gap-40` 반응형 자동 축소 의존 | 모바일 전용 토큰(`$section-gap-24` 등) 추가 |

> ⚠️ **트레이드오프:**
> - `/sermons/series`·`/sermons/series/[id]` 라우트는 Phase 0 skeleton 상태로 본문 미구현 → 카드/링크 클릭 시 h1만 보임 (Phase 4-5에서 채움).
> - 모바일에서 `$section-gap-40` 고정 시 mockup 22-24 대비 다소 큼 — Phase 1 회고 후 사용자 피드백 누적 시 별도 토큰 도입 가능.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | sermons-recent-carousel PASS (run-id `20260514-175604`) / sermons-series-carousel PASS (`20260514-184102`) / sermons-main-layout PASS (`20260514-190038`) — 모두 ESLint/stylelint/build/knip 통과 (Knip 경고는 기존 부채) |
| `harness-gate` | 머지 직전 develop 기준 실행 예정 |
| Codex 계획 검증 | Recent PASS_WITH_DECISION_LOG `a53154d6` / Series 1차 CR→2차 PASS `a9d3bc39` / Main PASS_WITH_DECISION_LOG `a0cff5d1` |
| Codex 1차 검증 | Recent PASS `aa657e5d` / Series CR→FIX_APPLIED(meta_bar margin-top auto) `a6f62440` / Main PASS `a7a06c61` |
| Claude 2차 검증 | 3 task 모두 완료, 각 exec-plan §Claude 2차 검증 |
| ADR 판단 | 3 task 모두 불필요 (`app/(content)/sermons/_component/` + `page.tsx` 1-5줄, ADR_TRIGGER_PARTS 미해당) |
| 남은 warning | Knip 기존 부채 (sermons 외 영역) / ESLint 신규 0건 |

---

## 🗂️ 셀프 체크리스트

**기능적 완성도**
- [x] 요구사항 — mockup 1-2/1-3/1-4 layout 완성
- [x] 엣지 케이스 — 빈 sermons/series → `return null`, description null → meta_bar 하단 고정, Featured null → 캐러셀 그대로

**코드 품질**
- [x] 의도 명확 컴포넌트명·prop명
- [x] 디버그 로그 0

**보안 및 견고성**
- [x] 하드코딩 비밀값 0
- [x] 외부 데이터(getAllSeries / getSermons) → server-only 클라이언트 사용

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: `/sermons` 메인이 Featured 1개에서 → Featured + 최근 8건 캐러셀 + 진행 중 시리즈 캐러셀 3섹션으로 확장. PC/모바일 모두 drag·화살표 캐러셀 동작.
- **운영/릴리스 주의사항**: DB 마이그레이션 없음 / 환경변수 변경 없음 / `getAllSeries` 캐시는 기존 `sermonCache.seriesList()` (1일 revalidate) — 새 시리즈 추가/완료 시 admin action에서 `sermon-series-list` tag revalidate 필요 (기존 동일).
- **롤백 시 영향**: 메인 페이지가 PR #87 직후 상태(Featured 1개)로 복귀. /sermons 외 영향 0.
- **먼저 볼 화면**: `https://<preview>/sermons` — 3섹션 layout, 드래그·화살표, 카드 클릭 → /sermons/[id]·/sermons/series/[id], 모바일 풀폭 캐러셀.

---

## 📝 리뷰어를 위한 메모

- ADR 0010(harness compact plan + Codex CR cap) 첫 운영 적용 사례 — Recent/Series 두 sub-task는 PASS_WITH_DECISION_LOG verdict로 expression-only 지적을 의사결정 로그로 분리해 plan 라운드 5→1-2로 단축.
- 다음 작업(Phase 2 설교 상세 페이지)에서 `<Carousel>` 사용 4번째 케이스가 누적되면 gap prop 도입(Carousel.tsx 자체 수정) 별도 task 검토 가치.
- `/sermons/series` 페이지 본문은 별도 task — 본 PR 머지 직후 카드 클릭 시 skeleton만 보임을 사용자가 인지함.
