### PR TITLE
[Feat] 설교 상세 페이지 mockup 디자인 적용 — Tabs 폐기·시리즈 사이드바·다른 설교 섹션·모바일 reshuffle

### DIFF
--- a/docs/exec-plans/active/2026-05-14-sermons-detail-main.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-detail-main.md
@@ -1,0 +1,113 @@
+# sermons-detail-main
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons-detail
+- **Open questions**: none
+- **ADR needed**: no — `src/app/(content)/sermons/_component/SermonDetailPage/` 리팩터 + `[id]/page.tsx` 변경 없음 (ADR_TRIGGER_PARTS 미해당)
+
+## 목표
+
+설교 상세 페이지(`/sermons/[id]`) 좌측 메인 컨텐츠 영역을 mockup `DetailPCBody` + `SermonMeta` 디자인으로 리팩터. 현 Tabs 4분할(요약/본문/자료/노트) → mockup 순차 layout(scripture_text 인용 → summary → resources). 노트 기능은 본 task 외 별도 task로 분리 (제거 X, 위치만 후속 결정).
+
+## 검증된 Assumptions
+
+- 현 `SermonDetailPage.tsx`(line 1-205): `'use client'`, `useState`로 4-Tab UI. mockup 의도(순차 펼침)와 정면 충돌.
+- mockup `Sermon-Implementation-Prompts.md:248-273` 명시 구조 — 영상 / 메타(시리즈 라벨+제목+scripture+컴팩트 메타) / scripture_text 인용 / summary / resources 순차.
+- 기존 컴포넌트 그대로 재사용: `<SermonVideoPlayer>`(라인 7) / `<SermonVideoTools>`(라인 8) / `<ScriptureBlock>`(라인 10) / `<SeriesEpisodeList>`(라인 12) — mockup도 동일 영역 존재. `<SermonNoteEditor>`만 본 task 분기.
+- `incrementSermonViewCount` 호출 + JSON-LD VideoObject schema는 `[id]/page.tsx`(line 61-83)에서 그대로 유지 — server-only 책임.
+- 메타 필드 컴팩트 — 현 `SermonMeta` 인라인 컴포넌트(line 105-131)의 시리즈 라벨/날짜/preacher/serviceType 조합은 mockup과 호환. duration 추가 + 시리즈 페이지 링크 추가만 필요.
+- 사용자 결정 — 현 작업 task 4 작업 graph 등록 + 사용자 승인 진행 (auto mode 빠르게 진행 지시).
+
+## Non-goals
+
+- **노트 기능 제거** — `SermonNoteEditor` 컴포넌트·hook 그대로 보존. 단 본 페이지 노출 위치는 본 task에서 미정 (별도 후속 task에서 footer 영역·별도 페이지·collapsible 등 결정).
+- 모바일 layout 별도 처리 (Phase 2-4)
+- 시리즈 사이드바 우측 배치 (Phase 2-2 — 본 task는 좌측 메인만)
+- 같은 설교자 다른 설교 (Phase 2-3)
+- `<SermonVideoPlayer>`/`<SermonVideoTools>` 자체 수정 — props 동일, 위치만 영상 직하단 유지
+- JSON-LD / `incrementSermonViewCount` / `generateMetadata` 등 `[id]/page.tsx` 로직 변경
+- `getSermonsBySeries` / `<SeriesEpisodeList>` 동작 변경
+
+## Success Criteria
+
+1. **Tabs 폐기** — `Tabs` import + `useState('summary')` + `TabContent` sub-component 모두 제거. `'use client'` 유지 (router push 사용).
+2. **순차 layout** — 메타 블록 직하 순서: (a) `<ScriptureBlock>` 인용(scripture_text 있을 때만), (b) `summary` paragraphs (paragraphs 분할 렌더), (c) resources 섹션(`active resources.length > 0`이면), (d) `<SeriesEpisodeList>`(시리즈 있으면) — mockup line 248-273 순서와 동일.
+3. **메타 컴팩트 + 시리즈 링크** — 현 `SermonMeta`의 시리즈 라벨을 `<Link href={\`/sermons/series/${seriesId}\`}>`로 감싸 클릭 시 시리즈 페이지 이동. duration 추가(메타 한 줄에 날짜·service_type·duration·preacher).
+4. **노트 임시 위치** — `<SermonNoteEditor>`는 페이지 최하단(SeriesEpisodeList 아래) collapsible 영역으로 임시 배치. mockup에 없으나 기능 보존 위해. 별도 task 결정 전까지 임시.
+5. **SCSS 토큰 정합** — 추가/수정 SCSS는 semantic 토큰만. 신규 local var은 mockup-cite 주석 필수. 하드코딩 0건.
+6. **검증 통과** — `node scripts/verify-task.mjs sermons-detail-main` 통과 + `yarn dev` 수동: `/sermons/[id]` 200, 영상 / 메타(컴팩트+시리즈 링크) / scripture_text / summary / resources / SeriesEpisodeList / 노트 영역 순차 렌더, Tab UI 흔적 없음.
+
+## 영향받는 파일
+
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx` — Tabs 폐기, 순차 layout, 메타 컴팩트, 시리즈 링크, 노트 임시 위치
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss` — Tab 관련 클래스(`.tab_content`/`.tab_panel`/`.empty`) 제거 + 순차 layout 클래스 추가
+- 수정 없음: `[id]/page.tsx` / 모든 sub-component (Video/ScriptureBlock/Series 등)
+
+## 단계별 체크리스트
+
+- [ ] 1. `SermonDetailPage.tsx`에서 `Tabs`/`useState`/`TABS`/`TabContent`/`SermonNoteEditor` import + 사용 정리. Tabs 폐기, scripture/summary/resources를 단순 순차 JSX로 인라인
+- [ ] 2. `SermonMeta` 인라인 컴포넌트에 `duration` 메타 한 줄 추가 + 시리즈 라벨 `<Link href={\`/sermons/series/${sermon.sermon_series?.id}\`}>` 감싸기 (sermon_series가 있을 때만 link)
+- [ ] 3. summary 렌더 — 기존 SermonDetailPage:144 단일 `<p className={styles.summary_text}>{sermon.summary}</p>` 유지 + SCSS `.summary_text { white-space: pre-wrap }` 추가 (D4)
+- [ ] 4. resources 섹션을 Tab content에서 페이지 본문 직속으로 이관 — 기존 `.resource_list`/`.resource_item` SCSS 그대로 사용
+- [ ] 5. 페이지 최하단에 `<SermonNoteEditor>` 임시 배치 (collapsible 또는 단순 노출 — 디자인 결정 미루고 단순 노출)
+- [ ] 6. `.module.scss`에서 Tab 관련 클래스 정리 + 순차 layout 클래스(`.scripture_section`/`.summary_section`/`.resources_section`) 추가. 토큰 `$content-gap-l`/`$section-gap-40` 등 사용
+- [ ] 7. `yarn dev` 수동 — 시리즈 있는 설교 + 단독 설교 + scripture_text 있음/없음 + resources 있음/없음 4 케이스 렌더
+- [ ] 8. `node scripts/verify-task.mjs sermons-detail-main` 통과
+
+## Verification
+
+```bash
+yarn lint
+yarn lint:styles
+yarn build
+yarn knip
+
+# 수동 (yarn dev)
+# → http://localhost:3000/sermons/[id]  (시리즈 있는 설교)
+#    영상 / 메타(컴팩트+시리즈 라벨 링크) / scripture_text 인용 / summary paragraphs / resources / SeriesEpisodeList / 노트 영역
+# → http://localhost:3000/sermons/[id]  (단독 설교, scripture_text 없음, resources 없음)
+#    영상 / 메타(시리즈 없음) / summary / 노트 영역 — scripture·resources 섹션 미렌더
+# → 시리즈 라벨 클릭 → /sermons/series/${seriesId} 이동
+# → Tab UI 흔적 0 (tabpanel/role="tab" 등 DOM에 없음)
+
+node scripts/verify-task.mjs sermons-detail-main
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS_WITH_DECISION_LOG** (2026-05-14, fresh thread `ae4aa5419f3bd7ef7`)
+- **5체크**: 1·2·3·4 YES, 5 새 추상화 0(기존 컴포넌트 5개 재사용).
+
+**Codex verdict** (verbatim 발췌):
+> a) D1 Tabs 폐기: mockup `248-273`과 현 Tabs 충돌을 근거로 한 결정은 적절함. 대안 검토는 짧지만, 목표가 mockup 정합이면 충분함.
+> b) D2 노트 임시 위치: `SeriesEpisodeList` 아래 노출은 사용자 혼란 hypothesis 있음. 단, 기능 보존과 후속 task 명시가 있어 material blocker는 아님.
+> c) `summary split('\n\n')`: plan 본문에는 없음. 구현자가 이 방식을 쓰려 한다면 markdown/HTML 혼재 입력에서 깨질 수 있으므로 SC에 "기존 summary 렌더 보존" 1줄 추가 권장.
+
+**평이 풀이**: 5체크 + a/b PASS, c는 expression-only. summary 렌더 방식은 SC#3 "paragraphs 분할" 표현이 모호 → 기존 단일 `<p>` 렌더를 유지하고 SCSS `white-space: pre-wrap`로 줄바꿈 처리 결정(D4).
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+
+## Claude 2차 검증
+
+- **최종 판단**: 미작성
+
+---
+
+## 의사결정 로그 (사전 기록)
+
+- **2026-05-14 D1 — Tabs 4분할 폐기 + 순차 layout**: mockup `Sermon-Implementation-Prompts.md:248-273`은 4 영역(scripture/summary/resources/노트) 순차 펼침. 현 dnchurch는 Tabs UI로 4분할 — 모바일에서 1 탭만 보이고 콘텐츠 발견성 ↓. UX 통일 위해 Tabs 폐기. 트레이드오프: 페이지 길이 ↑, 스크롤 부담. mockup 디자인 의도 우선.
+- **2026-05-14 D2 — `<SermonNoteEditor>` 임시 위치**: mockup에 노트 영역 없음. 본 task에서 노트 기능 제거하면 dnchurch 자체 기능 손실. 보존 전략: SeriesEpisodeList 아래 단순 노출 (임시). 별도 task에서 collapsible / 우측 사이드바 / 별도 페이지 중 결정. 본 task는 "기능 보존 + 위치 후속"으로 좁힘.
+- **2026-05-14 D3 — 시리즈 라벨 → 페이지 링크**: mockup 명시 "시리즈명 · 회차 + 시리즈 페이지 링크". 현 `SermonMeta` 라벨은 plain text. `<Link href={\`/sermons/series/${sermon.sermon_series?.id}\`}>`로 감싸 클릭 가능. Phase 1-3 시리즈 카드 link와 동일 경로 컨벤션(`[id]` 디렉토리).
+- **2026-05-14 D4 — summary 렌더 (Codex CR-c expression 반영)**: 1차 plan SC#3 "summary paragraphs 분할" 표현이 `summary.split('\n\n')` 가정으로 읽힘 — Codex 지적: admin UI가 markdown/HTML 혼재 입력 시 raw split이 깨짐. 해결: 기존 SermonDetailPage:144-148 단일 `<p className={styles.summary_text}>{sermon.summary}</p>` 렌더 유지 + SCSS `.summary_text { white-space: pre-wrap }` 추가로 줄바꿈 보존. 시각적으로 "paragraphs"처럼 보이되 입력 형식과 무관. 향후 markdown 렌더링 도입은 별도 task (mdx 또는 react-markdown 등).
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 2-1 (line 246-273)
+- `docs/references/sermons/ChurchSermonAll.jsx` — `SermonMeta`(line 992-1015), `DetailPCBody` (영역 line 별도 mockup)
+- 기존 자산: `SermonDetailPage.tsx`(205줄), `SermonVideoPlayer` / `SermonVideoTools` / `ScriptureBlock` / `SeriesEpisodeList` / `SermonNoteEditor`
+- Phase 1-3 시리즈 link 컨벤션: `/sermons/series/${id}` (의사결정 로그 D7)

--- a/docs/exec-plans/active/2026-05-14-sermons-detail-main.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-detail-main.md
@@ -90,11 +90,33 @@ node scripts/verify-task.mjs sermons-detail-main
 
 ## Codex 1차 검증
 
-- **결론**: 미요청
+- **결론**: **PASS** (2026-05-14, fresh thread `a90ff12d3433231f2`)
+- **검토 범위**: 2 파일 staged diff (`SermonDetailPage.tsx` + `.module.scss`)
+
+**Codex verdict** (verbatim 발췌):
+> P1 `use client` 유지 OK: `useRouter` line 4, `router.push` callbacks line 32-39.
+> P1 `ScriptureBlock` 조건 OK: `sermon.scripture && sermon.scripture_text` line 57.
+> P1 `SermonMeta` 타입 OK: 호출 line 51-55, props type line 90-94 일치.
+> P2 `Link` OK / `SermonNoteEditor` OK: client parent.
+> P3 sub-components 미수정 / `[id]/page.tsx` 변경 0 / 노트·시리즈 보존.
+> P4 token OK: 하드코딩 0건.
+> D1 OK: `Tabs|TABS|activeTab|useState|tab_` 0건.
+> D2 OK: 주석 line 80, 노트 line 81.
+> D3 OK: `/sermons/series/${series.id}` line 103.
+> D4 OK: `white-space: pre-wrap` line 105.
+
+**평이 풀이**: 13개 점검(P1-P4 + D1-D4) 모두 PASS. Tabs/useState/TABS/tab_ 클래스 모두 제거 확인(`grep` 0건), `<Link>` 시리즈 라벨 + `pre-wrap` summary + 노트 임시 노출 주석 + ScriptureBlock null-safe 조건 모두 plan과 정합.
 
 ## Claude 2차 검증
 
-- **최종 판단**: 미작성
+- **검토 내용**: 2 파일 staged diff(`git diff --cached`) 교차 확인 + Codex 1차 PASS 13개 항목 검증.
+  - `SermonDetailPage.tsx`(약 150줄, 기존 205줄에서 축소): `useState`/`TABS`/`TabContent`/`Tabs` import + 사용 모두 제거 확인 (`grep`). `SermonMeta`는 sermon 객체 prop으로 통합(개별 8 props → 3 props로 단순화). `<Link href={\`/sermons/series/${series.id}\`}>` 감싸기 — `series` truthy 분기, plain text fallback "단독 설교". `ResourceList` sub-component 분리(현 메인 함수 75줄). `SermonNoteEditor` 페이지 최하단 임시 노출 + 주석으로 D2 의도 명시.
+  - `SermonDetailPage.module.scss`: `.tab_content`/`.tab_panel`/`.empty` 3 클래스 제거. `.summary_text { white-space: pre-line → pre-wrap }` (D4). `.series_tag`에 `align-self: flex-start` + `text-decoration: none` + `hover-color-shift($primary-hover)` 추가. `.series_tag_plain` 신규(단독 설교용 $txt-tertiary).
+- **실행한 검증**: `node scripts/verify-task.mjs sermons-detail-main` (run-id `20260514-192907`) → ✓ 필수 검증 통과 (ESLint / stylelint / Build (next) / Knip).
+  - `logs/sermons-detail-main/20260514-192907/summary.log`: `✓ 필수 검증 통과 (⚠ 경고: Knip — 기존 부채)`.
+  - `git status -s`: M 2 + A 1 — plan §영향받는 파일과 일치 (SermonDetailPage 2 파일 + exec-plan).
+- **남은 항목**: `yarn dev` 수동 검증 (`/sermons/[id]` 진입: 4 케이스 — 시리즈 있음+scripture+resources / 시리즈 없음+scripture / scripture_text 없음 / resources 없음. Tab UI 흔적 0, 시리즈 라벨 클릭 → `/sermons/series/${id}`, summary 줄바꿈 보존, 노트 영역 최하단 노출).
+- **최종 판단**: ✅ **PASS** — verify-task PASS + Codex 1차 PASS + diff 교차 확인 일치. 사용자 yarn dev 수동 검증 후 commit 진행 가능.
 
 ---
 

--- a/docs/exec-plans/active/2026-05-14-sermons-detail-mobile.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-detail-mobile.md
@@ -1,0 +1,114 @@
+# sermons-detail-mobile
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons-detail
+- **Open questions**: none
+- **ADR needed**: no — `SermonDetailPage.tsx/.scss` 모바일 reshuffle만 (ADR_TRIGGER_PARTS 미해당)
+
+## 목표
+
+`/sermons/[id]` 모바일/tablet 순서를 mockup `MDetailBody`(line 327-351) 정합으로 reshuffle. 현재 모바일 stack 순서가 mockup 7(시리즈 회차)→8(같은 설교자)과 다름 — SermonOtherByPreacher가 사이드바 위에 있음. 본 task로 OtherByPreacher를 `main_column` 밖으로 이동 + sidebar 뒤에 배치. 메타 row 모바일 컴팩트.
+
+## 검증된 Assumptions
+
+- 현 `SermonDetailPage.tsx`(Phase 2-3 완료, line 1-160 정도): JSX 구조 `<div layout>` 안 `<div main_column>` (video + info_section incl. OtherByPreacher + Note) + `<SermonSeriesSidebar>` sibling. 모바일 stack 시 순서: video → SermonMeta → Scripture → summary → Resources → **OtherByPreacher** → Note → **Sidebar(회차)**. mockup 순서와 OtherByPreacher/Sidebar 위치 어긋남.
+- mockup `MDetailBody` 8단계 순서(line 338-346): 영상 / 메타 헤더 / 컴팩트 메타 / scripture / summary / 자료 / 시리즈 회차 / 같은 설교자.
+- 현 `.layout_with_sidebar` PC 1024+ grid `1fr 36rem` (Phase 2-2). 본 task 모바일/tablet에서는 stack 유지하되 자식 자매 순서로 mockup 정합.
+- 현 `.meta_row` (`SermonDetailPage.module.scss:60-67`) `flex-wrap: wrap; font-size: $font-size-13`. 모바일 표시 시 두 줄 빈도 — 컴팩트 처리(폰트 11/12로 축소 또는 gap 축소).
+- `SermonNoteEditor`는 mockup 외 자체 기능. 본 task에서도 임시 위치 — `main_column` 끝 그대로 유지 (별도 task로 위치 확정 예정).
+
+## Non-goals
+
+- `<SermonVideoPlayer>` / `<SermonVideoTools>` / `<ScriptureBlock>` / `<SermonSeriesSidebar>` / `<SermonOtherByPreacher>` 자체 수정 — 위치/SCSS 외 props 변경 X
+- 새 모바일 전용 컴포넌트 추가
+- 영상 영역 풀폭 — 이미 LayoutContainer 안 100% width로 풀폭 (mockup 334 자연 충족)
+- 첨부 자료 풀폭 — 이미 `.resource_item` width 100% (mockup 336 자연 충족)
+- `SermonNoteEditor` 위치 결정 (별도 task)
+- PC grid 자체 변경 (Phase 2-2 결과 유지)
+- `[id]/page.tsx` 데이터/server 로직 변경
+
+## Success Criteria
+
+1. **JSX 재배치** — `SermonOtherByPreacher`를 `main_column` 안에서 제거하고 `<div className={styles.layout}>` 안 `<SermonSeriesSidebar>` 다음 sibling으로 이동. 시리즈 없을 때도 동일 위치.
+2. **PC grid 정합** — `.layout_with_sidebar` PC 1024+에서 OtherByPreacher는 `grid-column: 1 / -1`로 row 2 full-width. main_column(row1 col1) + sidebar(row1 col2) + OtherByPreacher(row2 fullwidth).
+3. **시리즈 없을 때 PC** — `.layout` 단일 컬럼 flex(현행). OtherByPreacher는 stack 마지막. grid 미적용.
+4. **모바일/tablet 순서** — stack 자식 순서: video → SermonMeta → Scripture → summary → Resources → SermonNoteEditor(main_column 끝) → SermonSeriesSidebar(있을 때) → SermonOtherByPreacher. mockup 1-6 + 7-8 정합. SermonNoteEditor가 6과 7 사이에 위치하나 mockup 외 기능이라 trade-off(D3).
+5. **메타 row 모바일 컴팩트** — `.meta_row`에 모바일 `font-size: $font-size-12` 또는 `gap: $spacing-4` 축소. 한 줄 우선이되 4-5 span(날짜+service_type+duration+preacher) 시 자연 wrap 허용. mockup line 335 "작은 폰트, 한 줄" 의도.
+6. **검증 통과** — `verify-task.mjs sermons-detail-mobile` PASS + `yarn dev` 수동: PC 1024+ (시리즈 있음) → row1 main+sidebar / row2 OtherByPreacher fullwidth. 모바일 (시리즈 있음) → 1-8 + Note 끼임. 단독 설교 → sidebar 미렌더, OtherByPreacher 그 자리에 표시.
+
+## 영향받는 파일
+
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx` — JSX reshuffle (`<SermonOtherByPreacher>` main_column 밖으로 이동)
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss` — `.layout_with_sidebar`에 `grid-template-columns 1fr 36rem` + `grid-auto-flow: row` 유지 + OtherByPreacher 모듈 클래스에 `grid-column: 1 / -1`. `.meta_row` 모바일 컴팩트.
+- 수정 없음: `SermonOtherByPreacher.tsx/.scss` (위치만 이동, prop 동일) / `SermonSeriesSidebar` / `[id]/page.tsx` / 그 외
+
+## 단계별 체크리스트
+
+- [ ] 1. `SermonDetailPage.tsx`: `<SermonOtherByPreacher>` 컴포넌트를 `main_column` 안 `<SermonNoteEditor>` 위에서 제거하고 `<div className={styles.layout}>` 안 `<SermonSeriesSidebar>` 다음 sibling으로 이동
+- [ ] 2. `SermonDetailPage.module.scss .layout_with_sidebar`: 기존 `grid-template-columns: 1fr 36rem` 유지. row 2에서 OtherByPreacher full-width — `.layout_with_sidebar > :nth-child(3)` 또는 OtherByPreacher 모듈에 modifier 추가 또는 새 클래스 `.other_full_width { grid-column: 1 / -1 }` 추가
+- [ ] 3. `SermonDetailPage.module.scss .meta_row`: 모바일에서 `font-size: $font-size-12; gap: $spacing-4` (`respond-up($breakpoint-tablet)`에서 `font-size: $font-size-13; gap: $spacing-8`로 복귀)
+- [ ] 4. `yarn dev` 수동: PC 1024+ 시리즈 있는 설교 + 시리즈 없는 설교 / 모바일 동일 4 케이스 + 메타 컴팩트 확인
+- [ ] 5. `verify-task.mjs sermons-detail-mobile` 통과
+
+## Verification
+
+```bash
+yarn lint
+yarn lint:styles
+yarn build
+yarn knip
+
+# 수동 (yarn dev)
+# → PC 1024+ 시리즈 있음 — row1: main_column / sidebar / row2: OtherByPreacher full-width 3 카드
+# → PC 1024+ 단독 설교 — 단일 컬럼 stack, OtherByPreacher 본문 아래 3 카드 (PC repeat(3,1fr) 그대로)
+# → 모바일 시리즈 있음 — stack: video / SermonMeta / Scripture / summary / Resources / SermonNoteEditor / SermonSeriesSidebar / SermonOtherByPreacher
+# → 모바일 단독 설교 — stack에서 sidebar 미렌더, OtherByPreacher 그 자리
+# → 모바일 메타 row 한 줄 또는 2 줄 (font 작아짐, gap 좁아짐)
+# → 회차 목록 max-h 480 scroll — 페이지 전체 스크롤과 충돌 0
+
+node scripts/verify-task.mjs sermons-detail-mobile
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS_WITH_DECISION_LOG** (2026-05-14, fresh thread `ae0962aec5dc785b9`)
+
+**Codex verdict** (verbatim 발췌):
+> a) Note는 mockup에 없다는 증거가 plan에 있으므로 차단은 아니지만, summary와 scrutiny의 위치 설명이 서로 달라 decision log가 필요합니다.
+> b) PC series grid에서 `.other_full_width { grid-column: 1 / -1 }`는 plan의 `main_column / sidebar / OtherByPreacher` 구조에 맞고, no-series flex에서는 inert라는 설명도 CSS 동작상 타당합니다.
+> c) `meta_row`는 plan이 `nowrap`을 추가하지 않으므로 4-5개 span에서 줄바꿈이 남고, 한 줄 mockup 의도는 증명되지 않아 overflow를 감수할 근거가 없습니다.
+
+**평이 풀이**: a) Note D3 기록 충분, b) `.other_full_width` 구현 패턴 정합, c) wrap 유지로 mockup "한 줄" 100% 보장 아님 — 모바일 폰트 12 + gap 4 축소만 적용, wrap는 overflow 회피.
+
+## Codex 1차 검증
+
+- **결론**: **PASS** (생략 — Codex 계획 검증 PASS_WITH_DECISION_LOG + 본 task scope = JSX 1줄 위치 swap + SCSS 2 modifier 추가/수정, ADR 0010 위임 트리거 미해당. Claude 2차에서 cover)
+
+## Claude 2차 검증
+
+- **검토 내용**: 2 파일 staged diff(`git diff --cached`) 교차 확인.
+  - `SermonDetailPage.tsx`: `<SermonOtherByPreacher>` 컴포넌트를 `info_section` 안 `<SermonNoteEditor>` 위에서 제거 + `<SermonSeriesSidebar>` 다음 sibling에 `<div className={styles.other_full_width}>` wrapping 후 배치. JSX 자식 순서: main_column / sidebar(시리즈 있을 때) / other_full_width. 노트 주석은 단일 라인으로 정리.
+  - `SermonDetailPage.module.scss`: `.other_full_width { @include respond-up($breakpoint-pc-sm) { grid-column: 1 / -1 } }` 신규 — `.layout_with_sidebar` grid에서 row 2 full-width, 단독 설교 `.layout` flex에서는 inert. `.meta_row` 모바일 기본 `gap: $spacing-4; font-size: $font-size-12`, `respond-up($breakpoint-tablet)`에서 `gap: $spacing-8; font-size: $font-size-13`로 확대 (D4).
+- **실행한 검증**: `node scripts/verify-task.mjs sermons-detail-mobile` (run-id `20260514-203420`) → ✓ 필수 검증 통과 (ESLint / stylelint / Build (next) / Knip).
+  - Knip warn은 SeriesEpisodeList unused 기존 부채(D6, sermons-detail-series-sidebar). 신규 unused 0건.
+- **남은 항목**: `yarn dev` 수동 검증 (PC 1024+ 시리즈 있음 → row1 main+sidebar / row2 OtherByPreacher full-width 3 카드 / 모바일 stack 순서 — video/Meta/Scripture/summary/Resources/Note/Sidebar/OtherByPreacher / 모바일 메타 row 폰트 12·gap 4 컴팩트).
+- **최종 판단**: ✅ **PASS** — verify-task PASS + Codex 계획 검증 PASS_WITH_DECISION_LOG + diff 교차 확인 일치. 사용자 yarn dev 수동 검증 후 commit 진행.
+
+---
+
+## 의사결정 로그 (사전 기록)
+
+- **2026-05-14 D1 — `SermonOtherByPreacher` `main_column` 밖으로 이동**: 현 위치(`main_column` 안 SermonNoteEditor 위)는 모바일 stack에서 mockup 8(같은 설교자)이 7(회차 목록=사이드바) 위에 와서 mockup 순서 어긋남. 해결: `<div className={styles.layout}>` 안 `<SermonSeriesSidebar>` 다음 sibling으로 이동. PC에서는 `grid-column: 1 / -1`로 row 2 full-width — 단일 grid 안에서 3 자식(main_column / sidebar / OtherByPreacher) 자연 배치.
+- **2026-05-14 D2 — PC OtherByPreacher full-width 처리**: `.layout_with_sidebar`가 grid `1fr 36rem`인데 OtherByPreacher만 row 2 full-width 필요. 옵션: (a) `grid-column: 1 / -1` 명시 클래스 `.other_full_width`를 OtherByPreacher 컴포넌트에 추가, (b) `.layout_with_sidebar > :last-child` selector. (a) 채택 — selector 의존도 ↓, 명시적. 컴포넌트 자체에 `<section className={clsx(styles.section, externalClass)}>` 형태로 외부 클래스 받기보다 SermonDetailPage SCSS에 wrapping `<div className={styles.other_full_width}>` 추가.
+- **2026-05-14 D3 — `SermonNoteEditor` 위치 모바일에서 6과 7 사이**: mockup 외 자체 기능. 본 task에서 main_column 끝 유지 — 모바일 stack에서 Resources(6) 뒤 → SermonNoteEditor → Sidebar(7) → OtherByPreacher(8). 노트가 mockup 7-8 사이에 끼임. trade-off: mockup 정합 100%는 노트 별도 위치 결정 후. 본 task는 mockup 7-8 순서 정합 우선, 노트 위치는 별도 후속.
+- **2026-05-14 D4 — 메타 row 모바일 폰트 축소 + gap 축소**: 현 `.meta_row { font-size: $font-size-13; gap: $spacing-8 }` 모바일에서 4-5 span(날짜+service_type+duration+preacher) 두 줄 가능. 모바일 기본 `font-size: $font-size-12; gap: $spacing-4`로 시작 + `respond-up($breakpoint-tablet)`에서 13/8로 확대. 모바일 한 줄 우선이되 wrap 유지.
+- **2026-05-14 D5 — 메타 row `nowrap` 미적용 (Codex CR-c 반영)**: mockup line 335 "작은 폰트, 한 줄" 의도는 `flex-wrap: nowrap`을 함의하나 본 plan은 wrap 유지. 이유: 4-5 span(날짜·service_type·duration·preacher 최대 4) + 한국어 텍스트 길이가 viewport 360px 이하 모바일에서 한 줄 보장 불가, `nowrap` 적용 시 horizontal overflow 위험. trade-off: mockup "한 줄" 100% 미보장 대신 가독성·overflow 회피 우선. 폰트·gap 축소(D4)로 한 줄 발생 확률만 ↑.
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 2-4 (line 327-351)
+- `docs/references/sermons/ChurchSermonAll.jsx` — `MDetailBody`(line 2360+에서 별도 정의)
+- Phase 2-1·2-2·2-3 완료 후 누적 layout 위에서 reshuffle 진행 (`docs/exec-plans/active/2026-05-14-sermons-detail-*.md`)

--- a/docs/exec-plans/active/2026-05-14-sermons-detail-other-sermons.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-detail-other-sermons.md
@@ -1,0 +1,110 @@
+# sermons-detail-other-sermons
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons-detail
+- **Open questions**: none
+- **ADR needed**: no — `_component/` + `SermonDetailPage.tsx` + `[id]/page.tsx` 데이터 추가만 (ADR_TRIGGER_PARTS 미해당, 신규 service method 없음)
+
+## 목표
+
+`/sermons/[id]` 본문 하단(`main_column` 안, `<SermonNoteEditor>` 위)에 "같은 설교자의 다른 설교 3개" 섹션 추가. mockup Phase 2-3(line 307-323) — 가로 row 3개(작은 썸네일 + 제목 + 날짜). 현재 설교 제외, 같은 설교자 다른 설교 3건 이상일 때만 표시.
+
+## 검증된 Assumptions
+
+- `sermon.preacher` 타입 `Preacher | null` (`types/sermon.ts:11-15`). truthy일 때 `preacher.id` 사용 가능.
+- 기존 `getSermons({preacherId, pageSize: N})` 가능 — `SermonListParams.preacherId`(`types/sermon.ts:37-45`) + `sermon-service.ts:76 query.eq('preacher_id', preacherId)`. Phase 1-1 Featured와 동일 server-only static client 패턴.
+- mockup Phase 2-3은 별도 컴포넌트 함수 정의 없음(`grep "function OtherSermons"` 0 hit) — prompt 본문(line 307-323) + standalone sidebar 디자인(line 1219-1276) 차용.
+- mockup 본문 "가로 row 3개" → PC 3 카드 / 모바일 vertical stack 3 카드 (Phase 1-2 recent 카드 비슷 패턴 단순 컴팩트).
+- 본 task에 모바일 분기 포함 — `mobileFullBleed` 없음, 단순 `respond-up` grid 분기 (Phase 2-4 별도 분리하지 않음 — 단순한 grid라 한 task 안 흡수).
+
+## Non-goals
+
+- 시리즈 사이드바 변경 (Phase 2-2 완료, 본 task 무관)
+- mockup `StandaloneSidebar` 우측 사이드바 배치 (사이드바 영역은 시리즈 있을 때만 — Phase 2-2 결정. 단독 설교는 사이드바 미렌더 유지)
+- 새 service method 추가
+- `<SermonVideoPlayer>` / `<ScriptureBlock>` / `<SermonNoteEditor>` 자체 수정
+- mockup의 `Phase 2-3 검증` "모바일에서는 별도 섹션으로 표시" — 본 task에서 모바일도 동일 위치(main_column 안) 노출. 별도 섹션 분리는 Phase 2-4에서
+
+## Success Criteria
+
+1. **신규 컴포넌트** `src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.tsx` + `.module.scss`. props: `{ preacherLabel: string; sermons: SermonWithRelations[] }`. `sermons.length === 0`이면 `return null`.
+2. **레이아웃** — 헤더 h2 "{preacherLabel}의 다른 설교" + 3 카드 grid (PC `grid-template-columns: repeat(3, 1fr)`, 모바일 1 column stack). gap `$content-gap-m`.
+3. **카드 구조** — `<Link href={\`/sermons/${id}\`} draggable={false}>` 래핑, 상단 16:9 썸네일(`<CloudinaryImage fill>` + `cloudinaryFetchUrl`), 하단 텍스트(title `<h3>` 2줄 line-clamp + scripture `$primary` + date `$txt-tertiary`).
+4. **데이터 fetching** — `[id]/page.tsx`에서 `sermon.preacher?.id` truthy 시 `getSermons({preacherId: sermon.preacher.id, pageSize: 4})` 호출. 결과 `filter(s => s.id !== sermon.id).slice(0, 3)` 적용. 3건 미만이면 빈 배열 전달 → 컴포넌트 미렌더.
+5. **위치** — `SermonDetailPage.tsx` `<div className={styles.info_section}>` 안 `<SermonNoteEditor>` 위 (resource list 다음).
+6. **PC drag-ghost 차단** — Phase 1-2 D5 패턴 (Link draggable={false} + SCSS user-select:none + -webkit-user-drag:none + thumb pointer-events:none).
+7. **검증 통과** — `verify-task.mjs sermons-detail-other-sermons` PASS + `yarn dev` 수동: 같은 설교자 ≥3건 설교 / 같은 설교자 2건 이하 / 단독 설교 / 시리즈 있는 설교 4 케이스.
+
+## 영향받는 파일
+
+- 신규: `src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.tsx`
+- 신규: `src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.module.scss`
+- 수정: `src/app/(content)/sermons/[id]/page.tsx` — `getSermons({preacherId, pageSize: 4})` 추가 호출 + filter/slice + prop 전달
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx` — `otherSermonsByPreacher` prop 추가, `<SermonOtherByPreacher>` 배치
+
+## 단계별 체크리스트
+
+- [ ] 1. `SermonOtherByPreacher.tsx` — 카드 3개 grid, `<Link>` 래핑, CloudinaryImage 썸네일, drag-ghost 차단
+- [ ] 2. `SermonOtherByPreacher.module.scss` — semantic 토큰만 (`$bg-card`/`$border-card`/`$radius-s`/`$primary`/`$txt-*`). PC `grid-template-columns: repeat(3, 1fr)` / 모바일 `1fr`
+- [ ] 3. `[id]/page.tsx` — preacher id로 `getSermons` 호출 + filter/slice + prop 전달
+- [ ] 4. `SermonDetailPage.tsx` — `otherSermonsByPreacher: SermonWithRelations[]` prop 추가, `<SermonNoteEditor>` 위에 `<SermonOtherByPreacher preacherLabel={preacherLabel} sermons={otherSermonsByPreacher} />` 배치
+- [ ] 5. `yarn dev` 수동 — 4 케이스 + 카드 클릭 → `/sermons/${id}` 이동
+- [ ] 6. `verify-task.mjs sermons-detail-other-sermons` 통과
+
+## Verification
+
+```bash
+yarn lint
+yarn lint:styles
+yarn build
+yarn knip
+
+# 수동 (yarn dev)
+# → 같은 설교자 ≥3건 설교 /sermons/[id] — 섹션 표시 (3 카드)
+# → 같은 설교자 2건 이하 — 섹션 미렌더 (return null)
+# → 단독 설교(시리즈 없음) — 섹션 표시 (사이드바 없으므로 본문 100% width grid 3)
+# → 시리즈 있는 설교 — 사이드바 옆 main_column 안 섹션 표시 (grid 3 fit)
+# → 카드 클릭 → /sermons/${id} 이동 / 드래그 → ghost 없음
+
+node scripts/verify-task.mjs sermons-detail-other-sermons
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS_WITH_DECISION_LOG** (2026-05-14, fresh thread `a774d0679b1bbbdd0`)
+- **5체크**: 1·2·3·4 OK, 5 새 추상화 사실상 없음(신규 컴포넌트 1, service 0).
+
+**Codex verdict** (verbatim 발췌):
+> a. `page.tsx`: `getSermonById` 뒤 `getSermonsBySeries`와 `getSermons({ preacherId })`는 서로 독립이므로 순차 await는 TTFB를 늘릴 수 있음. 권장: sermon 로드 후 두 호출을 `Promise.all`로 묶기.
+> b. `pageSize:4 → filter(current id) → slice(0,3)`: "same-preacher count ≥ 3"을 "현재 설교 제외 3개 이상"으로 해석하면 맞음. 권장: 결정 로그에 "current 제외 기준" 명시.
+> c. "mobile shows as separate section"은 1fr stack인지, mobile에서 위치 이동인지 모호함. 권장: 위치는 `main_column` above `SermonNoteEditor`로 고정한다고 결정 로그에 남기기.
+
+**평이 풀이**: a) `[id]/page.tsx`에서 series + preacher 두 fetch를 `Promise.all`로 병렬 → TTFB 단축. b) "≥3건" 기준이 현재 제외 후라는 점 명시. c) 모바일에서 별도 섹션 이동 아닌 단순 1fr stack(동일 위치)이라는 점 명시.
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+
+## Claude 2차 검증
+
+- **최종 판단**: 미작성
+
+---
+
+## 의사결정 로그 (사전 기록)
+
+- **2026-05-14 D1 — `getSermons({preacherId, pageSize:4})` 직접 호출 vs 신규 service method**: 신규 method `getOtherSermonsByPreacher` 추가하면 cache key 분리 가능하나 ADR 0010 외과적 변경 위반. Phase 1-1 Featured 동일 패턴(`getSermons({pageSize:1})`) 채택. cache는 `sermon-cache.ts list()` 공유(1day revalidate). pageSize:4로 1건 buffer + slice 3로 현재 설교 제외.
+- **2026-05-14 D2 — 본 task에 모바일 grid 분기 포함**: mockup Phase 2-4가 모바일 별도 처리 명시이나 본 컴포넌트의 PC 3 grid → 모바일 1 column stack은 `respond-up`만으로 단순 처리 가능. Phase 2-4의 모바일 분기는 사이드바 위치 + 메타 압축 등 더 큰 변경이라 본 단순 grid는 본 task 안 흡수.
+- **2026-05-14 D3 — Phase 1-2 D5 drag-ghost 차단 패턴 재적용**: PC `<Link>` 카드 wrap의 anchor native drag ghost는 Phase 1-2에서 사용자 검증 발견. 본 카드도 동일 처리 (`draggable={false}` + SCSS user-select/-webkit-user-drag/pointer-events). 카드 디자인 컨벤션화.
+- **2026-05-14 D4 — `Promise.all`로 series + preacher 병렬 fetch (Codex CR-a 반영)**: 1차 plan은 `[id]/page.tsx` 현 코드(`getSermonById` → `getSermonsBySeries` 순차)에 `getSermons({preacherId})`만 추가하는 형태였음. Codex 지적 — 둘은 독립이라 순차 await는 TTFB 증가. 해결: sermon 로드 후 `Promise.all([getSermonsBySeries(...), getSermons({preacherId, pageSize: 4})])` 병렬화. 같은 sermon 페이지 진입 시 2 fetch 병렬 → 단일 fetch 시간(서비스 단 더 느린 쪽)으로 단축.
+- **2026-05-14 D5 — "3건 이상" 기준은 현재 설교 제외 후 (Codex CR-b 반영)**: mockup line 318 "3개 이상 있을 때만"의 해석. `pageSize: 4` fetch 후 `filter(s => s.id !== sermon.id)` 적용한 결과가 ≥3건일 때 표시. 정확히 4건이면 현재 1건 제외 → 3건 노출, 컴포넌트 `sermons.length === 0` 분기 외 별도 ≥3 게이트 X. 단 SermonOtherByPreacher가 3 카드만 렌더(slice(0,3))라 결과가 1-2건이면 카드 1-2개만 노출 — 본 plan은 그 경우도 미렌더 처리? 결정: `≥3건일 때만 렌더`를 `[id]/page.tsx`에서 `result.length === 3`이면 컴포넌트에 prop 전달, 미만이면 빈 배열로 전달해 `return null`.
+- **2026-05-14 D6 — 모바일 위치 main_column 안 동일 (Codex CR-c 반영)**: mockup Phase 2-3 검증 "모바일에서는 별도 섹션으로 표시" — 본 plan은 별도 섹션 분리 X, `main_column` 안 `SermonNoteEditor` 위 동일 위치 유지. 모바일 변경은 grid 1fr stack 뿐. 더 큰 모바일 layout reshuffle은 Phase 2-4 별도.
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 2-3 (line 307-323)
+- `docs/references/sermons/ChurchSermonAll.jsx` — StandaloneSidebar(line 1219-1276)에서 row 디자인 차용
+- Phase 1-2 D5 drag-ghost 패턴 / Phase 2-2 사이드바 톤 통일 D8 (완료 후 묶음 PR)

--- a/docs/exec-plans/active/2026-05-14-sermons-detail-series-sidebar.md
+++ b/docs/exec-plans/active/2026-05-14-sermons-detail-series-sidebar.md
@@ -1,0 +1,157 @@
+# sermons-detail-series-sidebar
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-14
+- **브랜치**: feat/sermons-detail
+- **Open questions**: none
+- **ADR needed**: no — `_component/` + `SermonDetailPage.tsx/.scss` (ADR_TRIGGER_PARTS 미해당)
+
+## 목표
+
+`/sermons/[id]` 데스크톱 layout을 grid `1fr 360px`로 변경하고 우측에 시리즈 사이드바(`SermonSeriesSidebar`) 신규 컴포넌트를 추가. 사이드바는 mockup `SeriesSidebar`(line 1120-1217) 디자인 — 시리즈 카드(SERIES 라벨 + 제목 + description + 메타 border-top) + 자체 회차 목록(max-h 480 scroll, grid 32/1fr/auto, 현재 회차 강조). 시리즈 있는 설교만 사이드바 표시.
+
+## 검증된 Assumptions
+
+- 현 `SermonDetailPage.tsx`(150줄, Phase 2-1 완료): `.layout`이 flex column 단일. `<SeriesEpisodeList>`로 회차 목록 본문 흐름 끝에 노출.
+- 현 `SermonDetailPage.module.scss .layout` line 5-18: `display:flex; flex-direction:column; gap:$content-gap-m`. 데스크톱에서도 stack. 본 task에서 PC grid로 분기.
+- mockup `DetailPCBody`(line 1278-1289): `grid-template-columns: 1fr 360px; gap: 32px`. 모바일은 1fr stack 자연.
+- mockup `SeriesSidebar`(line 1120-1217): 시리즈 카드 + 회차 목록 (max-h 480 overflow auto). 현재 회차 강조 (gold 번호 / bold 제목 / primary play 원형).
+- `sermon.sermon_series` truthy일 때만 사이드바. `seriesEpisodes` prop은 이미 `[id]/page.tsx`(line 71)에서 `getSermonsBySeries` 결과로 전달됨.
+- 기존 `<SeriesEpisodeList>`는 본 task에서 SermonDetailPage 사용 제거. 컴포넌트 디렉토리 보존 — Phase 2-4 모바일 회차 목록 재사용 후보.
+- `$bg-secondary` `$bg-card` `$border-card` `$accent` `$primary` `$txt-primary` `$txt-secondary` `$txt-tertiary` 토큰 있음 (Phase 1-3 확인).
+
+## Non-goals
+
+- 모바일·tablet 사이드바 위치 변경 (Phase 2-4 — 본 task는 PC `respond-up($breakpoint-pc-sm)`(1024)에서 grid 적용, 1023px 이하는 stack 단순)
+- 같은 설교자의 다른 설교 (Phase 2-3 mockup `StandaloneSidebar`)
+- `<SeriesEpisodeList>` 자체 수정 또는 삭제 (디렉토리 보존)
+- `<SermonVideoPlayer>` / `<SermonVideoTools>` / `<ScriptureBlock>` / `<SermonNoteEditor>` 자체 수정
+- `[id]/page.tsx` 로직 변경 (server data fetching 그대로)
+- 신규 데이터/service 추가 (`seriesEpisodes`는 이미 prop으로 전달됨)
+- 신규 spacing 토큰 추가
+
+## Success Criteria
+
+1. **신규 컴포넌트** `src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx` + `.module.scss`. props: `{ series: SermonSeries; episodes: SermonWithRelations[]; currentSermonId: number; onSelect: (s: SermonWithRelations) => void }`. 'use client' (onSelect callback). `episodes.length === 0`이면 `return null`.
+2. **시리즈 카드** — "SERIES" eyebrow($accent, letter-spacing wide) + h3 series.title + description(있을 때) + border-top 메타(`formattedDate(started_at)` ~ `ended_at ? formattedDate : "진행 중"` · `episodes.length`편).
+3. **회차 목록 카드** — 헤더 "전체 회차 (N편)" + 스크롤 영역 max-h 480px overflow-y auto. 각 row: grid `$spacing-32 1fr auto` (번호/제목+날짜·duration/현재 play 원형). 현재 회차(`ep.id === currentSermonId`): 번호 `$accent`, 제목 `$txt-primary` bold, 우측 `$primary` 원형 play 아이콘. 다른 회차: 번호 `$txt-tertiary`, 제목 `$txt-secondary`.
+4. **현재 회차 클릭 disable** — `aria-current="true"` + `onClick` 무동작 (또는 `disabled` attr). mockup line 1175 `isCurrent` 시각 강조만.
+5. **layout grid 변경** — `SermonDetailPage.module.scss .layout`에 modifier 클래스 `.layout_with_sidebar` 추가. `respond-up($breakpoint-pc-sm)` (1024px)에서 `display: grid; grid-template-columns: 1fr 360px; gap: $section-gap-40 $content-gap-xl`. 768~1023px 구간(tablet)은 stack — 본문 380px overflow 회피(D5). 모바일 + tablet 모두 flex column.
+6. **시리즈 없을 때 PC 그리드 1단** — `sermon.sermon_series` falsy면 modifier 클래스 미부여(`.layout`만). 단일 컬럼. JSX 적용: `<div className={clsx(styles.layout, hasSeries && styles.layout_with_sidebar)}>`. Phase 2-3 standalone sidebar 추가 시 갱신 예정.
+7. **`<SeriesEpisodeList>` 사용 제거** — SermonDetailPage에서 import + 렌더 제거. 컴포넌트 파일은 보존(`docs/tech-debt-tracker.md`에 본 task 머지 직후 항목 등록 — Phase 2-4 사용 가능성 + 정리 deadline). Knip warn 1건 신규는 기존 패턴(`✓ 필수 검증 통과 (⚠ 경고: Knip — 기존 부채, 커밋 차단 안 됨)`)과 동일 — verify-task PASS 차단 안 됨(D6).
+8. **검증 통과** — `verify-task.mjs sermons-detail-series-sidebar` PASS + `yarn dev` 수동: 시리즈 있는 설교 → 우측 사이드바(PC) / 본문 아래 stack(모바일). 단독 설교 → 사이드바 미렌더. 회차 클릭 → 다른 설교로 이동. 현재 회차 클릭 비활성.
+
+## 영향받는 파일
+
+- 신규: `src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx` (client)
+- 신규: `src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.module.scss`
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx` — `<SeriesEpisodeList>` import + 사용 제거, `<SermonSeriesSidebar>` import + 우측 배치
+- 수정: `src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss` — `.layout`에 PC grid 추가, 시리즈 분기 클래스 또는 `.info_section`/`.sidebar_section` 분리
+
+## 단계별 체크리스트
+
+- [ ] 1. `SermonSeriesSidebar.tsx` — 시리즈 카드 + 회차 목록 단일 컴포넌트. props 위 정의, currentSermonId로 강조 분기
+- [ ] 2. `SermonSeriesSidebar.module.scss` — 시리즈 카드(`$bg-secondary`/`$radius-s`/`$padding-card`) + 회차 목록 카드(`$bg-card`/`$radius-s`/scroll) + 현재 회차 강조
+- [ ] 3. `SermonDetailPage.tsx` — `<SeriesEpisodeList>` 제거, `<SermonSeriesSidebar series={sermon.sermon_series} episodes={seriesEpisodes} currentSermonId={sermon.id} onSelect={handleEpisodeSelect} />` 추가. `handleViewAllSeries`는 사이드바 내부에서 사용 안 함 — 별도 제공 X
+- [ ] 4. `SermonDetailPage.module.scss .layout` — `respond-up($breakpoint-tablet)`에서 grid 1fr 360px (시리즈 있을 때) / 1fr (시리즈 없을 때). 클래스 분기 또는 modifier 클래스 사용
+- [ ] 5. `yarn dev` 수동 — 4 케이스 (시리즈+PC / 시리즈+모바일 / 단독+PC / 단독+모바일) + 회차 클릭 + 현재 회차 클릭 비활성
+- [ ] 6. `verify-task.mjs sermons-detail-series-sidebar` 통과
+
+## Verification
+
+```bash
+yarn lint
+yarn lint:styles
+yarn build
+yarn knip
+
+# 수동
+# → /sermons/[id] 시리즈 있음 PC — 좌 본문 / 우 360px 사이드바(시리즈 카드 + 회차 목록 scroll)
+# → /sermons/[id] 시리즈 있음 모바일 — stack (본문 ↓ 사이드바)
+# → /sermons/[id] 단독 설교 PC — 사이드바 미렌더, 본문 100% width
+# → 회차 row 클릭 → router.push(/sermons/${ep.id})
+# → 현재 회차 row — gold 번호 + bold 제목 + primary play 원형, 클릭 비활성(`aria-current` 또는 disabled)
+# → 회차 8건 이상 — max-h 480 scroll 작동
+
+node scripts/verify-task.mjs sermons-detail-series-sidebar
+```
+
+---
+
+## Codex 계획 검증
+
+- **결론**: **PASS_WITH_DECISION_LOG** (2026-05-14, 1차 CR thread `afceffdadce0926fa` → 2차 PARTIAL thread `a2f49b544780da1c4`. 2차에서 "수정 후 재검증 없이 구현 진입 가능" 명시 — 잔존 plan-text consistency 본 갱신으로 정리 완료, expression-only로 분류해 PASS_WITH_DECISION_LOG verdict 기록 + WORK 진입)
+
+### 1차 — CHANGE_REQUEST (2026-05-14)
+
+**Codex verdict** (verbatim):
+> 1. grid 시작 breakpoint — `$breakpoint-tablet`(768px)은 너무 좁음. 768~1024px 구간에서 사이드바 360px + gap 32px = 본문 376px로 영상/본문 overflow 가능. SC#5에 grid 시작점을 `$breakpoint-pc-sm`(또는 구체 px)으로 명시하거나, `minmax(0, 360px)`로 사이드바를 수축 허용하도록 수정 필요.
+> 2. Knip warn 충돌 해소 — SC#8 "verify-task PASS"와 D4 "파일 보존" 사이의 Knip warn 처리 방침을 exec-plan에 명시. 허용 부채로 등록(tech-debt-tracker.md)하거나, Phase 2-4 전까지 더미 import로 경고 0 유지 중 하나를 결정해야 합니다.
+
+**평이 풀이**: a) 1024 미만 PC 폭에서 grid 376~600px 본문이 영상 16:9 + 텍스트와 충돌. b) SeriesEpisodeList unused 파일 보존이 Knip warn을 만들어 verify-task PASS 정의와 충돌.
+
+**반영**:
+- (a) SC#5 grid 시작점 `$breakpoint-pc-sm`(1024)로 상향. 의사결정 로그 D5 신규 — 768~1023 stack 유지, 1024+에서 grid.
+- (b) SC#7에 `tech-debt-tracker.md` 등록 + Knip warn 허용 PASS 조건 명시. 의사결정 로그 D6 신규.
+- SC#6에 `clsx(styles.layout, hasSeries && styles.layout_with_sidebar)` JSX 예시 1줄 추가.
+
+### 2차 — PARTIAL → PASS-level (2026-05-14)
+
+**Codex verdict** (verbatim 발췌):
+> c) RESOLVED — SC#7/D6가 파일 보존, `sermons-series-episode-list-unused` post-merge 등록, Knip warn 허용 PASS 조건을 함께 명시해 충돌 해소됐습니다.
+> a) PARTIAL — SC#5/D5는 `$breakpoint-pc-sm` 1024px로 수정됐고 토큰 값도 맞지만, Non-goals/체크리스트/D2 등 plan 내 `$breakpoint-tablet` 잔존 문구가 있어 1024px 결정과 모순됩니다.
+> b) PARTIAL — `sermon.sermon_series` truthy 기반 modifier 분기는 코드베이스 `clsx(styles.x, cond && styles.y)` 관례와 맞지만, plan 본문에 `clsx` 예시 코드가 실제로 없어 구현자가 패턴을 명확히 파악하기 어렵습니다.
+> 두 항목은 plan 텍스트 수정만으로 해소 가능합니다. 수정 후 재검증 없이 구현 진입 가능한 수준입니다.
+
+**평이 풀이**: c material CR은 해소. a/b는 plan 본문에 `$breakpoint-tablet` 잔존 + clsx 예시 부재 — expression-only consistency 문제. Codex가 "재검증 없이 진입 가능" 명시 → 본 갱신으로 (i) Non-goals 문구 `$breakpoint-pc-sm`(1024)로 정정, (ii) D2 표현 정리, (iii) SC#6에 clsx 예시 추가 완료. expression-only로 PASS_WITH_DECISION_LOG verdict 발급 + WORK 진입.
+
+## Codex 1차 검증
+
+- **결론**: **CHANGE_REQUEST → FIX_APPLIED** (Claude 1줄 fix, 2026-05-14, fresh thread `a0365aff5d4c808a9`)
+- **검토 범위**: 4 파일 staged diff (`SermonSeriesSidebar.tsx` + `.module.scss` 신규 + `SermonDetailPage.tsx` + `.module.scss` 수정)
+
+**Codex verdict** (verbatim 발췌):
+> P1 `SermonSeriesSidebar.tsx:61` `!isCurrent` onClick guard는 `disabled`가 이미 click을 막으므로 **죽은 코드**. 제거 권장.
+> P1 `series &&` 이중 guard — `hasSeriesSidebar`만으로 TS narrowing 불충분, series 타입이 null 포함이므로 이중 guard는 필요하고 충분함.
+> P2 둘 다 `'use client'`. RSC 경계 위반 없음.
+> P3 staged diff 정확히 4개(M 2, A 2). SeriesEpisodeList delete diff 없음(보존).
+> P4 hardcoded: `36rem` 1회 사용 local var 선택사항, `1px` border 일반적, `0.4` opacity 하드코딩, max-height local var 사용 확인, align-items: start 의도 명확, D5 `$breakpoint-pc-sm` 사용 확인.
+
+**평이 풀이**: P1·P2·P3 모두 OK. P1 dead code 1건만 material — `<button disabled={isCurrent}>`가 이미 click 차단하므로 `!isCurrent &&` onClick guard는 중복. P4 하드코딩 3건은 expression — `36rem`(1회 사용), `1px border`(SCSS 표준), `0.4 opacity`(기존 SermonDetailPage `.dot` 동일 패턴).
+
+**반영**:
+- (P1 material) `SermonSeriesSidebar.tsx:61` onClick `() => !isCurrent && onSelect(ep)` → `() => onSelect(ep)` (1줄)
+- (P4 expression) 그대로 유지 — `36rem` 1회 사용 + 기존 `.dot opacity 0.4` 패턴 일관 (의사결정 로그 D7)
+
+## Claude 2차 검증
+
+- **검토 내용**: 5 파일 staged diff(`git diff --cached`) + Codex 1차 결과(P1·P2·P3 PASS + P4 expression-only + dead code 1건 fix 적용) 교차 확인.
+  - `SermonSeriesSidebar.tsx`(82줄): `<aside>` 2 카드 구조. summary card (eyebrow SERIES + h2 title + description p + meta border-top 5 span). list card (header "전체 회차 (N편)" + `<ul>` + `<button disabled={isCurrent} aria-current onClick={() => onSelect(ep)}>` 4 child grid). dead code `!isCurrent` 가드 제거 확인.
+  - `SermonSeriesSidebar.module.scss`(~180줄): semantic 토큰 + local var 1(`$episode-list-max-height: 48rem`). `.episode_row_current { background-color: $primary-subtle }` 강조. `.order_num`/`.title` nested current 분기로 색·굵기 분기. `hover-bg-shift($bg-hover)` 적용. min-width: 0 + ellipsis로 가로 overflow 회피.
+  - `SermonDetailPage.tsx`(+5줄/-9줄): SeriesEpisodeList import + 사용 + handleViewAllSeries 모두 제거. clsx import 추가. layout JSX 재배치 — `<div className={clsx(styles.layout, hasSeriesSidebar && styles.layout_with_sidebar)}>` 안에 `<div className={styles.main_column}>`(video + info) + `<SermonSeriesSidebar>` 자매 배치. series 이중 guard 정합(TS null narrowing).
+  - `SermonDetailPage.module.scss`(+18줄): `.layout_with_sidebar { @include respond-up($breakpoint-pc-sm) { display:grid; grid-template-columns: 1fr 36rem; align-items: start; gap: $section-gap-40 $content-gap-xl } }` + `.main_column` 신규. 기존 `.layout` 보존 (모바일/tablet 단일 컬럼).
+- **실행한 검증**: `node scripts/verify-task.mjs sermons-detail-series-sidebar` 재실행(dead code fix 반영 후) → ✓ 필수 검증 통과 (ESLint / stylelint / Build (next) / Knip).
+  - 첫 run(`20260514-195336`) PASS, fix 후 재실행 PASS — log 별도 run-id.
+  - Knip 경고 1건 추가 — `<SeriesEpisodeList>` 사용 제거로 컴포넌트 unused. D6 합의대로 기존 부채 동일 패턴 통과. 별도 `docs/tech-debt-tracker.md` 항목 등록 (Phase 2-4 재사용 또는 정리 deadline).
+- **남은 항목**: `yarn dev` 수동 검증 (시리즈 있는 설교 PC 1024+ → grid 1fr 360px / 모바일·tablet → stack / 단독 설교 → 사이드바 미렌더, 회차 클릭 → `/sermons/${ep.id}` / 현재 회차 disabled).
+- **최종 판단**: ✅ **PASS** — verify-task PASS + Codex 1차 P1-P4 + dead code 1건 fix + diff 교차 확인 일치. 사용자 yarn dev 수동 검증 후 commit + tech-debt 등록 진행.
+
+---
+
+## 의사결정 로그 (사전 기록)
+
+- **2026-05-14 D1 — `SermonSeriesSidebar` 신규 vs `SeriesEpisodeList` 확장**: 기존 SeriesEpisodeList는 ListItem + 5 visible + "전체 N편 보기" 버튼 패턴(별도 페이지 push). mockup 사이드바는 시리즈 카드 + 자체 회차 목록(scroll) 통합 단일 컴포넌트. 시각·동작 차이 큼 → 신규 컴포넌트로 분리. SeriesEpisodeList 파일은 디렉토리 보존(Phase 2-4 모바일 회차 목록에서 재사용 후보).
+- **2026-05-14 D2 — `1fr 360px` 고정 vs `1fr minmax`**: mockup `DetailPCBody` line 1282은 `1fr 360px` 고정. 본 plan 채택. trade-off: 1024px PC 폭에서 본문 width = 1024 - 360 - 32(gap) - $container-padding *2 = 약 520-600px로 영상 16:9 height ~330px OK. grid 진입 시점은 D5에서 `$breakpoint-pc-sm`(1024)로 확정. 부족 시 별도 토큰 도입.
+- **2026-05-14 D3 — 회차 목록 max-h 480 + scroll 유지**: mockup line 1173 그대로. trade-off: 회차 30건 이상이면 사이드바 안 scroll 깊어짐 — 사용자 회차 검색 어려움. 본 task는 mockup 디자인 정합 우선, 회차 30+ 시리즈는 별도 검색·필터 UX 후속 결정.
+- **2026-05-14 D4 — `<SeriesEpisodeList>` 디렉토리 보존**: SermonDetailPage 사용 제거 후 파일은 unused. Knip warn 1건 추가 가능 — 그러나 Phase 2-4 모바일에서 시리즈 회차 목록(별도 UX, scroll 외)로 재사용 후보. 본 task에서 디렉토리 삭제 X. Phase 2-4 완료 시점에 진짜 unused면 그때 정리.
+- **2026-05-14 D5 — grid 시작 breakpoint `$breakpoint-pc-sm`(1024) 채택 (Codex CR-a 반영)**: 1차 plan은 `$breakpoint-tablet`(768)에서 grid 시작. Codex 지적 — 768~1023px 구간에서 본문 width = viewport - 360(사이드바) - 32(gap) - $container-padding *2 = 약 376~600px로 영상 16:9 + 텍스트 padding overflow 위험. 해결: grid 시작점을 `$breakpoint-pc-sm`(1024)로 올림. 1024px에서 본문 ~520-600px 확보(영상 16:9 height ~330px OK). 768~1023 구간은 stack 유지(`mobileFullBleed` 캐러셀 없는 detail page라 stack overflow 0).
+- **2026-05-14 D6 — Knip warn 처리 (Codex CR-c 반영)**: 1차 plan SC#7 "파일 보존" + D4 "Knip warn 1건 추가 가능" vs SC#8 "verify-task PASS" 충돌. 해결: (a) 본 task 머지 직후 `docs/tech-debt-tracker.md`에 항목 등록 (slug: `sermons-series-episode-list-unused`, deadline: Phase 2-4 완료 시점) — 추적 명시. (b) verify-task는 Knip warn을 차단 없이 통과(`logs/<task-id>/summary.log` 기존 패턴 동일 — `⚠ 경고: Knip — 기존 부채, 커밋 차단 안 됨`). plan SC#8 "PASS" 조건은 lint·build·stylelint 통과 + Knip warn 부채 허용 의미로 일관 유지.
+- **2026-05-14 D7 — Codex 1차 P4 expression 분류**: `36rem`(1회 사용)/`1px border`(SCSS 표준)/`0.4 opacity`(기존 SermonDetailPage `.dot` 동일 패턴) 하드코딩 3건은 expression-only — 신규 토큰 추가 없이 그대로 유지. Codex `align-items: start`·D5 `$breakpoint-pc-sm` 사용 확인.
+- **2026-05-14 D8 — 사이드바 톤 통일 (사용자 수동 검증 발견)**: 1차 구현에서 `.summary_card { $bg-secondary }`(warm cream) + `.list_card { $bg-card }`(white) + `.list_header { $bg-secondary }`로 사이드바 안에 warm/white 톤 혼재 — styles SKILL warm vs cool 역할 분리 룰 위반(정적 사이드바는 단일 톤). 해결: `.summary_card`·`.list_header` 모두 `$bg-card`(white)로 통일. 두 카드 시각 분리는 컨테이너 gap(`$spacing-12`) + border 만으로. mockup `C.toneSoft`의 warm bg 의도는 dnchurch warm/cool 룰과 충돌 — dnchurch 룰 우선.
+
+## 참고 자료
+
+- `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 2-2 (line 276-303)
+- `docs/references/sermons/ChurchSermonAll.jsx` — `SeriesSidebar`(line 1120-1217), `DetailPCBody`(line 1278-1289)
+- Phase 2-1 완료: SermonDetailPage 150줄 순차 layout (본 task 위 layout grid 변경)
+- Phase 1-3 카드 경로 컨벤션: `/sermons/series/${id}` (의사결정 로그 D7)

--- a/docs/exec-plans/completed/2026-05-14-sermons-main-layout.md
+++ b/docs/exec-plans/completed/2026-05-14-sermons-main-layout.md
@@ -84,11 +84,28 @@ node scripts/verify-task.mjs sermons-main-layout
 
 ## Codex 1차 검증
 
-- **결론**: 미요청
+- **결론**: **PASS** (2026-05-14, fresh thread `a7a06c6114b0ef9f3`)
+- **검토 범위**: 2 파일 staged diff (`page.module.scss` 신규 5줄 + `page.tsx` 2줄 수정)
+
+**Codex verdict** (verbatim):
+> P1 Bugs/types: PASS — styles import, token injection, className 병합은 모두 [ASSUMED from project rules]로 충족.
+> P2 Layer: PASS — RSC의 `.module.scss` 사용은 [ASSUMED from project rules] 허용, client boundary 필요 없음.
+> P3 Surgical: PASS — `page.tsx`는 import와 `className` 변경만 보이며, 기존 로직은 diff summary상 변경 없음.
+> P4 Token: PASS — SCSS 3개 값은 semantic token으로 보이고, D1/D2 구현은 제공된 decision log와 일치.
+
+**평이 풀이**: 4 priority 모두 PASS — token injection(`$section-gap-40`/`$spacing-24`/`$spacing-40`)이 globals.scss additionalData로 작동, `LayoutContainer`의 `clsx` className 병합 정합, RSC `.module.scss` 사용 OK, surgical change (2 파일 / 2 + 5줄).
 
 ## Claude 2차 검증
 
-- **최종 판단**: 미작성
+- **검토 내용**: 2 파일 staged diff(`git diff --cached`) 교차 확인 + Codex 1차 PASS 검증.
+  - `page.module.scss`(5줄): `.sections { display:flex; flex-direction:column; gap:$section-gap-40; padding-block: $spacing-24 $spacing-40 }`. 하드코딩 0건, 토큰 3종 모두 globals 반응형(`var(--*)`).
+  - `page.tsx`(+2줄): `import styles from './page.module.scss'` + `<LayoutContainer className={styles.sections}>` 1 attr. 기존 로직(redirect/Promise.all 3-tuple/filter dedup/3 컴포넌트 배치) 모두 유지. 인접 정리 0.
+  - **branch 정정 절차**: 작업 중간에 git 환경 불일치(`refactor/harness-codex-review-cap` branch에서 stash apply로 conflict 발생) 발견 → `git checkout HEAD --` 4 파일 복원 → `git switch feat/sermons` → Phase 1-4 변경 page.tsx에 재적용. 최종 검증은 올바른 branch `feat/sermons` HEAD `191a635` 위에서 수행.
+- **실행한 검증**: `node scripts/verify-task.mjs sermons-main-layout` (run-id `20260514-190038`, `feat/sermons` branch) → ✓ 필수 검증 통과 (ESLint / stylelint / Build (next) / Knip).
+  - `logs/sermons-main-layout/20260514-190038/summary.log`: `✓ 필수 검증 통과 (⚠ 경고: Knip — 기존 부채)`.
+  - `git status -s`: A 3 (page.module.scss + page.tsx M + exec-plan A) — plan §영향받는 파일과 일치.
+- **남은 항목**: `yarn dev` 수동 검증 (`/sermons` 진입: Hero 정상, 3 섹션 사이 vertical gap 가시적, page top/bottom padding 적용, 모바일에서도 spacing 작동 + mobileFullBleed 좌우 -16 충돌 0).
+- **최종 판단**: ✅ **PASS** — verify-task PASS + Codex 1차 PASS + branch 정정 후 diff 교차 확인 일치. 사용자 yarn dev 수동 검증 후 commit 진행 가능.
 
 ---
 
@@ -98,3 +115,17 @@ node scripts/verify-task.mjs sermons-main-layout
 - `docs/references/sermons/ChurchSermonAll.jsx` — `ListPCHero`(line 795-803), `ListPCBody`(line 968-986), `MListBanner`(line 2207-2213), `MListBody`(line 2352-2370)
 - `src/components/layout/Hero/hero.config.ts:14` — 기존 `/sermons` HeroMeta 자동 적용
 - `src/components/layout/container/LayoutContainer.tsx` + `.module.scss` — horizontal padding/max-width만, vertical은 page 책임
+
+## 회고 (필수 5필드)
+
+- KPI / 시작-종료 (분): ~45 (단순 SCSS 1 + page.tsx 2줄 + branch 정정 후속)
+- KPI / Codex 라운드: 2 (계획 PASS_WITH_DECISION_LOG `a0cff5d1` + 1차 PASS `a7a06c61`)
+- KPI / material 사후 발견: 0 (branch mishap은 process error로 별도 분류, 자동 검증으로 자체 정정)
+- KPI / harness-gate placeholder fail: 0
+- KPI / 사용자 검토 부족 피드백: 0
+
+## 회고
+
+- 잘된 것: 작업 자체는 외과적(SCSS 1 + page.tsx 2줄). Codex 양 라운드 PASS, 의사결정 로그 D1-D2로 expression-only 분리.
+- 다음에 할 것: 다중 branch 진행 시 작업 시작 전 `git branch --show-current` 1회 확인 — 본 task에서 `refactor/harness-codex-review-cap`에 stash apply로 conflict 발생, 자동 검증 후 자체 정정. 사전 차단 가능.
+- 발견된 부채: 모바일 단일 토큰 `$section-gap-40` 사용(D1) — 사용자 피드백 누적 시 모바일 전용 `$section-gap-24` 등 도입 검토.

--- a/docs/exec-plans/completed/2026-05-14-sermons-recent-carousel.md
+++ b/docs/exec-plans/completed/2026-05-14-sermons-recent-carousel.md
@@ -134,3 +134,17 @@ node scripts/verify-task.mjs sermons-recent-carousel
 - `docs/references/sermons/ChurchSermonAll.jsx` — `SermonCarouselCard`(line 728-789), `ListPCRecent`(line 894-928), `MListRecent`(line 2272-2304)
 - `src/components/ui/Carousel/Carousel.tsx` (Phase 0 산출) — `useCarousel`/`<CarouselArrows>`/`<Carousel>` 3 export
 - Phase 1-1 completed: `docs/exec-plans/completed/2026-05-14-sermons-featured.md` — `getSermons({pageSize:1})` 의사결정 로그(동일 이유로 본 plan도 `getSermons({pageSize:8})` 채택)
+
+## 회고 (필수 5필드)
+
+- KPI / 시작-종료 (분): ~75 (ADR 0010 적용 첫 task — plan 1라운드 + Codex 1차 1라운드 + verify + D5 후속 fix)
+- KPI / Codex 라운드: 2 (계획 PASS_WITH_DECISION_LOG `a53154d6` + 1차 PASS `aa657e5d`)
+- KPI / material 사후 발견: 1 (D5 PC `<Link>` ghost image drag 버벅임 — 사용자 수동 검증)
+- KPI / harness-gate placeholder fail: 0
+- KPI / 사용자 검토 부족 피드백: 0
+
+## 회고
+
+- 잘된 것: Phase 1-1 SermonFeatured 패턴 재사용으로 카드 컴포넌트 작성 비용 ↓. ADR 0010 compact plan + PASS_WITH_DECISION_LOG가 expression-only 지적 3건(D1-D3)을 plan 갱신 라운드 없이 흡수.
+- 다음에 할 것: 후속 캐러셀 task부터 PC `<Link>` 카드 wrap에는 처음부터 `draggable={false}` + SCSS drag-ghost 차단 패턴 default 적용 (D5 재발 차단).
+- 발견된 부채: `sermon-cache.ts list()` revalidate 1day vs `recent()` 1hour 차이 (D1) — 새 설교 등록 시 admin action에서 `sermon-list` tag revalidate 누락되면 메인이 최대 24h stale. 운영 모니터링 항목.

--- a/docs/exec-plans/completed/2026-05-14-sermons-series-carousel.md
+++ b/docs/exec-plans/completed/2026-05-14-sermons-series-carousel.md
@@ -150,3 +150,17 @@ node scripts/verify-task.mjs sermons-series-carousel
 - `docs/references/sermons/Sermon-Implementation-Prompts.md` Phase 1-3 (line 195-219)
 - `docs/references/sermons/ChurchSermonAll.jsx` — `SeriesGridCard`(line 594-642), `ListPCSeriesPreview`(line 930-966)
 - Phase 1-2: `docs/exec-plans/completed/2026-05-14-sermons-recent-carousel.md`(머지 후 이동) — Carousel 사용 패턴 + D5 drag-ghost 차단 (본 plan D4 재사용)
+
+## 회고 (필수 5필드)
+
+- KPI / 시작-종료 (분): ~90 (plan CR 1라운드 + Codex 1차 CR 1건 + D7 경로 정정 후속 fix + verify 3회)
+- KPI / Codex 라운드: 3 (계획 1차 CHANGE_REQUEST `a0eeb1aa` → 2차 PASS `a9d3bc39` + 1차 CR→FIX_APPLIED `a6f62440`)
+- KPI / material 사후 발견: 2 (description null → meta_bar margin-top auto 누락 Codex 발견 / `/series` → `/sermons/series` 경로 사용자 검증 발견)
+- KPI / harness-gate placeholder fail: 0
+- KPI / 사용자 검토 부족 피드백: 0
+
+## 회고
+
+- 잘된 것: Codex CR 1차 3건(D5 filter / D6 scrim / D7 calc 검증)을 plan 수정으로 즉시 해소하여 2차 PASS. ADR 0010 verdict matrix가 material vs expression 분리에 효과적.
+- 다음에 할 것: 새 라우트 경로는 컴포넌트 link 작성 전 `ls src/app/(content)/<route>/` 또는 mockup vs 실제 디렉토리 1회 확인 — D7 사용자 발견 차단.
+- 발견된 부채: `sermon_series.cover_tone` 컬럼 부재 (D1) + `sermon_series` 안 preacher 직접 컬럼 부재 (D2) — Phase 5 시리즈 상세 페이지 작업 시 정식 컬럼 추가 또는 시리즈-설교자 집계 쿼리 결정.

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -319,4 +319,13 @@
 - **확인**: 변경 1줄. 빌드/lint PASS
 - **참고**: sermon 자료 단일 50MB 한도(`src/lib/sermon-resource.ts`)는 운영상 차단 사례 미확인 — 발생 시 별도 부채로 등록
 
-<!-- last-audit: 2026-05-11 -->
+### 🟢 `<SeriesEpisodeList>` 컴포넌트 unused (sermons-detail-series-sidebar 머지 이후)
+
+- **상태**: 🟢 마이그레이션 가능
+- **무엇**: `src/app/(content)/sermons/_component/SeriesEpisodeList/SeriesEpisodeList.tsx` + `.module.scss` — 본 컴포넌트는 PR #90(`feat/sermons-detail`)에서 `SermonDetailPage`의 회차 목록 노출을 `<SermonSeriesSidebar>`로 이관하며 사용처가 사라짐
+- **왜**: 1차 의도(sermons-detail-series-sidebar D4 / Codex CR-c)는 Phase 2-4 모바일 회차 목록에서 재사용 후보로 보존이었으나, Phase 2-4 mobile reshuffle도 동일 PR에 흡수되어 `SermonSeriesSidebar`가 모바일 stack에서도 시리즈 회차 책임 → 본 컴포넌트 재사용처 0건 확정
+- **마이그레이션 경로**: 별도 task에서 (a) 디렉토리 + module SCSS 삭제 + Knip warn 정리, (b) 다른 use case(예: 어드민 사이드 패널 회차 목록) 발견 시 그 task에서 재사용
+- **영향 범위**: `src/app/(content)/sermons/_component/SeriesEpisodeList/` (2 파일, 약 100줄)
+- **발견일**: 2026-05-14 (PR #90 Codex 객관 리뷰 발견)
+
+<!-- last-audit: 2026-05-14 -->

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -6,7 +6,7 @@ import {
   getSermonsBySeries,
   incrementSermonViewCount
 } from '@/services/sermon';
-import { getSermonThumbnail } from '@/utils/sermon';
+import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
 import type { SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
 
@@ -20,9 +20,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   if (!sermon) return {};
 
   const title = sermon.title;
-  const preacherLabel = sermon.preacher
-    ? `${sermon.preacher.name}${sermon.preacher.title ? ` ${sermon.preacher.title}` : ''}`
-    : '';
+  const preacherLabel = formatPreacherLabel(sermon.preacher);
   const description = sermon.summary ?? `${preacherLabel}의 설교`;
   const thumbnail = getSermonThumbnail(sermon);
 

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -1,6 +1,11 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import { getSermonById, getSermonsBySeries, incrementSermonViewCount } from '@/services/sermon';
+import {
+  getSermonById,
+  getSermons,
+  getSermonsBySeries,
+  incrementSermonViewCount
+} from '@/services/sermon';
 import { getSermonThumbnail } from '@/utils/sermon';
 import type { SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
@@ -63,10 +68,20 @@ export default async function SermonDetail({ params }: PageProps) {
 
   if (!sermon) notFound();
 
-  let seriesEpisodes: SermonWithRelations[] = [];
-  if (sermon.sermon_series?.slug) {
-    seriesEpisodes = await getSermonsBySeries(sermon.sermon_series.slug);
-  }
+  // 시리즈 회차 + 같은 설교자 다른 설교를 병렬 fetch (의사결정 로그 D4 — sermons-detail-other-sermons).
+  // 같은 설교자 ≥3건일 때만 노출 (현재 설교 제외 후 기준, D5). pageSize 4 = 현재 1건 buffer + 최대 3건 노출.
+  const [seriesEpisodes, otherByPreacher] = await Promise.all([
+    sermon.sermon_series?.slug
+      ? getSermonsBySeries(sermon.sermon_series.slug)
+      : Promise.resolve([] as SermonWithRelations[]),
+    sermon.preacher?.id
+      ? getSermons({ preacherId: sermon.preacher.id, pageSize: 4 }).then((res) =>
+          res.sermons.filter((s) => s.id !== sermon.id).slice(0, 3)
+        )
+      : Promise.resolve([] as SermonWithRelations[])
+  ]);
+
+  const otherSermonsByPreacher = otherByPreacher.length === 3 ? otherByPreacher : [];
 
   incrementSermonViewCount(sermon.id).catch(() => {});
 
@@ -78,7 +93,11 @@ export default async function SermonDetail({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <SermonDetailPage sermon={sermon} seriesEpisodes={seriesEpisodes} />
+      <SermonDetailPage
+        sermon={sermon}
+        seriesEpisodes={seriesEpisodes}
+        otherSermonsByPreacher={otherSermonsByPreacher}
+      />
     </>
   );
 }

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
@@ -27,6 +27,13 @@
   }
 }
 
+// SermonOtherByPreacher row 2 full-width (sermons-detail-mobile D2). 단독 설교 flex layout에서는 inert.
+.other_full_width {
+  @include respond-up($breakpoint-pc-sm) {
+    grid-column: 1 / -1;
+  }
+}
+
 .main_column {
   display: flex;
   flex-direction: column;
@@ -92,9 +99,14 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: $spacing-8;
-  font-size: $font-size-13;
+  gap: $spacing-4;
+  font-size: $font-size-12;
   color: $txt-tertiary;
+
+  @include respond-up($breakpoint-tablet) {
+    gap: $spacing-8;
+    font-size: $font-size-13;
+  }
 }
 
 .dot {

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
@@ -17,6 +17,27 @@
   }
 }
 
+// 시리즈 사이드바 동반 시 PC 1024+에서 grid 1fr 360px (의사결정 로그 D5)
+.layout_with_sidebar {
+  @include respond-up($breakpoint-pc-sm) {
+    display: grid;
+    grid-template-columns: 1fr 36rem;
+    align-items: start;
+    gap: $section-gap-40 $content-gap-xl;
+  }
+}
+
+.main_column {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+  min-width: 0;
+
+  @include respond-up($breakpoint-pc-sm) {
+    gap: $content-gap-l;
+  }
+}
+
 .video_section {
   display: flex;
   flex-direction: column;

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
@@ -1,3 +1,6 @@
+// 데스크톱 시리즈 사이드바 폭 — mockup `DetailPCBody` line 1282 (`1fr 360px`)
+$sidebar-width: 36rem;
+
 // ══════════════════════════════════════════
 // Layout
 // ══════════════════════════════════════════
@@ -21,7 +24,7 @@
 .layout_with_sidebar {
   @include respond-up($breakpoint-pc-sm) {
     display: grid;
-    grid-template-columns: 1fr 36rem;
+    grid-template-columns: 1fr $sidebar-width;
     align-items: start;
     gap: $section-gap-40 $content-gap-xl;
   }

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.module.scss
@@ -40,9 +40,19 @@
 }
 
 .series_tag {
+  align-self: flex-start;
   font-size: $font-size-13;
   font-weight: $font-weight-semibold;
   color: $primary;
+  text-decoration: none;
+
+  @include hover-color-shift($primary-hover);
+}
+
+.series_tag_plain {
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $txt-tertiary;
 }
 
 .sermon_title {
@@ -85,28 +95,14 @@
 }
 
 // ══════════════════════════════════════════
-// Tabs & Content
+// Summary
 // ══════════════════════════════════════════
-
-.tab_content {
-  min-height: 12rem;
-}
-
-.tab_panel {
-  padding: $spacing-16 0;
-}
 
 .summary_text {
   font-size: $font-size-14;
   line-height: $line-height-loose;
   color: $txt-secondary;
-  white-space: pre-line;
-}
-
-.empty {
-  font-size: $font-size-14;
-  color: $txt-tertiary;
-  font-style: italic;
+  white-space: pre-wrap; // admin UI 입력값의 줄바꿈 보존 (의사결정 로그 D4)
 }
 
 // ══════════════════════════════════════════

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { IoDocumentTextOutline, IoDownloadOutline } from 'react-icons/io5';
 import { LayoutContainer } from '@/components/layout';
 import SermonVideoPlayer from '../SermonVideoPlayer/SermonVideoPlayer';
 import SermonVideoTools from '../SermonVideoTools/SermonVideoTools';
-import { Tabs } from '@/components/ui';
 import ScriptureBlock from '../ScriptureBlock/ScriptureBlock';
 import SermonNoteEditor from '../SermonNoteEditor/SermonNoteEditor';
 import SeriesEpisodeList from '../SeriesEpisodeList/SeriesEpisodeList';
@@ -15,13 +14,6 @@ import { formatSermonDuration } from '@/utils/sermon';
 import type { SermonWithRelations, SermonResource } from '@/types/sermon';
 import styles from './SermonDetailPage.module.scss';
 
-const TABS = [
-  { id: 'summary', label: '요약' },
-  { id: 'scripture', label: '본문' },
-  { id: 'resources', label: '자료' },
-  { id: 'notes', label: '노트' }
-];
-
 type Props = {
   sermon: SermonWithRelations;
   seriesEpisodes: SermonWithRelations[];
@@ -29,12 +21,10 @@ type Props = {
 
 export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
   const router = useRouter();
-  const [activeTab, setActiveTab] = useState('summary');
 
   const preacherLabel = sermon.preacher
     ? `${sermon.preacher.name}${sermon.preacher.title ? ` ${sermon.preacher.title}` : ''}`
     : '';
-  const seriesTitle = sermon.sermon_series?.title;
   const duration = formatSermonDuration(sermon.duration);
   const hasSeriesEpisodes = seriesEpisodes.length > 0;
   const activeResources = sermon.sermon_resources.filter((r) => !r.deleted_at);
@@ -53,38 +43,44 @@ export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
     <LayoutContainer>
       <div className={styles.layout}>
         <div className={styles.video_section}>
-          <SermonVideoPlayer
-            videoId={sermon.video_id}
-            title={sermon.title}
-          />
+          <SermonVideoPlayer videoId={sermon.video_id} title={sermon.title} />
           <SermonVideoTools sermonId={String(sermon.id)} />
         </div>
 
         <div className={styles.info_section}>
           <SermonMeta
-            seriesTitle={seriesTitle}
-            seriesOrder={sermon.series_order}
-            title={sermon.title}
-            date={sermon.sermon_date}
-            preacher={preacherLabel}
-            scripture={sermon.scripture}
+            sermon={sermon}
+            preacherLabel={preacherLabel}
             duration={duration}
-            serviceType={sermon.service_type}
           />
-          <Tabs variant="underline" items={TABS} activeId={activeTab} onChange={setActiveTab} />
-          <TabContent activeTab={activeTab} sermon={sermon} resources={activeResources} />
+
+          {sermon.scripture && sermon.scripture_text && (
+            <ScriptureBlock
+              scriptureRef={sermon.scripture}
+              scriptureText={sermon.scripture_text}
+            />
+          )}
+
+          {sermon.summary && (
+            <p className={styles.summary_text}>{sermon.summary}</p>
+          )}
+
+          {activeResources.length > 0 && <ResourceList resources={activeResources} />}
+
           {hasSeriesEpisodes && (
             <SeriesEpisodeList
               currentSermonId={sermon.id}
               sermons={seriesEpisodes}
-              seriesTitle={seriesTitle ?? '시리즈'}
+              seriesTitle={sermon.sermon_series?.title ?? '시리즈'}
               onSelect={handleEpisodeSelect}
               onViewAll={handleViewAllSeries}
             />
           )}
+
+          {/* 노트는 mockup에 없으나 dnchurch 자체 기능. 임시 페이지 최하단 노출 (의사결정 로그 D2 — 별도 task로 위치 확정 예정) */}
+          <SermonNoteEditor sermonId={String(sermon.id)} />
         </div>
       </div>
-
     </LayoutContainer>
   );
 }
@@ -92,110 +88,71 @@ export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
 /* ── Sub-components ── */
 
 type SermonMetaProps = {
-  seriesTitle: string | undefined;
-  seriesOrder: number | null;
-  title: string;
-  date: string;
-  preacher: string;
-  scripture: string | null;
+  sermon: SermonWithRelations;
+  preacherLabel: string;
   duration: string | null;
-  serviceType: string;
 };
 
-function SermonMeta({
-  seriesTitle,
-  seriesOrder,
-  title,
-  date,
-  preacher,
-  scripture,
-  duration,
-  serviceType
-}: SermonMetaProps) {
+function SermonMeta({ sermon, preacherLabel, duration }: SermonMetaProps) {
+  const series = sermon.sermon_series;
+  const seriesOrder = sermon.series_order;
+
   return (
     <div className={styles.meta_block}>
-      <span className={styles.series_tag}>
-        {seriesTitle ? `${seriesTitle} · 제${seriesOrder ?? '?'}편` : '단독 설교'}
-      </span>
-      <h1 className={styles.sermon_title}>{title}</h1>
+      {series ? (
+        <Link href={`/sermons/series/${series.id}`} className={styles.series_tag}>
+          {series.title} · 제{seriesOrder ?? '?'}편
+        </Link>
+      ) : (
+        <span className={styles.series_tag_plain}>단독 설교</span>
+      )}
+      <h1 className={styles.sermon_title}>{sermon.title}</h1>
+      {sermon.scripture && <span className={styles.scripture_tag}>{sermon.scripture}</span>}
       <div className={styles.meta_row}>
-        <span>{formattedDate(date, 'YYYY년 MM월 DD일')}</span>
+        <span>{formattedDate(sermon.sermon_date, 'YYYY년 MM월 DD일')}</span>
         <Dot />
-        <span>{preacher}</span>
+        <span>{sermon.service_type}</span>
+        {duration && (
+          <>
+            <Dot />
+            <span>{duration}</span>
+          </>
+        )}
         <Dot />
-        <span>{serviceType}</span>
+        <span>{preacherLabel}</span>
       </div>
-      {scripture && <span className={styles.scripture_tag}>{scripture}</span>}
     </div>
   );
 }
 
-type TabContentProps = {
-  activeTab: string;
-  sermon: SermonWithRelations;
+type ResourceListProps = {
   resources: SermonResource[];
 };
 
-function TabContent({ activeTab, sermon, resources }: TabContentProps) {
+function ResourceList({ resources }: ResourceListProps) {
   return (
-    <div className={styles.tab_content} role="tabpanel">
-      {activeTab === 'summary' && (
-        <div className={styles.tab_panel}>
-          {sermon.summary ? (
-            <p className={styles.summary_text}>{sermon.summary}</p>
-          ) : (
-            <p className={styles.empty}>등록된 요약이 없습니다</p>
-          )}
-        </div>
-      )}
-
-      {activeTab === 'scripture' && (
-        <div className={styles.tab_panel}>
-          {sermon.scripture ? (
-            <ScriptureBlock scriptureRef={sermon.scripture} scriptureText={sermon.scripture_text} />
-          ) : (
-            <p className={styles.empty}>등록된 본문이 없습니다</p>
-          )}
-        </div>
-      )}
-
-      {activeTab === 'resources' && (
-        <div className={styles.tab_panel}>
-          {resources.length > 0 ? (
-            <ul className={styles.resource_list}>
-              {resources.map((res) => (
-                <li key={res.id}>
-                  <a
-                    href={res.file_url}
-                    className={styles.resource_item}
-                    download
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <IoDocumentTextOutline className={styles.resource_icon} aria-hidden="true" />
-                    <div className={styles.resource_info}>
-                      <span className={styles.resource_title}>{res.title}</span>
-                      {res.file_type && (
-                        <span className={styles.resource_type}>{res.file_type.toUpperCase()}</span>
-                      )}
-                    </div>
-                    <IoDownloadOutline className={styles.resource_download} aria-hidden="true" />
-                  </a>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className={styles.empty}>등록된 자료가 없습니다</p>
-          )}
-        </div>
-      )}
-
-      {activeTab === 'notes' && (
-        <div className={styles.tab_panel}>
-          <SermonNoteEditor sermonId={String(sermon.id)} />
-        </div>
-      )}
-    </div>
+    <ul className={styles.resource_list}>
+      {resources.map((res) => (
+        <li key={res.id}>
+          <a
+            href={res.file_url}
+            className={styles.resource_item}
+            download
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <IoDocumentTextOutline className={styles.resource_icon} aria-hidden="true" />
+            <div className={styles.resource_info}>
+              <span className={styles.resource_title}>{res.title}</span>
+              {res.file_type && (
+                <span className={styles.resource_type}>{res.file_type.toUpperCase()}</span>
+              )}
+            </div>
+            <IoDownloadOutline className={styles.resource_download} aria-hidden="true" />
+          </a>
+        </li>
+      ))}
+    </ul>
   );
 }
 

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -10,6 +10,7 @@ import SermonVideoTools from '../SermonVideoTools/SermonVideoTools';
 import ScriptureBlock from '../ScriptureBlock/ScriptureBlock';
 import SermonNoteEditor from '../SermonNoteEditor/SermonNoteEditor';
 import SermonSeriesSidebar from '../SermonSeriesSidebar/SermonSeriesSidebar';
+import SermonOtherByPreacher from '../SermonOtherByPreacher/SermonOtherByPreacher';
 import { formattedDate } from '@/utils/date';
 import { formatSermonDuration } from '@/utils/sermon';
 import type { SermonWithRelations, SermonResource } from '@/types/sermon';
@@ -18,9 +19,14 @@ import styles from './SermonDetailPage.module.scss';
 type Props = {
   sermon: SermonWithRelations;
   seriesEpisodes: SermonWithRelations[];
+  otherSermonsByPreacher: SermonWithRelations[];
 };
 
-export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
+export default function SermonDetailPage({
+  sermon,
+  seriesEpisodes,
+  otherSermonsByPreacher
+}: Props) {
   const router = useRouter();
 
   const preacherLabel = sermon.preacher
@@ -63,6 +69,11 @@ export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
             )}
 
             {activeResources.length > 0 && <ResourceList resources={activeResources} />}
+
+            <SermonOtherByPreacher
+              preacherLabel={preacherLabel}
+              sermons={otherSermonsByPreacher}
+            />
 
             {/* 노트는 mockup에 없으나 dnchurch 자체 기능. 임시 페이지 최하단 노출 (의사결정 로그 D2 — 별도 task로 위치 확정 예정) */}
             <SermonNoteEditor sermonId={String(sermon.id)} />

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -70,12 +70,7 @@ export default function SermonDetailPage({
 
             {activeResources.length > 0 && <ResourceList resources={activeResources} />}
 
-            <SermonOtherByPreacher
-              preacherLabel={preacherLabel}
-              sermons={otherSermonsByPreacher}
-            />
-
-            {/* 노트는 mockup에 없으나 dnchurch 자체 기능. 임시 페이지 최하단 노출 (의사결정 로그 D2 — 별도 task로 위치 확정 예정) */}
+            {/* 노트는 mockup에 없으나 dnchurch 자체 기능. 임시 위치 — 별도 task로 위치 확정 예정 (sermons-detail-main D2) */}
             <SermonNoteEditor sermonId={String(sermon.id)} />
           </div>
         </div>
@@ -88,6 +83,13 @@ export default function SermonDetailPage({
             onSelect={handleEpisodeSelect}
           />
         )}
+
+        <div className={styles.other_full_width}>
+          <SermonOtherByPreacher
+            preacherLabel={preacherLabel}
+            sermons={otherSermonsByPreacher}
+          />
+        </div>
       </div>
     </LayoutContainer>
   );

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import clsx from 'clsx';
 import { IoDocumentTextOutline, IoDownloadOutline } from 'react-icons/io5';
 import { LayoutContainer } from '@/components/layout';
@@ -12,7 +11,7 @@ import SermonNoteEditor from '../SermonNoteEditor/SermonNoteEditor';
 import SermonSeriesSidebar from '../SermonSeriesSidebar/SermonSeriesSidebar';
 import SermonOtherByPreacher from '../SermonOtherByPreacher/SermonOtherByPreacher';
 import { formattedDate } from '@/utils/date';
-import { formatSermonDuration } from '@/utils/sermon';
+import { formatPreacherLabel, formatSermonDuration } from '@/utils/sermon';
 import type { SermonWithRelations, SermonResource } from '@/types/sermon';
 import styles from './SermonDetailPage.module.scss';
 
@@ -27,19 +26,11 @@ export default function SermonDetailPage({
   seriesEpisodes,
   otherSermonsByPreacher
 }: Props) {
-  const router = useRouter();
-
-  const preacherLabel = sermon.preacher
-    ? `${sermon.preacher.name}${sermon.preacher.title ? ` ${sermon.preacher.title}` : ''}`
-    : '';
+  const preacherLabel = formatPreacherLabel(sermon.preacher);
   const duration = formatSermonDuration(sermon.duration);
   const series = sermon.sermon_series;
   const hasSeriesSidebar = Boolean(series) && seriesEpisodes.length > 0;
   const activeResources = sermon.sermon_resources.filter((r) => !r.deleted_at);
-
-  const handleEpisodeSelect = (ep: SermonWithRelations) => {
-    router.push(`/sermons/${ep.id}`);
-  };
 
   return (
     <LayoutContainer>
@@ -80,7 +71,6 @@ export default function SermonDetailPage({
             series={series}
             episodes={seriesEpisodes}
             currentSermonId={sermon.id}
-            onSelect={handleEpisodeSelect}
           />
         )}
 

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -2,13 +2,14 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import clsx from 'clsx';
 import { IoDocumentTextOutline, IoDownloadOutline } from 'react-icons/io5';
 import { LayoutContainer } from '@/components/layout';
 import SermonVideoPlayer from '../SermonVideoPlayer/SermonVideoPlayer';
 import SermonVideoTools from '../SermonVideoTools/SermonVideoTools';
 import ScriptureBlock from '../ScriptureBlock/ScriptureBlock';
 import SermonNoteEditor from '../SermonNoteEditor/SermonNoteEditor';
-import SeriesEpisodeList from '../SeriesEpisodeList/SeriesEpisodeList';
+import SermonSeriesSidebar from '../SermonSeriesSidebar/SermonSeriesSidebar';
 import { formattedDate } from '@/utils/date';
 import { formatSermonDuration } from '@/utils/sermon';
 import type { SermonWithRelations, SermonResource } from '@/types/sermon';
@@ -26,60 +27,56 @@ export default function SermonDetailPage({ sermon, seriesEpisodes }: Props) {
     ? `${sermon.preacher.name}${sermon.preacher.title ? ` ${sermon.preacher.title}` : ''}`
     : '';
   const duration = formatSermonDuration(sermon.duration);
-  const hasSeriesEpisodes = seriesEpisodes.length > 0;
+  const series = sermon.sermon_series;
+  const hasSeriesSidebar = Boolean(series) && seriesEpisodes.length > 0;
   const activeResources = sermon.sermon_resources.filter((r) => !r.deleted_at);
 
   const handleEpisodeSelect = (ep: SermonWithRelations) => {
     router.push(`/sermons/${ep.id}`);
   };
 
-  const handleViewAllSeries = () => {
-    if (sermon.sermon_series?.slug) {
-      router.push(`/sermons/all?series=${sermon.sermon_series.slug}`);
-    }
-  };
-
   return (
     <LayoutContainer>
-      <div className={styles.layout}>
-        <div className={styles.video_section}>
-          <SermonVideoPlayer videoId={sermon.video_id} title={sermon.title} />
-          <SermonVideoTools sermonId={String(sermon.id)} />
+      <div className={clsx(styles.layout, hasSeriesSidebar && styles.layout_with_sidebar)}>
+        <div className={styles.main_column}>
+          <div className={styles.video_section}>
+            <SermonVideoPlayer videoId={sermon.video_id} title={sermon.title} />
+            <SermonVideoTools sermonId={String(sermon.id)} />
+          </div>
+
+          <div className={styles.info_section}>
+            <SermonMeta
+              sermon={sermon}
+              preacherLabel={preacherLabel}
+              duration={duration}
+            />
+
+            {sermon.scripture && sermon.scripture_text && (
+              <ScriptureBlock
+                scriptureRef={sermon.scripture}
+                scriptureText={sermon.scripture_text}
+              />
+            )}
+
+            {sermon.summary && (
+              <p className={styles.summary_text}>{sermon.summary}</p>
+            )}
+
+            {activeResources.length > 0 && <ResourceList resources={activeResources} />}
+
+            {/* 노트는 mockup에 없으나 dnchurch 자체 기능. 임시 페이지 최하단 노출 (의사결정 로그 D2 — 별도 task로 위치 확정 예정) */}
+            <SermonNoteEditor sermonId={String(sermon.id)} />
+          </div>
         </div>
 
-        <div className={styles.info_section}>
-          <SermonMeta
-            sermon={sermon}
-            preacherLabel={preacherLabel}
-            duration={duration}
+        {hasSeriesSidebar && series && (
+          <SermonSeriesSidebar
+            series={series}
+            episodes={seriesEpisodes}
+            currentSermonId={sermon.id}
+            onSelect={handleEpisodeSelect}
           />
-
-          {sermon.scripture && sermon.scripture_text && (
-            <ScriptureBlock
-              scriptureRef={sermon.scripture}
-              scriptureText={sermon.scripture_text}
-            />
-          )}
-
-          {sermon.summary && (
-            <p className={styles.summary_text}>{sermon.summary}</p>
-          )}
-
-          {activeResources.length > 0 && <ResourceList resources={activeResources} />}
-
-          {hasSeriesEpisodes && (
-            <SeriesEpisodeList
-              currentSermonId={sermon.id}
-              sermons={seriesEpisodes}
-              seriesTitle={sermon.sermon_series?.title ?? '시리즈'}
-              onSelect={handleEpisodeSelect}
-              onViewAll={handleViewAllSeries}
-            />
-          )}
-
-          {/* 노트는 mockup에 없으나 dnchurch 자체 기능. 임시 페이지 최하단 노출 (의사결정 로그 D2 — 별도 task로 위치 확정 예정) */}
-          <SermonNoteEditor sermonId={String(sermon.id)} />
-        </div>
+        )}
       </div>
     </LayoutContainer>
   );

--- a/src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.module.scss
+++ b/src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.module.scss
@@ -1,0 +1,94 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+  padding-top: $section-gap-40;
+  border-top: 1px solid $border-subtle;
+}
+
+.title {
+  margin: 0;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+  letter-spacing: $letter-spacing-body;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $content-gap-m;
+
+  @include respond-up($breakpoint-tablet) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  // PC drag-ghost 차단 (Phase 1-2 D5)
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.thumb_box {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  background: $overlay-image;
+  overflow: hidden;
+}
+
+.thumb {
+  object-fit: cover;
+  -webkit-user-drag: none;
+  pointer-events: none;
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-6;
+  padding: $spacing-12 $spacing-16;
+}
+
+.card_title {
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $txt-primary;
+  line-height: $line-height-snug;
+  word-break: keep-all;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: $spacing-4;
+  font-size: $font-size-11;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+}
+
+.scripture {
+  color: $primary;
+  font-weight: $font-weight-semibold;
+}
+
+.dot {
+  opacity: 0.4;
+}
+
+.date {
+  font-variant-numeric: tabular-nums;
+}

--- a/src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.tsx
+++ b/src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import type { SermonWithRelations } from '@/types/sermon';
+import { cloudinaryFetchUrl } from '@/utils/cloudinary';
+import { getSermonThumbnail } from '@/utils/sermon';
+import { formattedDate } from '@/utils/date';
+import styles from './SermonOtherByPreacher.module.scss';
+
+type Props = {
+  preacherLabel: string;
+  sermons: SermonWithRelations[];
+};
+
+export default function SermonOtherByPreacher({ preacherLabel, sermons }: Props) {
+  if (sermons.length === 0) return null;
+
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.title}>{preacherLabel}의 다른 설교</h2>
+      <div className={styles.grid}>
+        {sermons.map((sermon) => (
+          <OtherCard key={sermon.id} sermon={sermon} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function OtherCard({ sermon }: { sermon: SermonWithRelations }) {
+  const thumb = cloudinaryFetchUrl(getSermonThumbnail(sermon));
+
+  return (
+    <Link href={`/sermons/${sermon.id}`} className={styles.card} draggable={false}>
+      <div className={styles.thumb_box}>
+        {thumb && (
+          <CloudinaryImage
+            src={thumb}
+            alt={sermon.title}
+            fill
+            sizes="(min-width: 768px) 33vw, 100vw"
+            className={styles.thumb}
+          />
+        )}
+      </div>
+      <div className={styles.body}>
+        <h3 className={styles.card_title}>{sermon.title}</h3>
+        <div className={styles.meta}>
+          {sermon.scripture && <span className={styles.scripture}>{sermon.scripture}</span>}
+          {sermon.scripture && <span className={styles.dot} aria-hidden="true">·</span>}
+          <span className={styles.date}>{formattedDate(sermon.sermon_date, 'YYYY.MM.DD')}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.module.scss
+++ b/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.module.scss
@@ -108,30 +108,25 @@ $episode-list-max-height: 48rem;
   grid-template-columns: $spacing-32 1fr auto;
   gap: $spacing-10;
   align-items: center;
-  width: 100%;
   padding: $spacing-12 $spacing-16;
-  background: transparent;
-  border: none;
   border-bottom: 1px solid $border-subtle;
-  text-align: left;
-  cursor: pointer;
+  text-decoration: none;
   color: inherit;
+  // PC drag-ghost 차단 (Phase 1-2 D5 패턴)
+  -webkit-user-drag: none;
 
   &:last-child {
     border-bottom: none;
   }
+}
 
-  &:not(:disabled) {
-    @include hover-bg-shift($bg-hover);
-  }
-
-  &:disabled {
-    cursor: default;
-  }
+.episode_row:not(.episode_row_current) {
+  @include hover-bg-shift($bg-hover);
 }
 
 .episode_row_current {
   background-color: $primary-subtle;
+  cursor: default;
 }
 
 .order_num {

--- a/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.module.scss
+++ b/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.module.scss
@@ -1,0 +1,192 @@
+// 회차 목록 최대 height — mockup `SeriesSidebar` line 1173 (max-h 480 overflow auto)
+$episode-list-max-height: 48rem;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-12;
+}
+
+// ══════════════════════════════════════════
+// Summary card (시리즈 메타)
+// ══════════════════════════════════════════
+
+.summary_card {
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  padding: $padding-card;
+}
+
+.eyebrow {
+  margin-bottom: $spacing-8;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  letter-spacing: $letter-spacing-wide;
+  color: $accent;
+}
+
+.series_title {
+  margin: 0 0 $spacing-8;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+  letter-spacing: $letter-spacing-body;
+  word-break: keep-all;
+}
+
+.series_description {
+  margin: 0 0 $spacing-12;
+  font-size: $font-size-12;
+  color: $txt-secondary;
+  line-height: $line-height-body-reading;
+  word-break: keep-all;
+}
+
+.summary_meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-4;
+  padding-top: $spacing-12;
+  border-top: 1px solid $border-subtle;
+  font-size: $font-size-11;
+  color: $txt-secondary;
+  font-variant-numeric: tabular-nums;
+}
+
+.dot {
+  opacity: 0.4;
+}
+
+.meta_ongoing {
+  color: $primary;
+  font-weight: $font-weight-bold;
+}
+
+.meta_completed {
+  color: $txt-secondary;
+}
+
+.count {
+  color: $txt-primary;
+  font-weight: $font-weight-bold;
+}
+
+// ══════════════════════════════════════════
+// Episode list card
+// ══════════════════════════════════════════
+
+.list_card {
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  overflow: hidden;
+}
+
+.list_header {
+  padding: $spacing-12 $spacing-16;
+  border-bottom: 1px solid $border-subtle;
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $txt-primary;
+}
+
+.episode_list {
+  display: flex;
+  flex-direction: column;
+  max-height: $episode-list-max-height;
+  overflow-y: auto;
+}
+
+.episode_row {
+  display: grid;
+  grid-template-columns: $spacing-32 1fr auto;
+  gap: $spacing-10;
+  align-items: center;
+  width: 100%;
+  padding: $spacing-12 $spacing-16;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid $border-subtle;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:not(:disabled) {
+    @include hover-bg-shift($bg-hover);
+  }
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+.episode_row_current {
+  background-color: $primary-subtle;
+}
+
+.order_num {
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+
+  .episode_row_current & {
+    color: $accent;
+  }
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  min-width: 0;
+}
+
+.title {
+  font-size: $font-size-12;
+  font-weight: $font-weight-medium;
+  color: $txt-secondary;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  .episode_row_current & {
+    color: $txt-primary;
+    font-weight: $font-weight-bold;
+  }
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: $spacing-4;
+  font-size: $font-size-11;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+}
+
+.meta_dot {
+  opacity: 0.4;
+}
+
+.play_indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $spacing-20;
+  height: $spacing-20;
+  border-radius: $radius-circle;
+  background-color: $primary;
+  color: $txt-inverse;
+}

--- a/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx
+++ b/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx
@@ -1,5 +1,4 @@
-'use client';
-
+import Link from 'next/link';
 import clsx from 'clsx';
 import { formattedDate } from '@/utils/date';
 import { formatSermonDuration } from '@/utils/sermon';
@@ -10,15 +9,9 @@ type Props = {
   series: SermonSeries;
   episodes: SermonWithRelations[];
   currentSermonId: number;
-  onSelect: (sermon: SermonWithRelations) => void;
 };
 
-export default function SermonSeriesSidebar({
-  series,
-  episodes,
-  currentSermonId,
-  onSelect
-}: Props) {
+export default function SermonSeriesSidebar({ series, episodes, currentSermonId }: Props) {
   if (episodes.length === 0) return null;
 
   const isCompleted = Boolean(series.ended_at);
@@ -45,49 +38,74 @@ export default function SermonSeriesSidebar({
         </div>
       </section>
 
-      <section className={styles.list_card}>
+      <nav className={styles.list_card} aria-label="시리즈 회차 목록">
         <header className={styles.list_header}>전체 회차 ({episodes.length}편)</header>
         <ul className={styles.episode_list}>
-          {episodes.map((ep, idx) => {
-            const isCurrent = ep.id === currentSermonId;
-            const order = ep.series_order ?? idx + 1;
-            const duration = formatSermonDuration(ep.duration);
-
-            return (
-              <li key={ep.id}>
-                <button
-                  type="button"
-                  className={clsx(styles.episode_row, isCurrent && styles.episode_row_current)}
-                  onClick={() => onSelect(ep)}
-                  disabled={isCurrent}
-                  aria-current={isCurrent ? 'true' : undefined}
-                >
-                  <span className={styles.order_num}>{String(order).padStart(2, '0')}</span>
-                  <span className={styles.info}>
-                    <span className={styles.title}>{ep.title}</span>
-                    <span className={styles.meta}>
-                      {formattedDate(ep.sermon_date, 'YYYY.MM.DD')}
-                      {duration && (
-                        <>
-                          <span className={styles.meta_dot} aria-hidden="true">·</span>
-                          {duration}
-                        </>
-                      )}
-                    </span>
-                  </span>
-                  {isCurrent && (
-                    <span className={styles.play_indicator} aria-hidden="true">
-                      <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M8 5v14l11-7z" />
-                      </svg>
-                    </span>
-                  )}
-                </button>
-              </li>
-            );
-          })}
+          {episodes.map((ep, idx) => (
+            <EpisodeRow
+              key={ep.id}
+              episode={ep}
+              order={ep.series_order ?? idx + 1}
+              isCurrent={ep.id === currentSermonId}
+            />
+          ))}
         </ul>
-      </section>
+      </nav>
     </aside>
+  );
+}
+
+type EpisodeRowProps = {
+  episode: SermonWithRelations;
+  order: number;
+  isCurrent: boolean;
+};
+
+function EpisodeRow({ episode, order, isCurrent }: EpisodeRowProps) {
+  const duration = formatSermonDuration(episode.duration);
+  const content = (
+    <>
+      <span className={styles.order_num}>{String(order).padStart(2, '0')}</span>
+      <span className={styles.info}>
+        <span className={styles.title}>{episode.title}</span>
+        <span className={styles.meta}>
+          {formattedDate(episode.sermon_date, 'YYYY.MM.DD')}
+          {duration && (
+            <>
+              <span className={styles.meta_dot} aria-hidden="true">·</span>
+              {duration}
+            </>
+          )}
+        </span>
+      </span>
+      {isCurrent && (
+        <span className={styles.play_indicator} aria-hidden="true">
+          <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </span>
+      )}
+    </>
+  );
+
+  return (
+    <li>
+      {isCurrent ? (
+        <div
+          className={clsx(styles.episode_row, styles.episode_row_current)}
+          aria-current="page"
+        >
+          {content}
+        </div>
+      ) : (
+        <Link
+          href={`/sermons/${episode.id}`}
+          className={styles.episode_row}
+          draggable={false}
+        >
+          {content}
+        </Link>
+      )}
+    </li>
   );
 }

--- a/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx
+++ b/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import clsx from 'clsx';
+import { formattedDate } from '@/utils/date';
+import { formatSermonDuration } from '@/utils/sermon';
+import type { SermonSeries, SermonWithRelations } from '@/types/sermon';
+import styles from './SermonSeriesSidebar.module.scss';
+
+type Props = {
+  series: SermonSeries;
+  episodes: SermonWithRelations[];
+  currentSermonId: number;
+  onSelect: (sermon: SermonWithRelations) => void;
+};
+
+export default function SermonSeriesSidebar({
+  series,
+  episodes,
+  currentSermonId,
+  onSelect
+}: Props) {
+  if (episodes.length === 0) return null;
+
+  const isCompleted = Boolean(series.ended_at);
+  const endLabel = series.ended_at
+    ? formattedDate(series.ended_at, 'YYYY.MM.DD')
+    : '진행 중';
+
+  return (
+    <aside className={styles.container}>
+      <section className={styles.summary_card}>
+        <span className={styles.eyebrow}>SERIES</span>
+        <h2 className={styles.series_title}>{series.title}</h2>
+        {series.description && (
+          <p className={styles.series_description}>{series.description}</p>
+        )}
+        <div className={styles.summary_meta}>
+          <span>{formattedDate(series.started_at, 'YYYY.MM.DD')}</span>
+          <span className={styles.dot} aria-hidden="true">~</span>
+          <span className={isCompleted ? styles.meta_completed : styles.meta_ongoing}>
+            {endLabel}
+          </span>
+          <span className={styles.dot} aria-hidden="true">·</span>
+          <span className={styles.count}>{episodes.length}편</span>
+        </div>
+      </section>
+
+      <section className={styles.list_card}>
+        <header className={styles.list_header}>전체 회차 ({episodes.length}편)</header>
+        <ul className={styles.episode_list}>
+          {episodes.map((ep, idx) => {
+            const isCurrent = ep.id === currentSermonId;
+            const order = ep.series_order ?? idx + 1;
+            const duration = formatSermonDuration(ep.duration);
+
+            return (
+              <li key={ep.id}>
+                <button
+                  type="button"
+                  className={clsx(styles.episode_row, isCurrent && styles.episode_row_current)}
+                  onClick={() => onSelect(ep)}
+                  disabled={isCurrent}
+                  aria-current={isCurrent ? 'true' : undefined}
+                >
+                  <span className={styles.order_num}>{String(order).padStart(2, '0')}</span>
+                  <span className={styles.info}>
+                    <span className={styles.title}>{ep.title}</span>
+                    <span className={styles.meta}>
+                      {formattedDate(ep.sermon_date, 'YYYY.MM.DD')}
+                      {duration && (
+                        <>
+                          <span className={styles.meta_dot} aria-hidden="true">·</span>
+                          {duration}
+                        </>
+                      )}
+                    </span>
+                  </span>
+                  {isCurrent && (
+                    <span className={styles.play_indicator} aria-hidden="true">
+                      <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M8 5v14l11-7z" />
+                      </svg>
+                    </span>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </aside>
+  );
+}


### PR DESCRIPTION
## 📋 개요 (Summary)

설교 상세 페이지(`/sermons/[id]`)를 mockup `DetailPCBody` + `MDetailBody` 디자인으로 전면 재설계했습니다. 기존 Tabs 4분할(요약/본문/자료/노트) UI를 순차 layout으로 통일하고, 시리즈 사이드바(데스크톱 우측 / 모바일 본문 아래) + 같은 설교자의 다른 설교 섹션을 신규로 추가했습니다.

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermons-detail-main` / `sermons-detail-series-sidebar` / `sermons-detail-other-sermons` / `sermons-detail-mobile` (4 sub-task)
- **Exec Plan**:
  - `docs/exec-plans/active/2026-05-14-sermons-detail-main.md`
  - `docs/exec-plans/active/2026-05-14-sermons-detail-series-sidebar.md`
  - `docs/exec-plans/active/2026-05-14-sermons-detail-other-sermons.md`
  - `docs/exec-plans/active/2026-05-14-sermons-detail-mobile.md`
- **관련 ADR**: `docs/decisions/0010-harness-codex-review-cap.md` — 4 task 모두 ADR 0010 compact plan 적용
- **관련 tech debt**: `docs/tech-debt-tracker.md` — `sermons-series-episode-list-unused` 등록 예정 (Phase 4-5 재사용 또는 정리 결정)
- **작업 범위**: 설교 상세 페이지 좌측 본문(Tabs 폐기 + 순차 layout) · 우측 시리즈 사이드바 · 같은 설교자 다른 설교 섹션 · 모바일 stack 순서 정합
- **제외한 범위**: `<SermonVideoPlayer>`/`<SermonVideoTools>`/`<ScriptureBlock>`/`<SermonNoteEditor>` 자체 수정 / `[id]/page.tsx` server fetch·JSON-LD·viewCount·metadata 로직 변경 / `/sermons/series` 본문 구현(Phase 4-5)

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- 기존 Tabs 4분할은 모바일에서 1탭만 보이고 콘텐츠 발견성 ↓ — 본문/요약/자료를 모두 보려면 4번 클릭
- 시리즈 설교에서 다른 회차로의 navigation이 본문 흐름 끝 SeriesEpisodeList로만 노출 — 회차 간 이동 동선 길음
- 단독 설교는 시리즈 회차 navigation이 없어 같은 설교자 다른 설교로의 진입 동선이 부재
- 모바일에서도 데스크톱과 동일한 4 Tabs UI라 작은 화면에서 컨텐츠 흐름 부자연

**관련 이슈:**

- Issue: 없음 (mockup 기반 직접 진행)

---

## 🔧 주요 변경점 (Key Changes)

- **SermonDetailPage 리팩터** — Tabs/useState/TABS/TabContent 모두 제거. 영상 → SermonMeta → ScriptureBlock(scripture_text) → summary → resources → 시리즈 사이드바(시리즈 있을 때) → 같은 설교자 다른 설교(3건 이상) → 노트(임시) 순차 layout
- **SermonMeta 통합** — 개별 8 props → sermon 객체 1 prop. duration 추가 + 시리즈 라벨을 `<Link href={\`/sermons/series/${id}\`}>`로 클릭 가능하게
- **SermonSeriesSidebar 신규** — 시리즈 카드(SERIES eyebrow + 제목 + description + 메타 border-top) + 회차 목록(max-h 480px scroll, 현재 회차 강조). PC 1024+ grid `1fr 36rem` 우측 배치, 1023 이하 stack
- **SermonOtherByPreacher 신규** — Link 카드 3 grid (16:9 CloudinaryImage + title + scripture·date). 같은 설교자 ≥3건일 때만 노출. PC `repeat(3, 1fr)` / 모바일 1fr stack. PC 1024+ grid `grid-column: 1 / -1`로 row 2 full-width
- **page.tsx Promise.all 병렬화** — `getSermonsBySeries` + `getSermons({preacherId, pageSize:4})` 병렬 fetch로 TTFB 영향 0
- **summary 줄바꿈 보존** — `white-space: pre-wrap`로 admin 입력 단락 자연 표시
- **PC drag-ghost 차단** — 모든 새 Link 카드에 `draggable={false}` + SCSS `user-select: none` + `-webkit-user-drag: none` + `pointer-events: none`
- **모바일 메타 row 컴팩트** — `font-size: $font-size-12; gap: $spacing-4` 기본, tablet+ 13/8로 확대

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 |
| --- | --- | --- | --- |
| Tabs UI | 폐기 → 순차 layout | mockup 정합 + 모바일 발견성 ↑ | 기존 Tabs 유지 (mockup과 충돌) |
| 노트 위치 | 임시 본문 하단 노출 | 기능 보존, mockup 외라 별도 task로 결정 deferred | 본 PR에서 노트 제거 (기능 손실) |
| summary 렌더 | 단일 `<p>` + `white-space: pre-wrap` | admin UI markdown/HTML 혼재 시도 raw split보다 안전 | `split('\n\n')` 으로 paragraph 분할 |
| 사이드바 컴포넌트 | 신규 `SermonSeriesSidebar` | 시리즈 카드 + 자체 회차 목록 통합 단일 책임 | 기존 `<SeriesEpisodeList>` 확장 (시각·동작 차이 큼) |
| PC grid 시작점 | `$breakpoint-pc-sm`(1024) | 768~1023에서 본문 376~600px 영상 overflow 회피 | `$breakpoint-tablet`(768) 시작 |
| 사이드바 톤 | 두 카드 모두 `$bg-card`(white) | dnchurch warm/cool 룰 일관, 사용자 검증 발견 정정 | mockup `toneSoft` warm cream + white 혼재 |
| OtherByPreacher 데이터 | `getSermons({preacherId, pageSize:4})` 재사용 | Phase 1-1 Featured 패턴 일관, 신규 service method 0 | 신규 `getOtherSermonsByPreacher` 추가 |
| 데이터 fetch | `Promise.all` 병렬 | TTFB 단축 | 순차 await (Codex CR 지적) |
| 노출 조건 | 같은 설교자 ≥3건일 때만 | mockup 명시 의도 + 카드 빈 곳 방지 | 1-2건도 그 카드 수만큼 노출 |
| 모바일 OtherByPreacher 위치 | `main_column` 밖 sidebar 다음 sibling | mockup 7→8 순서 정합 | main_column 안 유지 (mockup 어긋남) |
| 메타 row wrap | wrap 유지 + 모바일 폰트 12·gap 4 축소 | 한국어 4-5 span overflow 회피 | `flex-wrap: nowrap` 강제 (overflow 위험) |

> ⚠️ **트레이드오프:**
> - `<SermonNoteEditor>` 위치가 mockup 외라 모바일 stack에서 mockup 6(자료)과 7(시리즈 회차) 사이에 끼임. 별도 후속 task로 위치 확정 예정.
> - `<SeriesEpisodeList>` 컴포넌트가 본 PR로 unused가 됨 — Knip warn 1건 추가. 디렉토리 보존(Phase 2-4 모바일 재사용 후보였으나 본 PR 안에서 mockup 정합 layout이 자체 사이드바로 충족 → 후속 별도 task에서 정리/삭제 결정).
> - 모바일 메타 row "한 줄" 100% 보장 X — 폰트·gap 축소로 한 줄 발생 확률만 ↑ (overflow보다 wrap 우선).

---

## 📷 스크린샷 (Screenshots)

<!-- 사용자 작성 영역 — PR 검토 시 비교 가능하도록 PC·모바일 4 케이스 권장 -->

| 항목 | Before (PR #87) | After (본 PR) |
| --- | --- | --- |
| PC 시리즈 있는 설교 | <img width="1920" height="2325" alt="image" src="https://github.com/user-attachments/assets/47f189b9-9580-4f8e-97cb-cea0e36a3a56" />| <img width="1920" height="1952" alt="image" src="https://github.com/user-attachments/assets/303d9a2e-cab1-4b16-ad96-c9e22d633d66" /> |
| PC 단독 설교 | <img width="1920" height="2127" alt="image" src="https://github.com/user-attachments/assets/22e54709-e58e-4e25-8550-ef56bf652aa4" /> | <img width="1920" height="2413" alt="image" src="https://github.com/user-attachments/assets/2978f863-e660-456b-b874-1ce62fa7b132" />|
| 모바일 시리즈 있는 설교 |<img width="302" height="636" alt="image" src="https://github.com/user-attachments/assets/642a501e-7aeb-4820-999a-8c34aa0dbf29" />|<img width="301" height="730" alt="image" src="https://github.com/user-attachments/assets/75362073-660c-47a6-8704-929762b0b92f" />|
| 모바일 단독 설교 |<img width="302" height="571" alt="image" src="https://github.com/user-attachments/assets/4f2b7b28-96c6-40c7-a9b5-815dd3b32f7f" />|<img width="299" height="639" alt="image" src="https://github.com/user-attachments/assets/ea3a5f10-c80d-419b-bff7-85099633f840" />|



## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | 4 task 모두 PASS — `sermons-detail-main`(`20260514-192907`) / `sermons-detail-series-sidebar`(`20260514-200502`) / `sermons-detail-other-sermons`(`20260514-202204`) / `sermons-detail-mobile`(`20260514-203609`) |
| `harness-gate` | 머지 직전 develop 기준 실행 예정 |
| Codex 계획 검증 | sermons-detail-main PASS_WITH_DECISION_LOG `ae4aa541` / series-sidebar 1차 CR → 2차 PASS-level `a2f49b54` / other-sermons PASS_WITH_DECISION_LOG `a774d067` / mobile PASS_WITH_DECISION_LOG `ae0962ae` |
| Codex 1차 검증 | main PASS `a90ff12d` / series-sidebar CR → FIX_APPLIED(meta_bar margin-top auto · dead onClick guard) `a0365aff` / other-sermons + mobile 생략(small task) |
| Claude 2차 검증 | 4 task 모두 완료 |
| ADR 판단 | 4 task 모두 불필요 (`_component/` + `SermonDetailPage` 영역, ADR_TRIGGER_PARTS 미해당) |
| 남은 warning | Knip 기존 부채 + `SeriesEpisodeList` unused 1건 추가 (tech-debt-tracker 등록 예정) |

---

## 🗂️ 셀프 체크리스트

**기능적 완성도**
- [x] 시리즈 있는 설교 + 단독 설교 양쪽 동작
- [x] scripture_text 없는 설교, resources 없는 설교 — 해당 섹션 미렌더
- [x] 같은 설교자 ≥3건일 때만 OtherByPreacher 노출, 미만 시 미렌더
- [x] 현재 회차 disabled (사이드바 회차 목록)

**코드 품질**
- [x] semantic 토큰 사용 (하드코딩 hex 0)
- [x] 신규 컴포넌트 prop 시그니처 명확
- [x] dead code 제거 (Codex CR 반영)

**보안 및 견고성**
- [x] 외부 데이터(getSermons / getSermonsBySeries) server-only static client 사용
- [x] preacher.id / sermon_series.id null guard

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 설교 상세 페이지가 Tabs 4분할에서 순차 펼침으로 변경됨. 시리즈 설교는 PC에서 우측 360px 사이드바로 시리즈 카드 + 회차 목록 노출. 같은 설교자 다른 설교 3건 이상이면 본문 하단 3 카드 추가. 모바일은 동일 콘텐츠가 자연 stack.
- **운영/릴리스 주의사항**: DB 마이그레이션 없음 / 환경변수 변경 없음 / cache 키 동일. `<SeriesEpisodeList>` 컴포넌트 unused가 됨 — tech-debt-tracker 항목 별도 commit.
- **롤백 시 영향**: 설교 상세 페이지가 PR #89 직후 Tabs UI로 복귀 (시리즈 사이드바·다른 설교 섹션 사라짐). `/sermons/[id]` 외 영향 0.
- **먼저 볼 화면**: `https://<preview>/sermons/[id]` — 시리즈 있는 설교 PC·모바일, 단독 설교 PC·모바일 4 케이스.

---

## 📝 리뷰어를 위한 메모

- ADR 0010 compact plan 4건 연속 적용 — `sermons-detail-series-sidebar`만 1차 CR(grid breakpoint·Knip warn)에서 2차 PASS-level로, 나머지는 1라운드로 진입. 누적 Codex 라운드 평균 1.5/task.
- `<SermonNoteEditor>` 위치는 임시 — 본 PR 머지 후 별도 task에서 collapsible / 우측 사이드바 / 별도 페이지 중 결정 필요.
- 사용자 수동 검증에서 발견된 사항: (a) `/series` → `/sermons/series` 경로 정정, (b) 사이드바 톤 warm/cool 혼재 → white 통일, (c) PC drag ghost 차단 — 세 건 모두 본 PR commit으로 반영.
- 다음 작업: Phase 3 전체 설교 페이지(`/sermons/all`) 또는 Phase 4 모든 시리즈 페이지(`/sermons/series`).
