### PR TITLE
[Feat] 시리즈 상세 페이지(/sermons/series/[id]) — cover 헤로 + 회차 그리드

### DIFF
--- a/docs/exec-plans/active/2026-05-15-sermons-series-detail.md
+++ b/docs/exec-plans/active/2026-05-15-sermons-series-detail.md
@@ -111,6 +111,21 @@ material CR 0건, 전부 expression-only. 5체크 전부 PASS — Assumptions(co
 - DL-1~4 반영 확인: $overlay-image/$overlay-scrim, cache tag 문자열, UUID_RE 가드 위치, preacher 제외.
 - 외과적: bySeriesSlug/getSermonsBySeries 불변, 변경 전부 Phase 5 추적.
 
+## PR #92 자동리뷰 대응
+
+Gemini 3 + Codex 3 코멘트 트리아지. 코드 수정 3건(verify RUN_ID=`20260515-232128` PASS, HEAD 갱신 예정).
+
+- **[Codex #4 P1 — 적용]** `bySeriesId`가 `is_active` 필터를 통째 제거해 숨김(is_active=false) 시리즈가 UUID로 공개 노출. 코드 컨벤션상 `is_active`=공개 게이트(worship/staff/allSeries:126/bySeriesSlug:149/allPreachers:206 전부 `.eq('is_active',true)`), 완료 판정은 별축 `ended_at`(page.tsx:45·SermonSeriesBanner:23·SermonSeriesSidebar:17). → `bySeriesId` 시리즈 조회에 `.eq('is_active', true)` 복원. 완료 시리즈는 is_active=true+ended_at!=null이라 영향 없음, 숨김만 404. **계획의 "is_active 필터 없음" 결정 폐기** — 완료축을 is_active로 착각한 오류 정정.
+- **[Codex #5 P2 — 적용]** 헤로 ON-GOING/COMPLETED·메타 분기를 `series.is_active` → `series.ended_at === null`로. Banner/Sidebar/메인과 동일 축. 중복 `~` dot 외과적 통합, 분기 단순화로 dead가 된 `.hero_completed` SCSS 제거.
+- **[Codex #6 P2 — 적용]** `EpisodeGrid` 회차 번호 `index+1` → `sermon.series_order ?? index+1`. 비연속 series_order/중간 비공개 시 설교 상세 "제N편"과 번호 일치.
+- **[Gemini #3 — 미적용]** `started_at` null 가드 제안 → `database.types.ts:265 started_at: string` (NOT NULL, Insert 필수). 불가능 시나리오 방어 가드레일에 따라 미적용.
+- **[Gemini #1 — 미적용]** `Promise.all` 병렬화 제안 → 두 쿼리는 의도적 순차: 시리즈 미존재 시 `return null`로 episodes 쿼리 skip(notFound 경로 최적화). 병렬화 시 항상 둘 다 실행.
+- **[Gemini #2 — 미적용]** select narrowing → 공유 상수 `SERMON_WITH_RELATIONS_SELECT` 좁히기는 PR #91 #6과 동일 회귀 리스크. tech-debt 유지(별건 전용 쿼리 필요).
+
+> **Phase 4 파급**: `allSeriesIncludingInactive`(미PR `feat/sermons-all-series`)도 동일 전제(완료=is_active 착각) 오류. 완료는 ended_at 축이라 `allSeries`(is_active=true)가 이미 완료 포함 → Phase 4 PR 시 함수 존치 여부 재검토. 본 PR 범위 외.
+
+**ADR 판단(보강)**: 불필요 — `is_active` 필터 복원은 기존 공개 게이트 컨벤션 준수(신규 정책 아님), 일회성 버그 정정. `start-adr` 미실행.
+
 ---
 
 <!-- 이하 섹션은 해당 시에만 추가:

--- a/docs/exec-plans/active/2026-05-15-sermons-series-detail.md
+++ b/docs/exec-plans/active/2026-05-15-sermons-series-detail.md
@@ -1,0 +1,127 @@
+# sermons-series-detail
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-15
+- **브랜치**: feat/sermons-series-detail
+- **Open questions**: none
+- **ADR needed**: no — services/sermon에 read-only `bySeriesId` 신규(기존 `bySeriesSlug` 패턴 답습, 불변) + UI 페이지·컴포넌트. 캐시·라이브러리·레이어·인증 정책 불변.
+
+## 목표
+
+`/sermons/series/[id]`(현재 스켈레톤)를 mockup `SeriesDetailPCPage` 패턴의 시리즈 상세로 구현 — (5-1) cover 이미지 헤로(상태·기간·편수 메타) + (5-2) 회차 그리드(번호·썸네일·제목·말씀·날짜, PC 2열/모바일 1열). Phase 4 카드(`/sermons/series/${series.id}`)의 도착지.
+
+## 검증된 Assumptions
+
+- `series/[id]/page.tsx` 스켈레톤(제목만), 동적 파라미터 `[id]`(UUID) — Explore Read 확인
+- Phase 4 `SeriesCard`는 `/sermons/series/${series.id}` 링크 — 파라미터 계약 = series UUID
+- `bySeriesSlug`(`sermon-service.ts:168`)는 slug+`is_active=true` 필터 — **id 기반·완료 포함 단건 함수 부재** → 신규 필요
+- `sermon_series`에 **`cover_tone` 컬럼 없음**, `cover_image_url`(string|null) 존재 — `database.types.ts` 확인. mockup의 cover_tone 그라디언트는 실 DB 미지원
+- `id`는 UUID 컬럼 — 비-UUID 문자열 `.eq('id', x)`는 Postgres throw (Phase 4 CR-2 동일 리스크)
+- 회차=해당 시리즈 sermons, `series_order` ASC → `sermon_date` ASC, `is_published`만 — `bySeriesSlug` 내부 쿼리 패턴 확인
+- `SeriesCard`/`GridCard`/`SeriesEpisodeList`/`SermonSeriesSidebar` 모두 레이아웃 상이 — 헤로·회차 카드 재사용 불가, 신규
+
+## Non-goals
+
+- 영상 재생(YouTube iframe) — Phase 7
+- 데이터 캐시·로딩/에러 UI 정교화 — Phase 6 (notFound 404만)
+- 회차 placeholder("곧 공개") 표시·진행 바 — 설계상 제거(Sermon-Design-Decisions 2-4)
+- `cover_tone` 마이그레이션 — DB 변경 회피(D1)
+- 표준 Hero 컴포넌트 사용 — 시리즈 상세는 cover-image 커스텀 헤로(D5)
+- `bySeriesSlug`·`getSermonsBySeries` 변경 — 공유 함수 불변(#6 교훈), 신규 분리
+
+## 의사결정 로그
+
+- **D1 — 헤로 배경 = `cover_image_url` + scrim, fallback 토큰 그라디언트**: mockup cover_tone 컬럼 미존재. 실 DB의 `cover_image_url`(SeriesCard도 사용)을 배경 이미지로, 없으면 `$overlay-image` 토큰 그라디언트. DB 마이그레이션·ADR 회피. (Phase 4 mockup-vs-DB 교훈)
+- **D2 — `bySeriesId(id)` 신규(완료 포함), `bySeriesSlug` 불변**: id 기반·`is_active` 필터 없음(완료 시리즈도 상세 노출). 시리즈 단건 + 회차 + sermon_count 반환. 별도 cache tag. 공유 slug 함수 변경 안 함.
+- **D3 — SeriesEpisodeCard·SeriesDetailHero 신규**: mockup 고유 3-col(번호│썸네일│정보)·cover 헤로. GridCard(번호 col 없음)·SeriesEpisodeList(세로 리스트)·SeriesCard(목록 카드) 레이아웃 불일치로 재사용 불가.
+- **D4 — 비-UUID/미존재 id → `notFound()`**: `id`는 UUID 컬럼. 잘못된 id가 쿼리에 닿으면 throw(Phase 4 CR-2). 쿼리 전 UUID 형식 가드 + `maybeSingle` null → `notFound()`.
+- **D5 — 커스텀 헤로(표준 Hero 미사용)**: 프로젝트 (content) 표준 Hero는 generic(`Hero/Hero.tsx:9-24` pathname config). 시리즈 상세는 cover 이미지 기반 다크 헤로라 별도 컴포넌트.
+- **DL-1 — SCSS 토큰 고정** (Codex 보완): 헤로 fallback 배경 = `$overlay-image`(`_semantic.scss:85`, SeriesCard도 사용), scrim = `$overlay-scrim`. rgba 신규 하드코딩 금지.
+- **DL-2 — cache tag 문자열 고정** (Codex 보완): 신규 tag `[ROOT, 'sermon-series-detail', \`sermon-series-detail-${id}\`]` — 기존 `sermon-series-list`/`sermon-series-${slug}`와 prefix 분리.
+- **DL-3 — UUID 가드 코드 고정** (Codex 보완): `series/[id]/page.tsx`에서 `if (!UUID_RE.test(id)) notFound();`를 `getSeriesDetail(id)` 호출 **이전**에 실행.
+- **DL-4 — 시리즈에 preacher 없음** (Codex 보완): `sermon_series`에 preacher 컬럼 없어 mockup의 헤로 메타 "설교자 · 기간 · N편" 중 설교자 제외 → 메타는 `시작 ~ 진행중|종료 · N편`. (Phase 4 동일 데이터 계약)
+
+## Success Criteria
+
+- `/sermons/series/{유효 id}`: cover 헤로(이미지 or fallback 그라디언트 + scrim) + "SERIES · 진행 중/완료" 라벨 + 제목 + 설명 + 메타(`시작 ~ 진행중|종료 · N편`) + 회차 그리드
+- 회차 카드: 번호(01..) + 썸네일(play·duration) + 제목 + 말씀 + 날짜, `series_order` 순. PC 2열/모바일 1열
+- 완료 시리즈도 정상 노출(is_active 무관), 진행/완료 메타 표기 분기
+- 비-UUID·미존재 id → 500 아님 `notFound()`(404)
+- `cover_image_url` 없는 시리즈도 fallback 헤로로 깨지지 않음
+- `node scripts/verify-task.mjs sermons-series-detail` PASS
+
+## 영향받는 파일
+
+- `src/services/sermon/sermon-service.ts` — `bySeriesId(id)` 신규(시리즈+회차+count, is_active 필터 없음)
+- `src/services/sermon/sermon-cache.ts` + `index.ts` — `seriesDetail(id)` cache tag + `getSeriesDetail(id)` wrapper
+- `src/app/(content)/sermons/series/[id]/page.tsx` — 스켈레톤 → 조립 + UUID 가드 + notFound
+- `src/app/(content)/sermons/_component/SeriesDetailPage/` — SeriesDetailHero·SeriesEpisodeCard·EpisodeGrid + `SeriesDetailPage.module.scss` (통합 1 scss)
+- 재사용(무변경): `formattedDate`, `formatSermonDuration`, `getSermonThumbnail`+`cloudinaryFetchUrl`(Phase 3 #1 교훈), `CloudinaryImage`, `EmptyState`/`notFound`
+
+## 단계별 체크리스트
+
+- [ ] 1. `sermon-service.ts` `bySeriesId` + `sermon-cache.ts` tag + `index.ts` `getSeriesDetail`
+- [ ] 2. `SeriesDetailPage.module.scss` (헤로 + 2열 회차 그리드, semantic 토큰)
+- [ ] 3. SeriesDetailHero (cover_image_url/fallback + scrim + 라벨·메타)
+- [ ] 4. SeriesEpisodeCard (번호│썸네일│정보, play·duration)
+- [ ] 5. EpisodeGrid + `[id]/page.tsx` 조립 (UUID 가드·notFound)
+- [ ] 6. verify-task
+
+## Verification
+
+- `node scripts/verify-task.mjs sermons-series-detail`
+- `/sermons/series/{Phase4 카드 id}` 진입: 헤로·회차 그리드 정상, 진행/완료 메타 분기
+- `/sermons/series/not-a-uuid` 및 미존재 UUID → 404(notFound), 500 아님
+- cover_image_url 없는 시리즈 fallback 헤로 확인
+- `/sermons/series`(Phase 4) 카드 → 상세 이동 동선
+
+## ADR 판단
+
+- **불필요** — `bySeriesId`는 기존 `bySeriesSlug` 읽기전용 패턴 답습 신규(공유 함수 불변), 나머지는 app 레이어 페이지·컴포넌트. 캐시·라이브러리·레이어·인증 정책 변경 없음. `start-adr` 미실행.
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: PASS_WITH_DECISION_LOG (confidence high)
+
+material CR 0건, 전부 expression-only. 5체크 전부 PASS — Assumptions(cover_image_url·UUID·bySeriesSlug is_active·SeriesCard id링크 실 코드 라인 확인), Non-goals(Phase7 영상·Phase6 정교화·cover_tone migration 제외), scope linkage, SC/verification 구체, 과한 추상화 없음.
+
+보완 권장 4건 → 의사결정 로그 DL-1~4 반영: SCSS 토큰 고정($overlay-image/$overlay-scrim), cache tag 문자열(sermon-series-detail-${id}), UUID_RE 가드 위치(getSeriesDetail 이전), 시리즈 preacher 컬럼 부재(헤로 메타에서 설교자 제외). WORK 진입(3차 재검증 없음).
+
+## Codex 1차 검증
+
+- **결론**: FIX_APPLIED
+
+> Types/Bugs OK(SeriesDetail·bySeriesId null·async params·UUID 가드 순서·import 경로 — `page.tsx:23-28` UUID 검증이 getSeriesDetail보다 먼저) · Layer/Surgical OK(`@/services/sermon`만, bySeriesSlug 불변) · SCSS OK(rgba 로컬변수 GridCard 선례 주석부 예외, hover 3원칙 위반 0, `.episode:hover .ep_play` opacity만) · Cache OK(`sermon-series-detail-${id}` 미충돌) · **Data Contract FIX_APPLIED**: 완료 시리즈가 `종료`를 안정 표시 안 하던 문제 → SeriesDetailHero inactive branch 항상 렌더 + `.hero_completed` 스타일 추가(Codex 직접수정).
+> verify: tsc/lint/lint:styles 0 errors. Next build Google Fonts fetch 실패는 sandbox 네트워크(코드 무관).
+
+**풀이**: 타입·레이어·SCSS·캐시 전부 통과. Codex가 완료 시리즈 메타 누락 가드를 직접 수정(missing-guard 범위 적합).
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS
+
+### 교차 확인
+
+- Codex 직접수정(SeriesDetailHero inactive 항상 `종료`) 교차 확인 — null-safe하나 `ended_at` 존재 시 종료일 미표시로 Phase 4 `SeriesCard`(`{start} ~ {ended}`)·design-decisions 2-4와 불일치. **보정**: inactive를 `ended_at ? 종료일 : "종료"`로 재수정 — Codex의 null 가드 의도 유지 + 일관성 회복. `.hero_completed`는 fallback로 여전히 사용(dead 아님).
+- verify-task(`b3eoy4a3d`) 필수 검증 PASS — 내 환경 build 통과(Codex sandbox의 Google Fonts fetch 실패는 환경 이슈, 코드 원인 아님). Hero 보정 후 재검증(`btycnq12x`).
+- DL-1~4 반영 확인: $overlay-image/$overlay-scrim, cache tag 문자열, UUID_RE 가드 위치, preacher 제외.
+- 외과적: bySeriesSlug/getSermonsBySeries 불변, 변경 전부 Phase 5 추적.
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+-->
+
+<!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/EpisodeGrid.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/EpisodeGrid.tsx
@@ -1,0 +1,34 @@
+import { EmptyState } from '@/components/ui';
+import SeriesEpisodeCard from './SeriesEpisodeCard';
+import type { SermonWithRelations } from '@/types/sermon';
+import styles from './SeriesDetailPage.module.scss';
+
+type Props = {
+  episodes: SermonWithRelations[];
+};
+
+export default function EpisodeGrid({ episodes }: Props) {
+  return (
+    <section aria-label="회차 목록">
+      <header className={styles.episodes_header}>
+        <h2 className={styles.episodes_title}>회차 목록</h2>
+        <span className={styles.episodes_total}>총 {episodes.length}편</span>
+      </header>
+      {episodes.length === 0 ? (
+        <EmptyState
+          title="아직 공개된 회차가 없습니다"
+          description="회차가 공개되면 이곳에 표시됩니다"
+          announce
+        />
+      ) : (
+        <ul role="list" className={styles.grid}>
+          {episodes.map((sermon, index) => (
+            <li key={sermon.id}>
+              <SeriesEpisodeCard sermon={sermon} order={index + 1} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/EpisodeGrid.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/EpisodeGrid.tsx
@@ -24,7 +24,10 @@ export default function EpisodeGrid({ episodes }: Props) {
         <ul role="list" className={styles.grid}>
           {episodes.map((sermon, index) => (
             <li key={sermon.id}>
-              <SeriesEpisodeCard sermon={sermon} order={index + 1} />
+              <SeriesEpisodeCard
+                sermon={sermon}
+                order={sermon.series_order ?? index + 1}
+              />
             </li>
           ))}
         </ul>

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailHero.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailHero.tsx
@@ -26,7 +26,7 @@ export default function SeriesDetailHero({ series }: Props) {
       <div className={styles.hero_scrim} aria-hidden />
       <div className={styles.hero_content}>
         <span className={styles.hero_eyebrow}>
-          SERIES · {series.is_active ? 'ON-GOING' : 'COMPLETED'}
+          SERIES · {series.ended_at === null ? 'ON-GOING' : 'COMPLETED'}
         </span>
         <h1 className={styles.hero_title}>{series.title}</h1>
         {series.description && (
@@ -34,24 +34,13 @@ export default function SeriesDetailHero({ series }: Props) {
         )}
         <div className={styles.hero_meta}>
           <span>{formattedDate(series.started_at, 'YYYY.MM.DD')}</span>
-          {series.is_active ? (
-            <>
-              <span className={styles.hero_dot} aria-hidden>
-                ~
-              </span>
-              <span className={styles.hero_ongoing}>진행 중</span>
-            </>
+          <span className={styles.hero_dot} aria-hidden>
+            ~
+          </span>
+          {series.ended_at ? (
+            <span>{formattedDate(series.ended_at, 'YYYY.MM.DD')}</span>
           ) : (
-            <>
-              <span className={styles.hero_dot} aria-hidden>
-                ~
-              </span>
-              {series.ended_at ? (
-                <span>{formattedDate(series.ended_at, 'YYYY.MM.DD')}</span>
-              ) : (
-                <span className={styles.hero_completed}>종료</span>
-              )}
-            </>
+            <span className={styles.hero_ongoing}>진행 중</span>
           )}
           <span className={styles.hero_dot} aria-hidden>
             ·

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailHero.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailHero.tsx
@@ -1,0 +1,64 @@
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import { cloudinaryFetchUrl } from '@/utils/cloudinary';
+import { formattedDate } from '@/utils/date';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import styles from './SeriesDetailPage.module.scss';
+
+type Props = {
+  series: SeriesWithSermonCount;
+};
+
+export default function SeriesDetailHero({ series }: Props) {
+  const cover = cloudinaryFetchUrl(series.cover_image_url);
+
+  return (
+    <section className={styles.hero}>
+      {cover && (
+        <CloudinaryImage
+          src={cover}
+          alt={series.title}
+          fill
+          sizes="100vw"
+          className={styles.hero_image}
+          priority
+        />
+      )}
+      <div className={styles.hero_scrim} aria-hidden />
+      <div className={styles.hero_content}>
+        <span className={styles.hero_eyebrow}>
+          SERIES · {series.is_active ? 'ON-GOING' : 'COMPLETED'}
+        </span>
+        <h1 className={styles.hero_title}>{series.title}</h1>
+        {series.description && (
+          <p className={styles.hero_desc}>{series.description}</p>
+        )}
+        <div className={styles.hero_meta}>
+          <span>{formattedDate(series.started_at, 'YYYY.MM.DD')}</span>
+          {series.is_active ? (
+            <>
+              <span className={styles.hero_dot} aria-hidden>
+                ~
+              </span>
+              <span className={styles.hero_ongoing}>진행 중</span>
+            </>
+          ) : (
+            <>
+              <span className={styles.hero_dot} aria-hidden>
+                ~
+              </span>
+              {series.ended_at ? (
+                <span>{formattedDate(series.ended_at, 'YYYY.MM.DD')}</span>
+              ) : (
+                <span className={styles.hero_completed}>종료</span>
+              )}
+            </>
+          )}
+          <span className={styles.hero_dot} aria-hidden>
+            ·
+          </span>
+          <span className={styles.hero_count}>{series.sermon_count}편</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailPage.module.scss
@@ -1,0 +1,269 @@
+// 시리즈 상세 — cover 헤로 + 회차 그리드. mockup SeriesDetailPCPage / SeriesEpisodeCard.
+
+// 썸네일 위 오버레이 — semantic 토큰 미정의 영역(이미지 위 dim). GridCard와 동일 패턴.
+$play-overlay-bg: rgba(255, 255, 255, 0.16);
+$play-overlay-border: rgba(255, 255, 255, 0.22);
+$duration-overlay-bg: rgba(0, 0, 0, 0.7);
+
+$ep-thumb-width: 13rem;
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: $section-gap-40;
+  padding: $spacing-20 0 $section-gap-80;
+}
+
+// ── Hero ──
+
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: $spacing-8;
+  min-height: 22rem;
+  padding: $spacing-28 $spacing-20;
+  overflow: hidden;
+  background: $overlay-image;
+  border-radius: $radius-m;
+  color: $txt-inverse;
+
+  @include respond-up($breakpoint-pc-sm) {
+    min-height: 28rem;
+    padding: $spacing-40;
+  }
+}
+
+.hero_image {
+  object-fit: cover;
+  pointer-events: none;
+}
+
+.hero_scrim {
+  position: absolute;
+  inset: 0;
+  background-color: $overlay-scrim;
+  pointer-events: none;
+}
+
+.hero_content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-8;
+  max-width: 72rem;
+}
+
+.hero_eyebrow {
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  letter-spacing: $letter-spacing-wide;
+  color: $accent;
+  text-transform: uppercase;
+}
+
+.hero_title {
+  margin: 0;
+  font-size: $font-size-24;
+  font-weight: $font-weight-bold;
+  letter-spacing: $letter-spacing-body;
+  line-height: $line-height-tight;
+  word-break: keep-all;
+
+  @include respond-up($breakpoint-pc-sm) {
+    font-size: $font-size-34;
+  }
+}
+
+.hero_desc {
+  margin: 0;
+  font-size: $font-size-13;
+  line-height: $line-height-body-reading;
+  color: $txt-image-subtle;
+  word-break: keep-all;
+
+  @include respond-up($breakpoint-pc-sm) {
+    font-size: $font-size-15;
+  }
+}
+
+.hero_meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: $spacing-4;
+  margin-top: $spacing-4;
+  font-size: $font-size-12;
+  color: $txt-image-subtle;
+  font-variant-numeric: tabular-nums;
+}
+
+.hero_dot {
+  opacity: 0.5;
+}
+
+.hero_ongoing,
+.hero_completed {
+  color: $txt-inverse;
+  font-weight: $font-weight-bold;
+}
+
+.hero_count {
+  color: $txt-inverse;
+  font-weight: $font-weight-bold;
+}
+
+// ── Episodes ──
+
+.episodes_header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: $spacing-12;
+  margin-bottom: $content-gap-m;
+  padding-bottom: $spacing-12;
+  border-bottom: 1px solid $border-subtle;
+}
+
+.episodes_title {
+  margin: 0;
+  font-size: $font-size-16;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+}
+
+.episodes_total {
+  font-size: $font-size-12;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $content-gap-s;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  @include respond-up($breakpoint-pc-sm) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.episode {
+  display: grid;
+  grid-template-columns: $spacing-32 $ep-thumb-width 1fr;
+  gap: $content-gap-s;
+  align-items: center;
+  padding: $spacing-12 $spacing-16;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  text-decoration: none;
+  color: inherit;
+
+  @include hover-lift;
+}
+
+.ep_number {
+  font-size: $font-size-14;
+  font-weight: $font-weight-bold;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.ep_thumb {
+  position: relative;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: $radius-xs;
+  background-color: $bg-secondary;
+}
+
+.ep_thumb_img {
+  object-fit: cover;
+}
+
+.ep_thumb_placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(135deg, $bg-secondary, $border-card);
+}
+
+.ep_play {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $spacing-32;
+  height: $spacing-32;
+  font-size: $font-size-11;
+  color: $accent;
+  background-color: $play-overlay-bg;
+  backdrop-filter: blur(4px);
+  border: 1px solid $play-overlay-border;
+  border-radius: $radius-circle;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.episode:hover .ep_play {
+  opacity: 1;
+}
+
+.ep_duration {
+  position: absolute;
+  right: $spacing-4;
+  bottom: $spacing-4;
+  padding: 0 $spacing-4;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  color: $txt-inverse;
+  background-color: $duration-overlay-bg;
+  border-radius: $radius-xxs;
+  font-variant-numeric: tabular-nums;
+}
+
+.ep_info {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+  min-width: 0;
+}
+
+.ep_title {
+  margin: 0;
+  font-size: $font-size-14;
+  font-weight: $font-weight-semibold;
+  color: $txt-primary;
+  line-height: $line-height-snug;
+
+  @include ellipsis-multi(2);
+  word-break: keep-all;
+}
+
+.ep_meta {
+  display: flex;
+  align-items: center;
+  gap: $spacing-4;
+  font-size: $font-size-11;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+}
+
+.ep_scripture {
+  color: $primary;
+  font-weight: $font-weight-semibold;
+}
+
+.ep_dot {
+  opacity: 0.4;
+}

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailPage.module.scss
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesDetailPage.module.scss
@@ -104,8 +104,7 @@ $ep-thumb-width: 13rem;
   opacity: 0.5;
 }
 
-.hero_ongoing,
-.hero_completed {
+.hero_ongoing {
   color: $txt-inverse;
   font-weight: $font-weight-bold;
 }

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesEpisodeCard.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesEpisodeCard.tsx
@@ -1,0 +1,66 @@
+import Link from 'next/link';
+import { IoPlay } from 'react-icons/io5';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import { cloudinaryFetchUrl } from '@/utils/cloudinary';
+import { formattedDate } from '@/utils/date';
+import { formatSermonDuration, getSermonThumbnail } from '@/utils/sermon';
+import type { SermonWithRelations } from '@/types/sermon';
+import styles from './SeriesDetailPage.module.scss';
+
+type Props = {
+  sermon: SermonWithRelations;
+  order: number;
+};
+
+export default function SeriesEpisodeCard({ sermon, order }: Props) {
+  const thumbnail = cloudinaryFetchUrl(getSermonThumbnail(sermon));
+  const duration = formatSermonDuration(sermon.duration);
+  const number = String(order).padStart(2, '0');
+
+  return (
+    <Link
+      href={`/sermons/${sermon.id}`}
+      className={styles.episode}
+      aria-label={`${number}편 ${sermon.title}${duration ? `, ${duration}` : ''}`}
+    >
+      <span className={styles.ep_number} aria-hidden="true">
+        {number}
+      </span>
+      <div className={styles.ep_thumb}>
+        {thumbnail ? (
+          <CloudinaryImage
+            src={thumbnail}
+            alt={sermon.title}
+            fill
+            sizes="(min-width: 1024px) 13rem, 40vw"
+            className={styles.ep_thumb_img}
+          />
+        ) : (
+          <div className={styles.ep_thumb_placeholder} aria-hidden="true" />
+        )}
+        <span className={styles.ep_play} aria-hidden="true">
+          <IoPlay />
+        </span>
+        {duration && (
+          <span className={styles.ep_duration} aria-hidden="true">
+            {duration}
+          </span>
+        )}
+      </div>
+      <div className={styles.ep_info}>
+        <h3 className={styles.ep_title}>{sermon.title}</h3>
+        <div className={styles.ep_meta}>
+          {sermon.scripture && (
+            <>
+              <span className={styles.ep_scripture}>{sermon.scripture}</span>
+              <span className={styles.ep_dot} aria-hidden="true">
+                ·
+              </span>
+            </>
+          )}
+          <span>{formattedDate(sermon.sermon_date, 'YY.MM.DD')}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/app/(content)/sermons/series/[id]/page.tsx
+++ b/src/app/(content)/sermons/series/[id]/page.tsx
@@ -1,15 +1,38 @@
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import { LayoutContainer } from '@/components/layout';
+import { getSeriesDetail } from '@/services/sermon';
+import SeriesDetailHero from '../../_component/SeriesDetailPage/SeriesDetailHero';
+import EpisodeGrid from '../../_component/SeriesDetailPage/EpisodeGrid';
+import styles from '../../_component/SeriesDetailPage/SeriesDetailPage.module.scss';
 
 export const metadata: Metadata = {
   title: '시리즈 상세',
   description: '대구동남교회 강해 설교 시리즈 상세'
 };
 
-export default function SeriesDetailPage() {
+// series_id는 UUID 컬럼 — 비-UUID 문자열이 쿼리에 닿으면 Postgres throw.
+// getSeriesDetail 호출 전 형식 가드 → 잘못된 URL은 500 아닌 404.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function SeriesDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) notFound();
+
+  const data = await getSeriesDetail(id);
+  if (!data) notFound();
+
   return (
     <LayoutContainer>
-      <h1>시리즈 상세</h1>
+      <div className={styles.page}>
+        <SeriesDetailHero series={data.series} />
+        <EpisodeGrid episodes={data.episodes} />
+      </div>
     </LayoutContainer>
   );
 }

--- a/src/services/sermon/index.ts
+++ b/src/services/sermon/index.ts
@@ -28,6 +28,12 @@ export const getSermonsBySeries = (seriesSlug: string) => {
   return sermonService(supabase).bySeriesSlug(seriesSlug);
 };
 
+/** 시리즈 상세(`/sermons/series/[id]`)용: id 기준 시리즈 단건 + 회차 (완료 포함) */
+export const getSeriesDetail = (id: string) => {
+  const supabase = createStaticClient(sermonCache.seriesDetail(id));
+  return sermonService(supabase).bySeriesId(id);
+};
+
 export const getAllPreachers = () => {
   const supabase = createStaticClient(sermonCache.preacherList());
   return sermonService(supabase).allPreachers();

--- a/src/services/sermon/sermon-cache.ts
+++ b/src/services/sermon/sermon-cache.ts
@@ -21,6 +21,10 @@ export const sermonCache = {
     tags: [ROOT, 'sermon-list', `sermon-series-${slug}`],
     revalidate: ONE_DAY_IN_SECONDS
   }),
+  seriesDetail: (id: string): NextCacheOptions => ({
+    tags: [ROOT, 'sermon-series-detail', `sermon-series-detail-${id}`],
+    revalidate: ONE_DAY_IN_SECONDS
+  }),
   preacherList: (): NextCacheOptions => ({
     tags: [ROOT, 'preacher-list'],
     revalidate: ONE_DAY_IN_SECONDS

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -166,14 +166,16 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
   },
 
   /**
-   * id로 시리즈 단건 + 회차(설교) 조회. `bySeriesSlug`와 달리 `is_active` 필터 없음
-   * — 완료 시리즈도 상세 노출. 미존재 시 null. sermon_count는 노출 회차 수.
+   * id로 시리즈 단건 + 회차(설교) 조회. `is_active`는 공개 노출 게이트라 유지
+   * — 완료 시리즈는 `ended_at`으로 판별되며 is_active=true로 그대로 노출.
+   * 숨김(is_active=false)·미존재 시 null. sermon_count는 노출 회차 수.
    */
   bySeriesId: async (id: string): Promise<SeriesDetail | null> => {
     const seriesRes = await supabase
       .from('sermon_series')
       .select('*')
       .eq('id', id)
+      .eq('is_active', true)
       .maybeSingle();
 
     const seriesHandled = handleResponse(seriesRes);

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -8,6 +8,7 @@ import type {
   SermonWithRelations,
   SermonListItem,
   SeriesWithSermonCount,
+  SeriesDetail,
   PreacherWithSermonCount,
   YearCount,
   AdminSermon,
@@ -162,6 +163,39 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
 
     const handled = handleResponse(res);
     return (handled.data ?? []) as unknown as SermonWithRelations[];
+  },
+
+  /**
+   * id로 시리즈 단건 + 회차(설교) 조회. `bySeriesSlug`와 달리 `is_active` 필터 없음
+   * — 완료 시리즈도 상세 노출. 미존재 시 null. sermon_count는 노출 회차 수.
+   */
+  bySeriesId: async (id: string): Promise<SeriesDetail | null> => {
+    const seriesRes = await supabase
+      .from('sermon_series')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+
+    const seriesHandled = handleResponse(seriesRes);
+    if (!seriesHandled.data) return null;
+
+    const res = await supabase
+      .from('sermons')
+      .select(SERMON_WITH_RELATIONS_SELECT)
+      .eq('series_id', id)
+      .eq('is_published', true)
+      .is('deleted_at', null)
+      .order('series_order', { ascending: true, nullsFirst: false })
+      .order('sermon_date', { ascending: true });
+
+    const handled = handleResponse(res);
+    const episodes = (handled.data ?? []) as unknown as SermonWithRelations[];
+    const seriesRow = seriesHandled.data as unknown as SeriesWithSermonCount;
+
+    return {
+      series: { ...seriesRow, sermon_count: episodes.length },
+      episodes
+    };
   },
 
   /** 활성 설교자 전체 + published + 미삭제 설교 편수 조회 (inner join — 노출 0편 설교자는 결과에서 제외) */

--- a/src/types/sermon.ts
+++ b/src/types/sermon.ts
@@ -34,6 +34,12 @@ export type SermonCardItem = SermonListItem &
 
 export type SeriesWithSermonCount = SermonSeries & { sermon_count: number };
 
+/** 시리즈 상세 페이지: 시리즈 단건 + 회차(설교) */
+export type SeriesDetail = {
+  series: SeriesWithSermonCount;
+  episodes: SermonWithRelations[];
+};
+
 export type PreacherWithSermonCount = Preacher & { sermon_count: number };
 
 export type SermonSortKey = 'recent' | 'oldest';


### PR DESCRIPTION
## 📋 개요 (Summary)

시리즈 카드/필터에서 진입할 개별 시리즈 상세 페이지 `/sermons/series/[id]` 신설 — cover 이미지 헤로 + 회차(설교) 그리드.

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermons-series-detail`
- **Exec Plan**: `docs/exec-plans/active/2026-05-15-sermons-series-detail.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: `docs/tech-debt-tracker.md` — getAllSeries/getAllPreachers select 최적화(별건, Phase 3에서 분리)
- **작업 범위**: id 기반 시리즈+회차 조회 인프라, 상세 페이지 UI(Hero·EpisodeGrid·EpisodeCard), UUID 가드
- **제외한 범위**: 영상 재생/첨부(Phase 7), SEO·share 메타(Phase 8), preacher 축(sermon_series에 컬럼 없음)

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:** Phase 4에서 모든 시리즈 목록(`/sermons/series`)을 만들었으나 개별 시리즈로 들어갈 상세 화면이 없어 동선이 끊김. 시리즈 단위로 회차를 순서대로 탐색할 진입점이 필요.

**관련 이슈:** 없음 (Sermon-Implementation-Prompts Phase 5)

---

## 🔧 주요 변경점 (Key Changes)

- `bySeriesId(id)` 서비스 신설 — 기존 `bySeriesSlug` **건드리지 않고** id 기반 조회 추가(shared 함수 회귀 방지). 회차는 `series_order` → `sermon_date` 정렬
- `SeriesDetail` 타입 + `sermon-cache` `seriesDetail(id)` 태그 + `getSeriesDetail` 래퍼 추가
- `SeriesDetailHero` — `cover_image_url`(Cloudinary) 헤로, scrim, ON-GOING/COMPLETED eyebrow, started~ended/진행중/종료 메타
- `EpisodeGrid`/`SeriesEpisodeCard` — 회차 그리드(빈 시 EmptyState), 회차번호·썸네일·hover play·duration
- `[id]/page.tsx` — UUID 정규식 가드 → 비-UUID/미존재는 500 아닌 `notFound()`

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 조회 키 | id 기반 신규 `bySeriesId` | shared `bySeriesSlug` 회귀 차단 | 기존 함수 확장 — Phase 3 select 회귀 사례 재발 위험 |
| 헤로 배경 | `cover_image_url` 이미지 | 실제 시리즈 비주얼 노출 | `cover_tone` 그라디언트 — 컬럼 미존재 |
| 잘못된 URL | UUID 가드 → `notFound()` | 비-UUID가 Postgres uuid 컬럼에 닿으면 500 throw | 무가드 — 500 노출 |
| 완료 시리즈 메타 | `ended_at ? 날짜 : "종료"` | Phase 4 SeriesCard·design-decisions와 일관 | 항상 "종료" — 날짜 정보 손실 |

> ⚠️ **트레이드오프:** id URL은 slug 대비 비가독 — 단 시리즈 진입은 카드/필터 링크 경유라 직접 타이핑 시나리오 낮음.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | PASS, RUN_ID=`20260515-225712`, HEAD=`2f253e5`, failed=0, warned=Knip |
| `harness-gate` | PASS |
| Codex 계획 검증 | PASS_WITH_DECISION_LOG |
| Codex 1차 검증 | FIX_APPLIED (완료 시리즈 메타 가드) |
| Claude 2차 검증 | 완료 (ended_at 일관성 보정) |
| ADR 판단 | 불필요 |
| 남은 warning | 기존 부채 (Knip) |

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: `/sermons/series/[id]` 신규 — 시리즈 클릭 시 cover 헤로 + 회차 목록 노출
- **운영 / 릴리스 주의사항**: 없음 (스키마 변경 없음, 읽기 전용)
- **롤백 시 영향**: 없음 (신규 라우트, 기존 경로 무변경)
- **먼저 볼 화면 / 흐름**: `/sermons/series` → 시리즈 카드 클릭 → `/sermons/series/<uuid>`

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- `bySeriesSlug`는 의도적으로 유지 — 통합 정리는 Phase 7+ 별건
- 영상 재생/SEO는 Phase 7·8 범위로 이 PR에서 의도적 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)