### PR TITLE
[Feat] 모든 시리즈 페이지(/sermons/series) — 상태·연도·검색 필터

### DIFF
--- a/docs/exec-plans/active/2026-05-15-sermons-all-series.md
+++ b/docs/exec-plans/active/2026-05-15-sermons-all-series.md
@@ -1,0 +1,158 @@
+# sermons-all-series
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-15
+- **브랜치**: feat/sermons-archive
+- **Open questions**: none
+- **ADR needed**: no — 신규 라우트 페이지 + UI 컴포넌트 + URL 헬퍼. services/sermon는 기존 `getAllSeries` 재사용(신규 쿼리·캐시·레이어 변경 없음). 신규 util은 app 레이어 보조.
+
+## 목표
+
+`/sermons/series`(현재 스켈레톤)를 mockup `AllSeriesPCPage`/`AllSeriesMPage` 패턴의 모든 시리즈 목록 페이지로 구현 — **상태(전체/진행중/완료)·연도·검색** 필터 + 3열 그리드(PC)/세로 리스트+BottomSheet(모바일). 설교자 축은 데이터 모델 미지원으로 제외(Non-goals). Phase 3 `/sermons/all` 구조를 시리즈 축으로 복제.
+
+> **개정 이력**: Option C(하이브리드) 채택 — Codex 계획 검증 CHANGE_REQUEST(CR-1·2·3) 반영. 설교자 필터 제외, 전체 시리즈 조회용 신규 서비스 함수 추가(getAllSeries 불변), year는 컬럼 직접, SeriesCard 완료 상태 분기.
+
+## 검증된 Assumptions
+
+- `src/app/(content)/sermons/series/page.tsx` 스켈레톤(제목+LayoutContainer만) — Explore Read 확인
+- `allSeries()`(=`getAllSeries`)는 `.eq('is_active', true)` 적용 — **활성 시리즈만 반환, 완료 시리즈 제외** — `sermon-service.ts:125` 확인 (CR-1)
+- `sermon_series` Row에 preacher 컬럼·relationship 0개 (`Relationships: []`) — **시리즈→설교자 직접 불가** — `database.types.ts` 확인 (CR-2)
+- `sermon_series.year`(number|null) 컬럼 존재 — 연도 필터는 overlap 계산 불요, 컬럼 직접 사용 — `database.types.ts` 확인
+- `SeriesCard`(`SermonSeriesCarousel/SeriesCard.tsx`)는 "ON-GOING"/"진행 중" 하드코딩(`:27,:35`) — 완료 표시 분기 필요 (CR-3). 캐러셀은 진행중만 전달하므로 분기 추가는 후방호환
+- `buildFilterHref`(`utils/search-params.ts:26`)는 basePath·keys 범용 — 재사용 가능
+- `buildSermonHref`/`SERMON_FILTER_KEYS`는 `/sermons/all` 고정 — 시리즈 재사용 불가
+
+## Non-goals
+
+- **설교자 필터·검색** — `sermon_series`에 preacher 없음. 시리즈→설교자는 sermons join 데이터모델 작업 필요 → **후속 task 분리** (tech-debt-tracker 등록)
+- 시리즈 상세 `/sermons/series/[id]` — **Phase 5**
+- 데이터 페칭 캐시·로딩/에러 UI — Phase 6 / 검색 디바운스·URL 정교화 — Phase 7
+- 정렬 드롭다운 — `is_active desc → started_at desc` 고정, sort param 없음
+- `getAllSeries` 동작·select 변경 — 공유 함수(캐러셀·admin·`/sermons/all`) 회귀 방지, 신규 함수로 분리
+
+## 의사결정 로그
+
+- **D1 — 시리즈 전용 URL 헬퍼 신설**: `utils/sermon.ts`에 `SERIES_FILTER_KEYS`(`status`/`year`/`q`) + `buildSeriesHref`/`parseSeriesParams` 추가, 범용 `buildFilterHref('/sermons/series', …)` 위임. 기존 `SERMON_*`와 별도 네이밍.
+- **D2(개정) — 전체 시리즈 조회 신규 함수 추가, getAllSeries 불변**: `allSeries()`는 `is_active=true` 고정이라 완료 미반환(CR-1). 공유 함수 변경은 캐러셀·admin 회귀(#6 교훈) → `getAllSeriesIncludingInactive()`(가칭) 신규: `.eq('is_active')` 제거 + sermon_count, `createStaticClient` 캐시 동일 패턴. `/sermons/series` 전용. status/year/q 필터·카운트는 결과셋에서 JS 계산.
+- **D3(개정) — SeriesCard 완료 상태 분기**: "ON-GOING"/"진행 중" 하드코딩을 `is_active` 분기로("진행 중"/"종료", 배지 동일). 캐러셀(진행중만 전달)에 후방호환. 신규 카드 안 만듦.
+- **D4 — 사이드바/시트 신규(패턴만 복제)**: 필터축(status/year)이 달라 `SermonSidebar`/`AdvancedFilterSheet` prop 재사용 불가 → `SeriesFilterSidebar`/`SeriesFilterBottomSheet` 신규. SCSS는 `SermonListPage.module.scss` `.radio`/`.option`/`.body` 패턴 복제한 `SeriesListPage.module.scss` 1개 통합.
+- **D5 — 연도 필터는 `sermon_series.year` 컬럼 직접**: mockup의 started~ended overlap 계산 불요(실 DB에 `year` 컬럼 존재). year 옵션·카운트는 결과셋 distinct year로 생성.
+- **DL-1(정합)**: status/year/q 필터 로직 위치는 `utils/sermon.ts`의 `filterSeries()` (page.tsx에서 호출). "page.tsx JS 계산" 표현을 util 함수 호출로 통일.
+- **DL-2 — 신규 캐시 tag 분리 명시** (Codex 재검증 decision-log): `getAllSeriesIncludingInactive()`는 `sermonCache.seriesListIncludingInactive()`(가칭) 신규 helper로 별도 tag `sermon-series-list-all` 사용 — 기존 `seriesList()` tag `[ROOT,'sermon-series-list']`와 분리해 캐시 혼선 차단.
+- **DL-3 — `sermon_series.year` 실 DB 검증**: dev(`mficogrxekuahjqborxw`) `execute_sql` 결과 시리즈 2건 모두 `year` non-null, `year == extract(year from started_at)` 100% 일치 → year 컬럼 직접 사용 확정. 단 **연도 필터 의미 = 시리즈당 단일 연도**(mockup started~ended overlap과 의도적 분기 — 실 DB는 단일 `year` 모델).
+- **DL-4 — dev 완료 시리즈 0건**: dev에 `is_active=false` 시리즈 0건. "완료" 필터 로직(`getAllSeriesIncludingInactive` 활성+완료 반환 + status 분기)은 정상이나 dev 데이터로는 빈 결과 — 검증은 로직·타입 기준, 완료 시드 시 표시 별도 확인.
+
+## Success Criteria
+
+- `/sermons/series` PC: 좌 사이드바(상태/연도 라디오 + 검색) + 우 3열 SeriesCard 그리드 + 결과 헤더("총 N개 시리즈")
+- 모바일: 검색 + 필터 아이콘(활성 카운트 배지) + BottomSheet(상태/연도, staged 적용) + 1열 리스트
+- 상태=진행중 → `is_active` 시리즈만, 완료 → `!is_active`만 (신규 함수가 활성+완료 모두 반환)
+- 연도=Y → `sermon_series.year === Y`, 검색어 → title·description 매칭
+- 미존재 필터값 URL 안전(throw 없음), 초기화 링크 동작
+- SeriesCard가 완료 시리즈를 "종료"로 정확 표시 / 캐러셀(진행중) 회귀 없음
+- `node scripts/verify-task.mjs sermons-all-series` PASS
+
+## 영향받는 파일
+
+- `src/app/(content)/sermons/series/page.tsx` — 스켈레톤 → 구현
+- `src/app/(content)/sermons/_component/SeriesListPage/` — SeriesFilterSidebar·SeriesFilterBottomSheet·SeriesResultHeader·SeriesGrid + `SeriesListPage.module.scss` (신규, 통합 1 scss)
+- `src/utils/sermon.ts` — `SERIES_FILTER_KEYS`·`buildSeriesHref`·`parseSeriesParams`·`filterSeries`(status/year/q) 추가
+- `src/services/sermon/sermon-service.ts` + `index.ts` — `getAllSeriesIncludingInactive()` 신규(읽기 전용, `getAllSeries` 불변)
+- `src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx` — `is_active` 완료 분기 (CR-3)
+- 재사용(무변경): `getAllPreachers` 미사용, `buildFilterHref`
+
+## 단계별 체크리스트
+
+- [ ] 1. `sermon-service.ts`+`index.ts` `getAllSeriesIncludingInactive()` (active+완료, sermon_count)
+- [ ] 2. `utils/sermon.ts` 시리즈 헬퍼(`SERIES_FILTER_KEYS`/`buildSeriesHref`/`parseSeriesParams`/`filterSeries`)
+- [ ] 3. `SeriesCard.tsx` `is_active` 완료 분기 (CR-3)
+- [ ] 4. `SeriesListPage.module.scss` (전체설교 패턴 복제 + 3열 그리드)
+- [ ] 5. SeriesFilterSidebar (PC, 상태/연도 라디오 + 검색)
+- [ ] 6. SeriesFilterBottomSheet (모바일 staged)
+- [ ] 7. SeriesResultHeader + SeriesGrid(SeriesCard 재사용)
+- [ ] 8. `series/page.tsx` 조립 (신규 함수 → filterSeries → 렌더, 미존재값 가드)
+- [ ] 9. verify-task
+
+## Verification
+
+- `node scripts/verify-task.mjs sermons-all-series`
+- `/sermons/series` PC: 상태(진행중/완료)/연도 필터 토글 → 그리드·카운트 갱신, 초기화 동작
+- `/sermons/series?status=ended&year=2025&q=...` 직접 진입 일관, 미존재값 throw 없음
+- 모바일: 필터 아이콘 배지·BottomSheet staged 적용 → 리스트 갱신
+- `/sermons`(진행중 시리즈 캐러셀) SeriesCard 표기 회귀 없음
+
+## ADR 판단
+
+- **불필요** — `getAllSeriesIncludingInactive()`는 기존 `allSeries` 패턴(읽기 전용 select + `createStaticClient` 캐시)을 따르는 신규 함수일 뿐, 캐시·라이브러리·레이어 경계·인증 정책 변경 없음. `getAllSeries` 불변. ADR_TRIGGER_PARTS(`src/services/`) 포함하나 영구 결정 아님. `start-adr` 미실행.
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: PASS_WITH_DECISION_LOG (재검증 confidence high — 1차 CHANGE_REQUEST 3건 반영 후)
+
+### 재검증 (Option C 개정 후)
+
+> CR-1 해소 — `getAllSeriesIncludingInactive()` 신규 함수가 완료 포함 반환, `getAllSeries`(carousel·admin 5곳) 불변. MATERIAL resolved.
+> CR-2 해소 — 설교자 Non-goal 분리가 데이터 계약과 일치(`sermon_series` preacher 0개, `sermons`만 `sermons_preacher_id_fkey`). Success Criteria preacher 미참조.
+> CR-3 해소 — `SeriesCard` `is_active` 분기 필요·후방안전(`/sermons/page.tsx:45` `ended_at===null`로 carousel엔 진행중만 전달).
+> 잔여 decision-log 2건(material 아님): 신규 cache tag 명시(→DL-2), `year` 채움 파일검증 불가(→DL-3 실 DB 검증 완료).
+
+**풀이**: 3개 material CR 모두 닫힘. 신규 회귀 없음. cache tag·year 채움은 의사결정 로그 DL-2/3/4로 고정. WORK 진입 가능(3차 재검증 안 함).
+
+### 1차 (초안) — CHANGE_REQUEST
+
+material CR 3건 (Claude 교차검증 확정):
+
+> CR-1: `완료` 상태 필터가 `getAllSeries()` 재사용 계획으로 불가 — `sermon-service.ts:125` `.eq('is_active', true)`가 완료 시리즈를 제거. `/sermons/series?status=ended`는 항상 0개.
+> CR-2: 설교자 필터·검색이 데이터 계약에 없음 — `database.types.ts` `sermon_series` Row에 preacher 컬럼 0개, `Relationships: []`. 시리즈→설교자는 sermons join 필요.
+> CR-3: `SeriesCard` 무변경 재사용이 완료 시리즈 오표시 — `SeriesCard.tsx:27/35` "ON-GOING"/"진행 중" 하드코딩.
+> DL-1(expression): D2 "page.tsx JS 계산" vs 영향파일 `utils/sermon.ts filterSeries` 위치 불일치 — 한 줄 정합.
+
+**풀이**: Phase 4 mockup은 시리즈가 status·preacher·year를 가진 SERIES_DATA를 가정했으나, 실제 DB는 (a) getAllSeries가 활성만 반환, (b) sermon_series에 preacher 없음. 무서비스변경(D2)·SeriesCard무변경(D3) 전제가 깨짐. `sermon_series.year` 컬럼은 존재 → year 필터는 overlap 불요. 스코프 재결정 필요(서비스 확장 vs 필터 축소).
+
+## Codex 1차 검증
+
+- **결론**: CHANGE_REQUEST (Phase 4 코드는 전 항목 OK — 유일 지적은 무관 아티팩트)
+
+> A 타입/버그 OK · B 레이어 OK(page→service, apis 우회 없음) · C **CR**: `pr90_diff.txt`(루트 untracked, PR #90 아티팩트, Phase 4 무관) 커밋 전 정리 필요 · D SCSS OK(semantic token만, 믹스인 존재, sheet_*/sidebar .option 분리) · E 캐시 OK(별도 tag, createStaticClient) · F 필터정확성 OK(status/year/q + facet count) · G unused: yarn lint sandbox 차단 → Claude verify-task로 확인
+
+**풀이**: Phase 4 신규/변경 코드는 타입·레이어·SCSS·캐시·필터 전부 통과. CR은 코드 결함이 아니라 세션 시작부터 있던 무관 untracked 파일 `pr90_diff.txt` 위생 지적 — 명시적 파일 스테이징으로 커밋 미포함, 사용자 파일이라 임의 삭제 안 함.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS
+
+### 교차 확인
+
+- Codex CR(`pr90_diff.txt`)은 Phase 4 산출물 아님 — 세션 시작 git status부터 존재한 PR #90 아티팩트. 커밋은 신규/변경 파일만 명시 스테이징하므로 미포함. 파괴적 액션(임의 삭제) 회피 — 사용자에 gitignore/삭제 위임.
+- `node scripts/verify-task.mjs sermons-all-series` PASS — ESLint(G 항목 커버)·build·type·stylelint 통과. Knip 경고는 기존 barrel false-positive.
+- Codex 직접수정 0건 — diff 변경 없음. 외과적: 변경 라인 전부 Phase 4 추적(SeriesCard 분기는 D3, 캐러셀 후방안전).
+- DB 검증(DL-3) 반영 확인: year 컬럼 직접 사용, dev 완료 0건(DL-4) — "완료" 필터 로직 정상이나 dev 데이터 빈 결과(시드 시 표시 별도 확인).
+
+## 전제 오류 정정 (PR #92 #4 동형 결함)
+
+D2(개정)/DL-2의 `getAllSeriesIncludingInactive` 신설 결정이 **전제 오류**였음. CR-1("`allSeries`가 완료 제외")이 dev 완료 0건(DL-4)으로 미검증 채택된 게 근인.
+
+- **근거**: `is_active`는 전역 공개 노출 게이트(worship/staff/allSeries/bySeriesSlug/allPreachers 일관), 생애주기는 별축 `ended_at`(page.tsx:45·SermonSeriesBanner:23·SermonSeriesSidebar:17). 완료 시리즈 = `is_active=true`+`ended_at!=null` → `allSeries`가 이미 완료 포함. `is_active` 필터 제거는 숨김 시리즈까지 공개 노출(PR #92 #4와 동형).
+- **수정 7건**: `allSeriesIncludingInactive` 메서드·`getAllSeriesIncludingInactive` wrapper·`seriesListAll` 태그 삭제 / `series/page.tsx` `getAllSeries()` 재사용 / `filterSeries` status 술어 `is_active`→`ended_at`(active=ended_at===null, ended=ended_at!==null) / `SeriesCard` 뱃지·메타 `ended_at` 축(Phase 5 SeriesDetailHero와 동일 패턴, `~` dot 통합).
+- **트레이드오프**: 삭제 함수의 `.order('is_active',desc)` "진행 중 우선" 정렬 소실 — 모든 공개 행이 is_active=true라 무의미했고 status 필터로 대체. 별도 정렬 요구 시 ended_at 기준 후속.
+- **검증**: verify-task `20260516-135216` PASS(tsc/lint/lint:styles 0). Codex 1차 **PASS**(의미구조 SOUND·수정 완전·캐시 정합·정렬 수용). Claude 2차 교차: 소스 dangling 0(`grep src`), `sermon-series-list-all` revalidate 참조 0(actions/services), `ended_at: string | null`(undefined 없음 → badge `===null`/meta `?` 타입 정합).
+- **ADR 판단(보강)**: 불필요 — 잉여 함수 삭제·기존 `allSeries` 재사용·기존 `ended_at` 컨벤션 준수. 신규 정책 아님, `start-adr` 미실행. tech-debt-tracker 해당 항목 해소 처리 예정.
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+-->
+
+<!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -337,9 +337,9 @@
 - **영향 범위**: `src/services/sermon/sermon-service.ts` (2 쿼리), 소비처 5곳
 - **발견일**: 2026-05-15 (PR #91 Gemini 코드리뷰 제안 / Codex 1차에서 회귀 확인)
 
-### 🟡 `allSeriesIncludingInactive` 전제 오류 — 완료축을 is_active로 착각 (Phase 4)
+### ✅ `allSeriesIncludingInactive` 전제 오류 — 완료축을 is_active로 착각 (Phase 4) (2026-05-16 해소)
 
-- **상태**: 🟡 Phase 4 PR 전 재검토 필수
+- **상태**: ✅ 해결됨 — `allSeriesIncludingInactive`/wrapper/`seriesListAll` 태그 삭제, `series/page.tsx`가 `getAllSeries()` 재사용, `filterSeries`·`SeriesCard` `ended_at` 축 전환. verify PASS·Codex 1차 PASS·Claude 2차 교차 클린. exec-plan "전제 오류 정정" 참조
 - **무엇**: `feat/sermons-all-series`(미PR) Phase 4가 "완료 시리즈도 목록 노출" 목적으로 `is_active` 필터를 제거한 `allSeriesIncludingInactive`/`getAllSeriesIncludingInactive` 신설
 - **왜 오류**: dnchurch에서 `is_active`=공개 노출 게이트(`worship`/`staff`/`allSeries`/`bySeriesSlug`/`allPreachers` 일관), 완료 판정은 별축 `ended_at`(`page.tsx:45`·`SermonSeriesBanner:23`·`SermonSeriesSidebar:17`). 완료 시리즈는 `is_active=true`+`ended_at!=null`이라 **`allSeries`(is_active=true)가 이미 완료 포함** → `allSeriesIncludingInactive`는 불필요할뿐 아니라 숨김(is_active=false) 시리즈까지 목록 노출(PR #92 #4와 동형 결함). Phase 4 계획 Codex CR-1("getAllSeries가 완료 제외")이 데이터 검증 없이 채택된 게 근인(dev DB 완료 시리즈 0건이라 미검출)
 - **마이그레이션 경로**: Phase 4 PR 전 (a) `allSeriesIncludingInactive` 폐기하고 `allSeries` 재사용 가능 여부 확인(완료 시리즈 표시는 ended_at 분기로), (b) 불가 시 `is_active=true` 유지한 채 정렬만 조정

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterBottomSheet.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterBottomSheet.tsx
@@ -5,7 +5,11 @@ import clsx from 'clsx';
 import { IoCheckmark } from 'react-icons/io5';
 import { BottomSheet, Button } from '@/components/ui';
 import useSeriesFilter from '@/hooks/useSeriesFilter';
-import { getSeriesYearOptions, type SeriesStatusFilter } from '@/utils/sermon';
+import {
+  getSeriesYearOptions,
+  SERIES_STATUS_OPTIONS,
+  type SeriesStatusFilter
+} from '@/utils/sermon';
 import type { SeriesWithSermonCount } from '@/types/sermon';
 import styles from './SeriesListPage.module.scss';
 
@@ -77,13 +81,7 @@ export default function SeriesFilterBottomSheet({
       <section className={styles.sheet_section}>
         <h3 className={styles.sheet_title}>상태</h3>
         <ul role="list" className={styles.sheet_option_list}>
-          {(
-            [
-              { value: null, label: '전체' },
-              { value: 'active', label: '진행 중' },
-              { value: 'ended', label: '완료' }
-            ] as { value: SeriesStatusFilter | null; label: string }[]
-          ).map((option) => (
+          {SERIES_STATUS_OPTIONS.map((option) => (
             <li key={option.label}>
               <FilterOption
                 label={option.label}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterBottomSheet.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterBottomSheet.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+import { IoCheckmark } from 'react-icons/io5';
+import { BottomSheet, Button } from '@/components/ui';
+import useSeriesFilter from '@/hooks/useSeriesFilter';
+import { getSeriesYearOptions, type SeriesStatusFilter } from '@/utils/sermon';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import styles from './SeriesListPage.module.scss';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  allSeries: SeriesWithSermonCount[];
+};
+
+type Draft = {
+  status: SeriesStatusFilter | null;
+  year: number | null;
+};
+
+function parseStatus(raw: string | null): SeriesStatusFilter | null {
+  return raw === 'active' || raw === 'ended' ? raw : null;
+}
+
+export default function SeriesFilterBottomSheet({
+  open,
+  onClose,
+  allSeries
+}: Props) {
+  const { status, year, setFilter } = useSeriesFilter();
+  const yearOptions = getSeriesYearOptions(allSeries);
+
+  const [draft, setDraft] = useState<Draft>({
+    status: parseStatus(status),
+    year: year ? Number(year) : null
+  });
+
+  // open 시점에만 현재 URL state를 draft에 동기화 — 시트 열린 동안 staged 의도 보존
+  useEffect(() => {
+    if (open) {
+      setDraft({
+        status: parseStatus(status),
+        year: year ? Number(year) : null
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const handleReset = () => setDraft({ status: null, year: null });
+
+  const handleApply = () => {
+    setFilter({
+      status: draft.status,
+      year: draft.year != null ? String(draft.year) : null
+    });
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      title="필터"
+      footer={
+        <>
+          <Button variant="secondary" fullWidth onClick={handleReset}>
+            초기화
+          </Button>
+          <Button fullWidth onClick={handleApply}>
+            적용
+          </Button>
+        </>
+      }
+    >
+      <section className={styles.sheet_section}>
+        <h3 className={styles.sheet_title}>상태</h3>
+        <ul role="list" className={styles.sheet_option_list}>
+          {(
+            [
+              { value: null, label: '전체' },
+              { value: 'active', label: '진행 중' },
+              { value: 'ended', label: '완료' }
+            ] as { value: SeriesStatusFilter | null; label: string }[]
+          ).map((option) => (
+            <li key={option.label}>
+              <FilterOption
+                label={option.label}
+                selected={draft.status === option.value}
+                onClick={() => setDraft((d) => ({ ...d, status: option.value }))}
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.sheet_section}>
+        <h3 className={styles.sheet_title}>연도</h3>
+        <ul role="list" className={styles.sheet_option_list}>
+          <li>
+            <FilterOption
+              label="전체"
+              selected={draft.year === null}
+              onClick={() => setDraft((d) => ({ ...d, year: null }))}
+            />
+          </li>
+          {yearOptions.map((option) => (
+            <li key={option}>
+              <FilterOption
+                label={`${option}년`}
+                selected={draft.year === option}
+                onClick={() => setDraft((d) => ({ ...d, year: option }))}
+              />
+            </li>
+          ))}
+        </ul>
+      </section>
+    </BottomSheet>
+  );
+}
+
+function FilterOption({
+  label,
+  selected,
+  onClick
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={clsx(styles.sheet_option, selected && styles.sheet_option_active)}
+      onClick={onClick}
+      aria-pressed={selected}
+    >
+      <span>{label}</span>
+      {selected && <IoCheckmark aria-hidden="true" />}
+    </button>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterButton.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+import { IoFunnelOutline } from 'react-icons/io5';
+import SeriesFilterBottomSheet from './SeriesFilterBottomSheet';
+import useSeriesFilter from '@/hooks/useSeriesFilter';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import styles from './SeriesListPage.module.scss';
+
+type Props = {
+  allSeries: SeriesWithSermonCount[];
+};
+
+export default function SeriesFilterButton({ allSeries }: Props) {
+  const [open, setOpen] = useState(false);
+  const { activeFilterCount } = useSeriesFilter();
+
+  return (
+    <>
+      <button
+        type="button"
+        className={styles.filter_btn}
+        onClick={() => setOpen(true)}
+        aria-label={
+          activeFilterCount > 0
+            ? `필터 열기 (${activeFilterCount}개 적용됨)`
+            : '필터 열기'
+        }
+      >
+        <IoFunnelOutline aria-hidden="true" />
+        <span className={styles.filter_label}>필터</span>
+        {activeFilterCount > 0 && (
+          <span className={styles.filter_badge} aria-hidden="true">
+            {activeFilterCount}
+          </span>
+        )}
+      </button>
+      <SeriesFilterBottomSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        allSeries={allSeries}
+      />
+    </>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterSidebar.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterSidebar.tsx
@@ -6,6 +6,7 @@ import {
   buildSeriesHref,
   filterSeries,
   getSeriesYearOptions,
+  SERIES_STATUS_OPTIONS,
   type SeriesStatusFilter
 } from '@/utils/sermon';
 import type { SearchParams } from '@/utils/search-params';
@@ -20,12 +21,6 @@ type Props = {
   hasActiveFilter: boolean;
   params: SearchParams;
 };
-
-const STATUS_OPTIONS: { value: SeriesStatusFilter | null; label: string }[] = [
-  { value: null, label: '전체' },
-  { value: 'active', label: '진행 중' },
-  { value: 'ended', label: '완료' }
-];
 
 export default function SeriesFilterSidebar({
   allSeries,
@@ -65,7 +60,7 @@ export default function SeriesFilterSidebar({
           </h3>
           <nav aria-label="상태 필터">
             <ul role="list" className={styles.option_list}>
-              {STATUS_OPTIONS.map((option) => (
+              {SERIES_STATUS_OPTIONS.map((option) => (
                 <li key={option.label}>
                   <FilterItem
                     href={buildSeriesHref(params, { status: option.value })}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterSidebar.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesFilterSidebar.tsx
@@ -1,0 +1,157 @@
+import Link from 'next/link';
+import clsx from 'clsx';
+import { ListItem } from '@/components/ui';
+import SeriesSearchForm from './SeriesSearchForm';
+import {
+  buildSeriesHref,
+  filterSeries,
+  getSeriesYearOptions,
+  type SeriesStatusFilter
+} from '@/utils/sermon';
+import type { SearchParams } from '@/utils/search-params';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import styles from './SeriesListPage.module.scss';
+
+type Props = {
+  allSeries: SeriesWithSermonCount[];
+  status?: SeriesStatusFilter;
+  year?: number;
+  q?: string;
+  hasActiveFilter: boolean;
+  params: SearchParams;
+};
+
+const STATUS_OPTIONS: { value: SeriesStatusFilter | null; label: string }[] = [
+  { value: null, label: '전체' },
+  { value: 'active', label: '진행 중' },
+  { value: 'ended', label: '완료' }
+];
+
+export default function SeriesFilterSidebar({
+  allSeries,
+  status,
+  year,
+  q,
+  hasActiveFilter,
+  params
+}: Props) {
+  const yearOptions = getSeriesYearOptions(allSeries);
+  const resetHref = buildSeriesHref(params, {
+    status: null,
+    year: null,
+    q: null
+  });
+
+  return (
+    <aside className={styles.sidebar}>
+      <div className={clsx(styles.sidebar_inner, styles.sidebar_card)}>
+        <header className={styles.sidebar_header}>
+          <h2 className={styles.sidebar_title}>필터</h2>
+          {hasActiveFilter && (
+            <Link href={resetHref} className={styles.sidebar_reset} scroll={false}>
+              초기화
+            </Link>
+          )}
+        </header>
+
+        <SeriesSearchForm />
+
+        <section
+          aria-labelledby="series-status-heading"
+          className={styles.sidebar_section}
+        >
+          <h3 id="series-status-heading" className={styles.section_label}>
+            상태
+          </h3>
+          <nav aria-label="상태 필터">
+            <ul role="list" className={styles.option_list}>
+              {STATUS_OPTIONS.map((option) => (
+                <li key={option.label}>
+                  <FilterItem
+                    href={buildSeriesHref(params, { status: option.value })}
+                    active={(status ?? null) === option.value}
+                    label={option.label}
+                    count={
+                      filterSeries(allSeries, {
+                        status: option.value ?? undefined,
+                        year,
+                        q
+                      }).length
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </section>
+
+        <section
+          aria-labelledby="series-year-heading"
+          className={styles.sidebar_section}
+        >
+          <h3 id="series-year-heading" className={styles.section_label}>
+            연도
+          </h3>
+          <nav aria-label="연도 필터">
+            <ul role="list" className={styles.option_list}>
+              <li>
+                <FilterItem
+                  href={buildSeriesHref(params, { year: null })}
+                  active={year === undefined}
+                  label="전체"
+                  count={filterSeries(allSeries, { status, q }).length}
+                />
+              </li>
+              {yearOptions.map((option) => (
+                <li key={option}>
+                  <FilterItem
+                    href={buildSeriesHref(params, { year: String(option) })}
+                    active={year === option}
+                    label={`${option}년`}
+                    count={
+                      filterSeries(allSeries, {
+                        status,
+                        year: option,
+                        q
+                      }).length
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+function FilterItem({
+  href,
+  active,
+  label,
+  count
+}: {
+  href: string;
+  active: boolean;
+  label: string;
+  count: number;
+}) {
+  return (
+    <ListItem
+      href={href}
+      selected={active}
+      scroll={false}
+      className={clsx(styles.option, active && styles.option_active)}
+      trailing={<span className={styles.option_count}>{count}</span>}
+    >
+      <span
+        className={clsx(styles.radio, active && styles.radio_active)}
+        aria-hidden="true"
+      >
+        {active && <span className={styles.radio_dot} />}
+      </span>
+      <span className={styles.option_label}>{label}</span>
+    </ListItem>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesGrid.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesGrid.tsx
@@ -1,0 +1,32 @@
+import { EmptyState } from '@/components/ui';
+import SeriesCard from '../SermonSeriesCarousel/SeriesCard';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import styles from './SeriesListPage.module.scss';
+
+type Props = {
+  series: SeriesWithSermonCount[];
+};
+
+export default function SeriesGrid({ series }: Props) {
+  if (series.length === 0) {
+    return (
+      <EmptyState
+        title="조건에 맞는 시리즈가 없습니다"
+        description="다른 상태·연도나 검색어를 사용해 보세요"
+        announce
+      />
+    );
+  }
+
+  return (
+    <section aria-label="시리즈 목록">
+      <ul role="list" className={styles.grid}>
+        {series.map((item) => (
+          <li key={item.id}>
+            <SeriesCard series={item} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesListPage.module.scss
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesListPage.module.scss
@@ -1,0 +1,392 @@
+// 모든 시리즈 페이지 — /sermons/all (SermonListPage) 레이아웃 패턴 복제, 그리드만 3열.
+
+// ══════════════════════════════════════════
+// Body Layout
+// ══════════════════════════════════════════
+
+.body {
+  display: flex;
+  gap: $content-gap-l;
+  padding: $spacing-20 0 $section-gap-80;
+
+  @include respond-up($breakpoint-pc-sm) {
+    gap: $content-gap-xl;
+    padding: $section-gap-40 0;
+  }
+}
+
+// ── Sidebar (PC) ──
+
+$radio-size: 1.3rem;
+$radio-dot-size: 0.4rem;
+
+.sidebar {
+  display: none;
+
+  @include respond-up($breakpoint-pc-sm) {
+    display: block;
+    width: 26rem;
+    flex-shrink: 0;
+  }
+}
+
+.sidebar_inner {
+  position: sticky;
+  top: calc(#{$header-height} + #{$spacing-24});
+  max-height: calc(100vh - #{$header-height} - #{$spacing-40});
+  overflow-y: auto;
+}
+
+.sidebar_card {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  padding: $padding-card;
+}
+
+.sidebar_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: $spacing-12;
+  border-bottom: 1px solid $border-subtle;
+}
+
+.sidebar_title {
+  margin: 0;
+  font-size: $font-size-13;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+}
+
+.sidebar_reset {
+  font-size: $font-size-11;
+  font-weight: $font-weight-medium;
+  color: $txt-tertiary;
+  text-decoration: none;
+
+  @include hover-color-shift($primary);
+}
+
+.sidebar_section {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-12;
+}
+
+.section_label {
+  margin: 0;
+  padding: 0 $spacing-8;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  letter-spacing: $letter-spacing-wide;
+  color: $txt-tertiary;
+  text-transform: uppercase;
+}
+
+.option_list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: $spacing-8;
+  padding: $spacing-6 $spacing-12;
+  font-size: $font-size-13;
+  color: $txt-secondary;
+  border-radius: $radius-xs;
+
+  @include hover-bg-shift($bg-hover);
+}
+
+.option_active {
+  background-color: $primary-subtle;
+  color: $primary;
+  font-weight: $font-weight-semibold;
+}
+
+.radio {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: $radio-size;
+  height: $radio-size;
+  border: 1.5px solid $border-strong;
+  border-radius: $radius-circle;
+  background-color: transparent;
+}
+
+.radio_active {
+  border-color: $primary;
+  background-color: $primary;
+}
+
+.radio_dot {
+  width: $radio-dot-size;
+  height: $radio-dot-size;
+  border-radius: $radius-circle;
+  background-color: $txt-inverse;
+}
+
+.option_label {
+  min-width: 0;
+  overflow: hidden;
+  font-size: $font-size-13;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.option_count {
+  flex-shrink: 0;
+  font-size: $font-size-11;
+  font-weight: $font-weight-medium;
+  color: $txt-tertiary;
+  font-variant-numeric: tabular-nums;
+
+  .option_active & {
+    color: $primary;
+  }
+}
+
+// ── Main ──
+
+.main {
+  flex: 1;
+  min-width: 0;
+}
+
+// ── Toolbar (mobile) ──
+
+.toolbar_header {
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar {
+  display: flex;
+  gap: $spacing-8;
+  margin-bottom: $content-gap-m;
+
+  @include respond-up($breakpoint-pc-sm) {
+    display: none;
+  }
+}
+
+.search_form {
+  position: relative;
+  flex: 1;
+}
+
+.search_icon {
+  position: absolute;
+  top: 50%;
+  left: $spacing-12;
+  transform: translateY(-50%);
+  font-size: $font-size-16;
+  color: $txt-tertiary;
+  pointer-events: none;
+}
+
+.search_input {
+  width: 100%;
+  padding: $spacing-10 $spacing-40;
+  font-size: $font-size-14;
+  color: $txt-primary;
+  border: 1px solid $border-primary;
+  border-radius: $radius-s;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease;
+
+  &::placeholder {
+    color: $txt-tertiary;
+  }
+
+  &:focus {
+    background: $bg-primary;
+    border-color: $primary;
+  }
+}
+
+.search_clear {
+  position: absolute;
+  top: 50%;
+  right: $spacing-12;
+  transform: translateY(-50%);
+  display: inline-flex;
+  padding: $spacing-4;
+  font-size: $font-size-16;
+  color: $txt-tertiary;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+
+  &:hover {
+    color: $txt-primary;
+  }
+}
+
+.filter_btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-4;
+  min-width: 4.2rem;
+  padding: 0 $spacing-12;
+  font-size: $font-size-13;
+  font-weight: $font-weight-medium;
+  color: $txt-secondary;
+  background: $primary-subtle;
+  border: 1px solid $border-primary;
+  border-radius: $radius-s;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+
+  svg {
+    font-size: $font-size-18;
+  }
+
+  .filter_label {
+    @include blind;
+  }
+
+  &:hover {
+    color: $txt-primary;
+  }
+}
+
+.filter_badge {
+  position: absolute;
+  top: -0.6rem;
+  right: -0.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8rem;
+  height: 1.8rem;
+  padding: 0 $spacing-4;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  color: $txt-inverse;
+  background-color: $primary;
+  border: 2px solid $bg-card;
+  border-radius: $radius-circle;
+  font-variant-numeric: tabular-nums;
+}
+
+// ── Result Header ──
+
+.result_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-12;
+  margin-bottom: $content-gap-m;
+  padding-bottom: $spacing-12;
+  border-bottom: 1px solid $border-subtle;
+}
+
+.result_count {
+  margin: 0;
+  font-size: $font-size-13;
+  color: $txt-secondary;
+  word-break: keep-all;
+
+  strong {
+    color: $txt-primary;
+    font-weight: $font-weight-bold;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.result_query {
+  color: $primary;
+  font-weight: $font-weight-bold;
+}
+
+// ── Grid (3-col PC) ──
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: $content-gap-m;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  @include respond-up($breakpoint-tablet-sm) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include respond-up($breakpoint-pc-sm) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+// ── BottomSheet (mobile filter) — 사이드바 .option과 의미가 달라 별도 ──
+
+.sheet_section {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-8;
+  margin-bottom: $content-gap-l;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.sheet_title {
+  margin: 0 $spacing-8;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  letter-spacing: $letter-spacing-wide;
+  color: $txt-tertiary;
+  text-transform: uppercase;
+}
+
+.sheet_option_list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sheet_option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: $spacing-12 $spacing-16;
+  font-size: $font-size-14;
+  font-weight: $font-weight-medium;
+  color: $txt-primary;
+  text-align: left;
+  background-color: transparent;
+  border: none;
+  border-radius: $radius-s;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+}
+
+.sheet_option_active {
+  color: $primary;
+  font-weight: $font-weight-semibold;
+  background-color: $primary-subtle;
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesResultHeader.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesResultHeader.tsx
@@ -1,0 +1,33 @@
+import styles from './SeriesListPage.module.scss';
+
+type Props = {
+  resultCount: number;
+  query?: string;
+};
+
+export default function SeriesResultHeader({ resultCount, query }: Props) {
+  const trimmed = query?.trim();
+
+  return (
+    <header className={styles.result_header}>
+      <p className={styles.result_count}>
+        {trimmed ? (
+          <>
+            <strong className={styles.result_query}>
+              &ldquo;{trimmed}&rdquo;
+            </strong>
+            <span> 검색 결과 </span>
+            <strong>{resultCount}</strong>
+            <span>개</span>
+          </>
+        ) : (
+          <>
+            <span>총 </span>
+            <strong>{resultCount}</strong>
+            <span>개 시리즈</span>
+          </>
+        )}
+      </p>
+    </header>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesSearchForm.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesSearchForm.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { IoClose, IoSearch } from 'react-icons/io5';
+import useSeriesFilter from '@/hooks/useSeriesFilter';
+import styles from './SeriesListPage.module.scss';
+
+export default function SeriesSearchForm() {
+  const { q, setFilter } = useSeriesFilter();
+  const [input, setInput] = useState(q);
+
+  useEffect(() => {
+    setInput(q);
+  }, [q]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    setFilter({ q: input.trim() || null });
+  };
+
+  const handleClear = () => {
+    setInput('');
+    setFilter({ q: null });
+  };
+
+  return (
+    <search className={styles.search_form}>
+      <form role="search" onSubmit={handleSubmit}>
+        <IoSearch className={styles.search_icon} aria-hidden="true" />
+        <input
+          type="text"
+          className={styles.search_input}
+          placeholder="시리즈 제목·설명"
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          aria-label="시리즈 검색"
+        />
+        {input && (
+          <button
+            type="button"
+            className={styles.search_clear}
+            onClick={handleClear}
+            aria-label="검색어 지우기"
+          >
+            <IoClose />
+          </button>
+        )}
+      </form>
+    </search>
+  );
+}

--- a/src/app/(content)/sermons/_component/SeriesListPage/SeriesToolbar.tsx
+++ b/src/app/(content)/sermons/_component/SeriesListPage/SeriesToolbar.tsx
@@ -1,0 +1,19 @@
+import SeriesSearchForm from './SeriesSearchForm';
+import SeriesFilterButton from './SeriesFilterButton';
+import type { SeriesWithSermonCount } from '@/types/sermon';
+import styles from './SeriesListPage.module.scss';
+
+type Props = {
+  allSeries: SeriesWithSermonCount[];
+};
+
+export default function SeriesToolbar({ allSeries }: Props) {
+  return (
+    <header className={styles.toolbar_header}>
+      <div className={styles.toolbar}>
+        <SeriesSearchForm />
+        <SeriesFilterButton allSeries={allSeries} />
+      </div>
+    </header>
+  );
+}

--- a/src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx
+++ b/src/app/(content)/sermons/_component/SermonSeriesCarousel/SeriesCard.tsx
@@ -24,7 +24,9 @@ export default function SeriesCard({ series }: Props) {
           />
         )}
         <div className={styles.cover_scrim} aria-hidden />
-        <span className={styles.badge}>ON-GOING</span>
+        <span className={styles.badge}>
+          {series.ended_at === null ? 'ON-GOING' : 'COMPLETED'}
+        </span>
       </div>
       <div className={styles.body}>
         <h3 className={styles.title}>{series.title}</h3>
@@ -32,7 +34,11 @@ export default function SeriesCard({ series }: Props) {
         <div className={styles.meta_bar}>
           <span>{formattedDate(series.started_at, 'YYYY.MM.DD')}</span>
           <span className={styles.dot} aria-hidden>~</span>
-          <span className={styles.ongoing}>진행 중</span>
+          {series.ended_at ? (
+            <span>{formattedDate(series.ended_at, 'YYYY.MM.DD')}</span>
+          ) : (
+            <span className={styles.ongoing}>진행 중</span>
+          )}
           <span className={styles.dot} aria-hidden>·</span>
           <span className={styles.count}>{series.sermon_count}편</span>
         </div>

--- a/src/app/(content)/sermons/series/page.tsx
+++ b/src/app/(content)/sermons/series/page.tsx
@@ -1,15 +1,47 @@
 import type { Metadata } from 'next';
 import { LayoutContainer } from '@/components/layout';
+import { getAllSeries } from '@/services/sermon';
+import { filterSeries, parseSeriesParams } from '@/utils/sermon';
+import SeriesFilterSidebar from '../_component/SeriesListPage/SeriesFilterSidebar';
+import SeriesToolbar from '../_component/SeriesListPage/SeriesToolbar';
+import SeriesResultHeader from '../_component/SeriesListPage/SeriesResultHeader';
+import SeriesGrid from '../_component/SeriesListPage/SeriesGrid';
+import styles from '../_component/SeriesListPage/SeriesListPage.module.scss';
 
 export const metadata: Metadata = {
   title: '모든 시리즈',
-  description: '대구동남교회 강해 설교 시리즈 목록'
+  description: '대구동남교회 강해 설교 시리즈를 상태·연도·검색으로 찾아보세요'
 };
 
-export default function AllSeriesPage() {
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function AllSeriesPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const { status, year, q } = parseSeriesParams(params);
+  const hasFilter = !!(status || year || q);
+
+  const allSeries = await getAllSeries();
+  const filtered = filterSeries(allSeries, { status, year, q });
+
   return (
     <LayoutContainer>
-      <h1>모든 시리즈</h1>
+      <div className={styles.body}>
+        <SeriesFilterSidebar
+          allSeries={allSeries}
+          status={status}
+          year={year}
+          q={q}
+          hasActiveFilter={hasFilter}
+          params={params}
+        />
+        <div className={styles.main}>
+          <SeriesToolbar allSeries={allSeries} />
+          <SeriesResultHeader resultCount={filtered.length} query={q} />
+          <SeriesGrid series={filtered} />
+        </div>
+      </div>
     </LayoutContainer>
   );
 }

--- a/src/hooks/useSeriesFilter.ts
+++ b/src/hooks/useSeriesFilter.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { SERIES_FILTER_KEYS, type SeriesFilterPatch } from '@/utils/sermon';
+
+export default function useSeriesFilter() {
+  const router = useRouter();
+  const sp = useSearchParams();
+
+  const [statusKey, yearKey, qKey] = SERIES_FILTER_KEYS;
+
+  const status = sp.get(statusKey);
+  const year = sp.get(yearKey);
+  const q = sp.get(qKey) ?? '';
+  const isActive = !!(status || year || q);
+  const activeFilterCount =
+    (status ? 1 : 0) + (year ? 1 : 0) + (q.trim() ? 1 : 0);
+
+  const setFilter = useCallback(
+    (patch: SeriesFilterPatch) => {
+      const next = new URLSearchParams(sp);
+      for (const [key, value] of Object.entries(patch)) {
+        if (value === undefined) continue;
+        if (value === null || value === '') next.delete(key);
+        else next.set(key, value);
+      }
+      const qs = next.toString();
+      router.push(`/sermons/series${qs ? `?${qs}` : ''}`, { scroll: false });
+    },
+    [router, sp]
+  );
+
+  return { status, year, q, isActive, activeFilterCount, setFilter };
+}

--- a/src/utils/sermon.ts
+++ b/src/utils/sermon.ts
@@ -122,3 +122,59 @@ export const buildSermonHref = (
   return buildFilterHref('/sermons/all', params, keys, patch);
 };
 
+// ── 모든 시리즈 페이지(/sermons/series) 필터 ──
+// 설교자 축은 sermon_series에 preacher가 없어 제외 (후속 task). 정렬 고정이라 sort 없음.
+
+export const SERIES_FILTER_KEYS = ['status', 'year', 'q'] as const;
+
+export type SeriesStatusFilter = 'active' | 'ended';
+
+export type SeriesFilterPatch = {
+  status?: string | null;
+  year?: string | null;
+  q?: string | null;
+};
+
+export function parseSeriesParams(raw: SearchParams) {
+  const rawStatus = getString(raw, 'status');
+  return {
+    status: (rawStatus === 'active' || rawStatus === 'ended'
+      ? rawStatus
+      : undefined) as SeriesStatusFilter | undefined,
+    year: getInt(raw, 'year', { min: 1900, max: 2100 }),
+    q: getString(raw, 'q'),
+  };
+}
+
+export const buildSeriesHref = (
+  params: SearchParams,
+  patch: SeriesFilterPatch = {},
+): string => buildFilterHref('/sermons/series', params, SERIES_FILTER_KEYS, patch);
+
+export function filterSeries(
+  series: SeriesWithSermonCount[],
+  filters: { status?: SeriesStatusFilter; year?: number; q?: string },
+): SeriesWithSermonCount[] {
+  const query = filters.q?.trim().toLowerCase();
+  return series.filter((item) => {
+    if (filters.status === 'active' && item.ended_at !== null) return false;
+    if (filters.status === 'ended' && item.ended_at === null) return false;
+    if (filters.year !== undefined && item.year !== filters.year) return false;
+    if (query) {
+      const haystack = `${item.title} ${item.description ?? ''}`.toLowerCase();
+      if (!haystack.includes(query)) return false;
+    }
+    return true;
+  });
+}
+
+/** 결과셋에 존재하는 연도 옵션 (내림차순) */
+export function getSeriesYearOptions(
+  series: SeriesWithSermonCount[],
+): number[] {
+  const years = series
+    .map((item) => item.year)
+    .filter((year): year is number => year != null);
+  return [...new Set(years)].sort((a, b) => b - a);
+}
+

--- a/src/utils/sermon.ts
+++ b/src/utils/sermon.ts
@@ -135,13 +135,26 @@ export type SeriesFilterPatch = {
   q?: string | null;
 };
 
+// status 필터 옵션 (사이드바·BottomSheet 공용)
+export const SERIES_STATUS_OPTIONS: {
+  value: SeriesStatusFilter | null;
+  label: string;
+}[] = [
+  { value: null, label: '전체' },
+  { value: 'active', label: '진행 중' },
+  { value: 'ended', label: '완료' }
+];
+
+const SERIES_YEAR_MIN = 1900;
+const SERIES_YEAR_MAX = 2100;
+
 export function parseSeriesParams(raw: SearchParams) {
   const rawStatus = getString(raw, 'status');
   return {
     status: (rawStatus === 'active' || rawStatus === 'ended'
       ? rawStatus
       : undefined) as SeriesStatusFilter | undefined,
-    year: getInt(raw, 'year', { min: 1900, max: 2100 }),
+    year: getInt(raw, 'year', { min: SERIES_YEAR_MIN, max: SERIES_YEAR_MAX }),
     q: getString(raw, 'q'),
   };
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

강해 설교 시리즈를 상태(진행중/완료)·연도·검색으로 탐색하는 `/sermons/series` 목록 페이지. 카드 클릭 시 시리즈 상세(#92)로 진입.

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermons-all-series`
- **Exec Plan**: `docs/exec-plans/active/2026-05-15-sermons-all-series.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: `docs/tech-debt-tracker.md` — "동형 결함" 항목 ✅ 해소(본 PR)
- **작업 범위**: 시리즈 필터 유틸·훅, /sermons/series UI(사이드바·BottomSheet·그리드), SeriesCard 생애주기 표시
- **제외한 범위**: 설교자 축(sermon_series에 컬럼 없음), getAllSeries select 최적화(tech-debt 별건)

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:** `/sermons/series`가 제목만 있는 스켈레톤이라 시리즈 단위 탐색 진입점이 없었음. Phase 5 시리즈 상세(#92)의 목록 측 진입 동선 완성 필요.

**관련 이슈:** 없음 (Sermon-Implementation-Prompts Phase 4)

---

## 🔧 주요 변경점 (Key Changes)

- `utils/sermon`: `SERIES_FILTER_KEYS`·`buildSeriesHref`·`parseSeriesParams`·`filterSeries`·`getSeriesYearOptions` + `useSeriesFilter` 훅
- `series/page.tsx`: `getAllSeries()` + 상태/연도/검색 필터 조립, PC 3열 그리드 / 모바일 BottomSheet
- SeriesListPage 8파일(SCSS·SearchForm·FilterSidebar·FilterBottomSheet·FilterButton·Toolbar·ResultHeader·Grid)
- `SeriesCard` 뱃지·메타를 `ended_at` 축으로(ON-GOING/COMPLETED, 진행중 vs 종료일) — 캐러셀과 공유, 일관 표시

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 시리즈 조회 | 기존 `getAllSeries` 재사용 | `is_active`=발행/공개 게이트, 완료는 `ended_at` 별축이라 `getAllSeries`(is_active=true)가 이미 완료 포함 | 신규 `allSeriesIncludingInactive` — 숨김(초안) 시리즈 공개 노출(PR #92 #4 동형 결함) |
| 생애주기 판정 | `ended_at === null` | Banner/Sidebar/메인·상세와 동일 축 | `is_active` 분기 — 발행축 오용, 표시 불일치 |
| 설교자 필터 | 제외 | sermon_series에 설교자 컬럼 부재 | 추가 — 데이터모델 미지원 |

> ⚠️ **트레이드오프:** 시리즈 정렬은 `started_at` 내림차순(진행중 우선 정렬 없음) — 전 행 is_active=true라 무의미했고 상태 필터로 대체. 데이터 의미축(`is_active`=발행/공개, `ended_at`=완료)은 사용자 확인 완료(2026-05-16).

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | PASS, RUN_ID=`20260516-143416`, HEAD=`97c74b0`, failed=0, warned=Knip |
| `harness-gate` | PASS |
| Codex 계획 검증 | PASS_WITH_DECISION_LOG |
| Codex 1차 검증 | PASS (전제 오류 정정분) |
| Claude 2차 검증 | 완료 (소스 dangling 0·revalidate 0·ended_at 타입 정합 교차 확인) |
| ADR 판단 | 불필요 |
| 남은 warning | 기존 부채 (Knip) |

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: `/sermons/series` 신규 — 시리즈를 상태·연도·검색으로 탐색, 카드→상세 진입
- **운영 / 릴리스 주의사항**: 스키마 변경 없음, 읽기 전용. dev DB에 완료/숨김 시리즈 0건이라 "완료" 필터·숨김 비노출은 시드 후 화면 확인 권장
- **롤백 시 영향**: 없음 (신규 라우트 + 공유 SeriesCard는 ended_at 분기로 캐러셀 후방안전)
- **먼저 볼 화면 / 흐름**: `/sermons/series` 필터 동작 + `/sermons` 캐러셀 SeriesCard 뱃지 무회귀

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- `is_active`=발행/공개(초안↔공개), `ended_at`=완료 — 독립 축. 공개 쿼리는 `is_active=true` 항상 유지, 생애주기는 `ended_at`. 혼동 금지(exec-plan "전제 오류 정정" 절 참조)
- Phase 4 전제 오류는 미머지 단계에서 본체 커밋에 흡수 정정 — 코드 이력은 클린, 정정 경위는 exec-plan에 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)