### PR TITLE
[Chore] sermons 섹션 마감 — exec-plan 5건 부킹 + 접근성 4건 수정

### DIFF
--- a/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
+++ b/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
@@ -24,7 +24,7 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 - 새 기능 추가, 머지된 #91~#95 재작업.
 - sermons 밖 전역 접근성·성능.
 - ADR_TRIGGER 파일 변경: `next.config.*`·`package.json`·`src/services/`·`scripts/`. 새 a11y/perf 라이브러리(axe-core 등) 도입. 그런 결함이 나오면 별도 plan/ADR로 분리한다.
-- 부킹(이미 커밋된 exec-plan 5건 이관 + tech-debt) — 별개 의도. 같은 브랜치에 있으나 별 커밋. PR 시점에 분리 결정(의사결정 로그 D1).
+- 부킹(이미 커밋된 exec-plan 5건 이관 + tech-debt) — 별개 의도. 같은 브랜치에 있으나 별 커밋. PR 시점에 분리 결정(의사결정 로그 D2).
 
 ## Success Criteria
 
@@ -114,9 +114,9 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 
 ## Claude 2차 검증
 
-- **최종 판단**: PASS
-- **현재 판단**: verify-task PASS(20260518-161602). h1→h2 className 기반이라 무영향(scss/querySelector/JSON-LD 의존 0). focus-visible 토큰 정합. ::before 교정으로 아이콘 위치 불변·탭타깃 ≥48px.
-- **다음 행동**: 커밋 승인 대기.
+- **최종 판단**: PASS (PR #97 외부 리뷰로 h1 회귀 1건 교정)
+- **현재 판단**: focus-visible 토큰 정합, `::before` 교정으로 아이콘 위치 불변·탭타깃 ≥48px은 그대로 유효. 단 h1→h2는 **회귀였고 되돌렸다** — `resolveHeroMeta('/sermons/123')`은 `HERO_META` direct(`/sermons`,`/sermons/all`,`/sermons/series`) 미스 + `GNB_ITEMS` 정확매칭 미스로 `null` 반환(`hero.config.ts:31~56`) → `Hero.tsx:13 if (!meta) return null` → 상세 페이지에 Hero h1 없음. `SermonDetailPage`의 h1이 그 페이지 유일 h1이었다.
+- **다음 행동**: `SermonDetailPage.tsx:94` h2→h1 환원 완료. 재verify PASS(20260518-183603, Knip 기존 부채). 커밋 승인 대기.
 
 ## 검증 이력
 
@@ -144,6 +144,17 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 - 판정: PASS (confidence medium)
 - 이유: 사용자 요청으로 교정본 독립 교차검증. 범위를 4파일로 한정해 과지연 재발 방지.
 - 조치: 변경 없음 — h1→h2·focus-visible·::before·surgical 전부 확인. Claude 대행 결과 독립 재확인.
+- 한계: bounded 프롬프트에 "`(content)/layout.tsx`가 모든 sermons 라우트에 Hero h1 렌더" 전제를 줬다. 이 전제가 거짓이라 h1→h2 회귀를 못 잡았다.
+
+</details>
+
+<details>
+<summary>2026-05-18 PR #97 외부 리뷰 (Codex GitHub bot · Gemini)</summary>
+
+- 판정: 지적 2건 전부 유효 — 반영 완료.
+- Codex P2 (`SermonDetailPage.tsx:94`): `/sermons/[id]`는 Hero가 안 떠 자체 h1이 페이지 유일 h1. h2 변경은 h1 소실 회귀. → h1으로 환원.
+- Gemini medium (`2026-05-18-sermons-a11y-perf.md:27`): 부킹 분리 결정 참조가 `D1`인데 실제는 `D2`(94행). → `D2`로 정정.
+- 교훈: 내부 bounded 교차검증에 거짓 전제를 주입하면 PASS가 무의미. SSOT(`hero.config.ts`) 직접 확인이 audit/전제보다 우선(ADR 0010).
 
 </details>
 

--- a/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
+++ b/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
@@ -16,30 +16,40 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 ## 검증된 Assumptions
 
 - 레퍼런스 미구현은 8-3·8-4뿐이다. Phase 0~7·8-1·8-2는 #91~#95로 머지됐다. (`Sermon-Implementation-Prompts.md:803-832`, develop log 확인)
-- sermons UI는 `src/app/(content)/sermons/_component/` 하위에 모인다. (Glob 확인 예정)
+- sermons UI = `src/app/(content)/sermons/_component/` 하위 16개 컴포넌트 디렉토리. 라우트 5개: `/sermons`·`/sermons/all`·`/sermons/series`·`/sermons/series/[id]`·`/sermons/[id]`. (Glob·find 확인)
 - 새 `complete-task`·`_template`은 develop `f67f523`(#96)에 반영됐다. (git show 확인)
 
 ## Non-goals
 
 - 새 기능 추가, 머지된 #91~#95 재작업.
 - sermons 밖 전역 접근성·성능.
-- 부킹(stash: exec-plan 4건 completed 이동 + tech-debt) — 별개 의도. 같은 브랜치에 실리나 별 커밋으로 분리.
+- ADR_TRIGGER 파일 변경: `next.config.*`·`package.json`·`src/services/`·`scripts/`. 새 a11y/perf 라이브러리(axe-core 등) 도입. 그런 결함이 나오면 별도 plan/ADR로 분리한다.
+- 부킹(이미 커밋된 exec-plan 5건 이관 + tech-debt) — 별개 의도. 같은 브랜치에 있으나 별 커밋. PR 시점에 분리 결정(의사결정 로그 D1).
 
 ## Success Criteria
 
-- 접근성: 인터랙티브 요소 aria-label 누락 0건. heading 계층 h1>h2>h3 정합. 색 대비 WCAG AA 통과. 키보드만으로 전 기능 도달. focus 표시 보임. 터치 타깃 ≥44px.
-- 성능: 이미지 lazy/priority 적정. 페이지네이션 동작. Lighthouse Performance·Accessibility 측정 후 회귀 항목 0.
+- 접근성(axe DevTools 또는 Lighthouse Accessibility로 5라우트 측정):
+  - 인터랙티브 요소 aria-label/접근명 누락 0건.
+  - heading 계층 h1→h2→h3 건너뜀 0건.
+  - 색 대비 위반 0건(본문 4.5:1·큰 텍스트 3:1).
+  - 키보드만으로 5라우트 전 기능 도달, focus 링 보임.
+  - 터치 타깃 ≥44×44px.
+- 성능(Lighthouse mobile, 5라우트):
+  - hero/featured 이미지만 `priority`, 목록·캐러셀은 lazy.
+  - `/sermons/all` 페이지네이션: page 파라미터 변경 시 URL·목록·포커스 갱신.
+  - Lighthouse Performance·Accessibility 점수가 점검 전 대비 하락 0.
 - verify-task PASS. knip 신규 0.
+- 측정 결과(axe/Lighthouse 전후)는 `## 검증 이력` 또는 `logs/sermons-a11y-perf/<run>/`에 표로 기록.
 
 ## 영향받는 파일
 
-- 점검 후 확정. 후보: `src/app/(content)/sermons/_component/` 하위.
+- 감사 전 미확정(audit-then-scope). 후보: `src/app/(content)/sermons/_component/` 하위 16개. 체크리스트 1·3 완료 시 결함 목록 + 확정 파일 목록을 본 plan에 기록한다.
 
 ## 단계별 체크리스트
 
-- [ ] 1. 접근성 점검(레퍼런스 8항) → 결함 목록 작성
+- [ ] 1. 접근성 점검(레퍼런스 8항, 5라우트) → 결함 + 영향 파일 목록을 plan에 기록
 - [ ] 2. 접근성 결함 국소 수정(aria-label·heading·대비·focus·터치)
-- [ ] 3. 성능 점검(이미지·페이지네이션·Lighthouse) → 결함 목록
+- [ ] 3. 성능 점검(이미지·페이지네이션·Lighthouse 5라우트) → 결함 + 영향 파일 목록을 plan에 기록
 - [ ] 4. 성능 결함 국소 개선
 - [ ] 5. verify-task + Codex 1차 + Claude 2차
 
@@ -47,11 +57,22 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 
 - `node scripts/verify-task.mjs sermons-a11y-perf`
 - 키보드만으로 sermons 5개 라우트 전 기능 도달 확인
-- Lighthouse(접근성·성능) 측정값 점검 전후 비교
+- axe/Lighthouse 점검 전후 측정값을 표로 비교(저장 위치 명시)
 
 ## ADR 판단
 
-- **불필요** — sermons app 컴포넌트 국소 점검·개선. ADR_TRIGGER(services·config 등) 미포함. `start-adr.mjs` 미실행.
+- **불필요** — sermons app 컴포넌트 국소 점검·개선만. ADR_TRIGGER(`next.config`·`package.json`·`src/services`·`scripts`)와 새 라이브러리는 Non-goals로 명시 배제. 그 범위 결함은 별도 plan/ADR. `start-adr.mjs` 미실행.
+
+## 의사결정 로그
+
+- **D1 — Codex 계획검증 CHANGE_REQUEST 반영**
+  - 문제: SC 6개 중 4개가 도구·라우트·임계값 미명시로 약했다. Non-goals에 ADR_TRIGGER·라이브러리 배제가 없어 `ADR: no`가 조건부였다. Assumptions에 미확인 항목("Glob 확인 예정")이 있었다.
+  - 해결: SC를 도구(axe/Lighthouse)·5라우트·임계값(4.5:1·44px·점수하락 0)·결과 저장 위치로 구체화했다. Non-goals에 ADR_TRIGGER 파일·새 라이브러리 배제를 명시했다. Assumptions를 Glob·find 실측(16 디렉토리·5 라우트)으로 교체했다. 8-3·8-4 분리 대신 한 task 유지(관련 closeout), 커밋만 a11y/perf 분리.
+  - 결과: material CR 해소. weak 기준 0, 범위 경계 명확. BLOCK 아니라 재요청 없이 WORK 진입.
+- **D2 — 부킹 5건과 a11y-perf를 한 브랜치, 별 커밋**
+  - 문제: `feat/sermons-a11y-perf`에 부킹 커밋(`17488f6`·`b3d3f90`)이 a11y-perf 작업과 섞인다. Codex가 PR 오염 지적.
+  - 해결: 사용자가 한 브랜치를 선택했다. 의도별로 커밋을 분리해 두고, PR 시점에 (a) 부킹만 develop 선머지 또는 (b) PR 본문에 분리 표기 + squash 중 택한다. 부킹은 순수 Docs라 분리·선머지가 쉽다.
+  - 결과: 커밋 단위로는 의도 분리 유지. 최종 PR 전략은 PR 생성 시 사용자 결정.
 
 ---
 
@@ -59,9 +80,9 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 
 ## Codex 계획 검증
 
-- **결론**: 미요청
-- **현재 판단**: 미요청
-- **다음 행동**: Codex 계획 검증 후 갱신
+- **결론**: CHANGE_REQUEST
+- **현재 판단**: material 2건(SC 4개 weak·Non-goals ADR/라이브러리 배제 누락) D1로 해소. expression(Assumptions 미확인·기록 조건)도 반영.
+- **다음 행동**: WORK 진입 — 체크리스트 1(접근성 점검)부터.
 
 ## Codex 1차 검증
 
@@ -77,19 +98,14 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 
 ## 검증 이력
 
-<!--
-이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
-규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
-
 <details>
-<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+<summary>2026-05-18 Codex 계획 검증</summary>
 
-- 판정: CHANGE_REQUEST
-- 이유: <핵심 이유 1개>
-- 조치: <D번호 또는 수정 위치>
+- 판정: CHANGE_REQUEST (confidence high)
+- 이유: SC 4개 도구·임계값 미명시, Non-goals ADR_TRIGGER·라이브러리 배제 누락, Assumptions 미확인 항목.
+- 조치: D1(SC 구체화·Non-goals 배제·Assumptions 실측), D2(브랜치 오염 PR 전략).
 
 </details>
--->
 
 ## 후속 작업
 

--- a/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
+++ b/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
@@ -41,17 +41,39 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 - verify-task PASS. knip 신규 0.
 - 측정 결과(axe/Lighthouse 전후)는 `## 검증 이력` 또는 `logs/sermons-a11y-perf/<run>/`에 표로 기록.
 
-## 영향받는 파일
+## 영향받는 파일 (접근성 점검 후 확정)
 
-- 감사 전 미확정(audit-then-scope). 후보: `src/app/(content)/sermons/_component/` 하위 16개. 체크리스트 1·3 완료 시 결함 목록 + 확정 파일 목록을 본 plan에 기록한다.
+수정 4건:
+- `SermonDetailPage/SermonDetailPage.tsx:94` — `<h1>` → `<h2>` (className 유지, 비주얼 무변경)
+- `SermonNoteEditor/SermonNoteEditor.tsx:56` — textarea에 `aria-label="설교 노트"` 추가
+- `SermonNoteEditor/SermonNoteEditor.module.scss:30` — `:focus-visible` 링(focus-ring 토큰) 추가
+- `SermonListPage/SermonListPage.module.scss:221` — `.search_clear` 탭타깃 `$spacing-48`(≥44px) + 중앙정렬
+
+성능 점검 결과 수정 0건(아래).
+
+## 접근성 점검 결과 (체크리스트 1)
+
+정적 감사(16 컴포넌트·5 라우트). 결함 8건 중 4건 수정, 4건 비결함.
+
+- **수정(고)**: NoteEditor textarea 라벨 부재(체크5), NoteEditor `outline:none` focus-visible 부재(체크6).
+- **수정(중)**: `/sermons/[id]` 중복 h1 + h3 스킵(체크3) — SermonDetailPage가 유일하게 자체 h1 방출. `news/bulletins/[id]` 등 타 (content) 상세는 Hero h1만 쓰는 게 컨벤션이라 h2로 정합. search_clear 탭타깃 ~32px(체크8).
+- **비결함**: 탭 `role="tab"` 부재(체크7) — detail-mockup D4에서 Codex 검증 후 ARIA tablist 의도적 회피(PC 전 패널 노출=disclosure 패턴). main/all/series h1 누락(체크3) — 오탐. `(content)/layout.tsx`의 공유 `Hero`가 h1(`Hero.tsx:22`) 제공. page 추가 시 중복 h1.
 
 ## 단계별 체크리스트
 
-- [ ] 1. 접근성 점검(레퍼런스 8항, 5라우트) → 결함 + 영향 파일 목록을 plan에 기록
-- [ ] 2. 접근성 결함 국소 수정(aria-label·heading·대비·focus·터치)
-- [ ] 3. 성능 점검(이미지·페이지네이션·Lighthouse 5라우트) → 결함 + 영향 파일 목록을 plan에 기록
-- [ ] 4. 성능 결함 국소 개선
-- [ ] 5. verify-task + Codex 1차 + Claude 2차
+- [x] 1. 접근성 점검(8항·5라우트) → 결함 8건 분류·기록
+- [x] 2. 접근성 결함 국소 수정 4건(라벨·focus-visible·중복h1·탭타깃)
+- [x] 3. 성능 정적 점검 → 결함 0건(아래 결과)
+- [x] 4. 성능 결함 국소 개선 — N/A(정적 결함 0)
+- [x] 5. verify-task PASS + Codex 1차(Claude 대행, fix#4 회귀 교정) + Claude 2차 PASS
+
+## 성능 점검 결과 (체크리스트 3)
+
+정적 점검. 수정 0건.
+
+- 이미지 priority/lazy: `SeriesDetailHero.tsx:23`·`SermonFeatured.tsx:38`만 `priority`. 나머지(GridCard·캐러셀·OtherByPreacher·EpisodeCard·VideoPlayer 포스터)는 Next Image 기본 lazy. SC와 정합 — 수정 불요.
+- 페이지네이션 URL 동기화: #91(Phase 7-1)에서 구현·머지됨.
+- Lighthouse 점수: 이 환경에 브라우저 없어 런타임 미측정. Vercel preview에서 확인 권장(저장소 런타임 검증 선례 패턴).
 
 ## Verification
 
@@ -86,15 +108,15 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 
 ## Codex 1차 검증
 
-- **결론**: 미요청
-- **현재 판단**: 미요청
-- **다음 행동**: 구현 diff 생성 후 갱신
+- **결론**: PASS (bounded 재실행, confidence medium)
+- **현재 판단**: 1차 Codex 과지연 취소 → Claude 대행이 fix#4 아이콘 좌측 이동 회귀 발견·`::before`로 교정. 이후 Codex bounded 재실행이 교정본 4건 전부 PASS(중복 h1 제거·focus-visible 토큰·::before 실히트영역·surgical).
+- **다음 행동**: Claude 2차 완료. 커밋은 사용자 지시로 보류.
 
 ## Claude 2차 검증
 
-- **최종 판단**: 미작성
-- **현재 판단**: 미작성
-- **다음 행동**: verify-task 후 갱신
+- **최종 판단**: PASS
+- **현재 판단**: verify-task PASS(20260518-161602). h1→h2 className 기반이라 무영향(scss/querySelector/JSON-LD 의존 0). focus-visible 토큰 정합. ::before 교정으로 아이콘 위치 불변·탭타깃 ≥48px.
+- **다음 행동**: 커밋 승인 대기.
 
 ## 검증 이력
 
@@ -104,6 +126,24 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 - 판정: CHANGE_REQUEST (confidence high)
 - 이유: SC 4개 도구·임계값 미명시, Non-goals ADR_TRIGGER·라이브러리 배제 누락, Assumptions 미확인 항목.
 - 조치: D1(SC 구체화·Non-goals 배제·Assumptions 실측), D2(브랜치 오염 PR 전략).
+
+</details>
+
+<details>
+<summary>2026-05-18 Codex 1차 검증 (과지연 취소 → Claude 대행)</summary>
+
+- 판정: FIX_APPLIED — Codex task 15분+ grep 루프 미수렴, 프로세스 종료. Claude가 4 a11y diff 직접 교차검증.
+- 이유: fix#4가 `min-width:$spacing-48`+center로 X 아이콘을 ~20px 좌측 이동(비주얼 회귀).
+- 조치: `::before` 48px 히트영역으로 교체 — 아이콘 위치 불변, 탭타깃 ≥48px. 재verify PASS.
+
+</details>
+
+<details>
+<summary>2026-05-18 Codex 1차 재검증 (bounded, --fresh)</summary>
+
+- 판정: PASS (confidence medium)
+- 이유: 사용자 요청으로 교정본 독립 교차검증. 범위를 4파일로 한정해 과지연 재발 방지.
+- 조치: 변경 없음 — h1→h2·focus-visible·::before·surgical 전부 확인. Claude 대행 결과 독립 재확인.
 
 </details>
 

--- a/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
+++ b/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
@@ -1,0 +1,136 @@
+# sermons-a11y-perf
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-18
+- **브랜치**: feat/sermons-a11y-perf
+- **Open questions**: none
+- **ADR needed**: no — sermons app 컴포넌트 국소 점검·개선만. services·config·레이어·정책 불변.
+
+## 목표
+
+sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검하고 국소 개선한다.
+
+- 새 기능은 없다. 머지된 #91~#95 결과물의 품질 보강이다.
+- 점검에서 나온 결함만 외과적으로 고친다.
+
+## 검증된 Assumptions
+
+- 레퍼런스 미구현은 8-3·8-4뿐이다. Phase 0~7·8-1·8-2는 #91~#95로 머지됐다. (`Sermon-Implementation-Prompts.md:803-832`, develop log 확인)
+- sermons UI는 `src/app/(content)/sermons/_component/` 하위에 모인다. (Glob 확인 예정)
+- 새 `complete-task`·`_template`은 develop `f67f523`(#96)에 반영됐다. (git show 확인)
+
+## Non-goals
+
+- 새 기능 추가, 머지된 #91~#95 재작업.
+- sermons 밖 전역 접근성·성능.
+- 부킹(stash: exec-plan 4건 completed 이동 + tech-debt) — 별개 의도. 같은 브랜치에 실리나 별 커밋으로 분리.
+
+## Success Criteria
+
+- 접근성: 인터랙티브 요소 aria-label 누락 0건. heading 계층 h1>h2>h3 정합. 색 대비 WCAG AA 통과. 키보드만으로 전 기능 도달. focus 표시 보임. 터치 타깃 ≥44px.
+- 성능: 이미지 lazy/priority 적정. 페이지네이션 동작. Lighthouse Performance·Accessibility 측정 후 회귀 항목 0.
+- verify-task PASS. knip 신규 0.
+
+## 영향받는 파일
+
+- 점검 후 확정. 후보: `src/app/(content)/sermons/_component/` 하위.
+
+## 단계별 체크리스트
+
+- [ ] 1. 접근성 점검(레퍼런스 8항) → 결함 목록 작성
+- [ ] 2. 접근성 결함 국소 수정(aria-label·heading·대비·focus·터치)
+- [ ] 3. 성능 점검(이미지·페이지네이션·Lighthouse) → 결함 목록
+- [ ] 4. 성능 결함 국소 개선
+- [ ] 5. verify-task + Codex 1차 + Claude 2차
+
+## Verification
+
+- `node scripts/verify-task.mjs sermons-a11y-perf`
+- 키보드만으로 sermons 5개 라우트 전 기능 도달 확인
+- Lighthouse(접근성·성능) 측정값 점검 전후 비교
+
+## ADR 판단
+
+- **불필요** — sermons app 컴포넌트 국소 점검·개선. ADR_TRIGGER(services·config 등) 미포함. `start-adr.mjs` 미실행.
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: 미요청
+- **현재 판단**: 미요청
+- **다음 행동**: Codex 계획 검증 후 갱신
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+- **현재 판단**: 미요청
+- **다음 행동**: 구현 diff 생성 후 갱신
+
+## Claude 2차 검증
+
+- **최종 판단**: 미작성
+- **현재 판단**: 미작성
+- **다음 행동**: verify-task 후 갱신
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 후속 작업
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt-tracker.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->

--- a/docs/exec-plans/completed/2026-05-15-sermons-archive-phase3.md
+++ b/docs/exec-plans/completed/2026-05-15-sermons-archive-phase3.md
@@ -1,6 +1,6 @@
 # sermons-archive-phase3
 
-- **상태**: 🟡 진행 중
+- **상태**: ✅ 완료 (2026-05-18)
 - **시작일**: 2026-05-14
 - **브랜치**: feat/sermons-archive
 - **Open questions**: none
@@ -64,3 +64,9 @@ sub-task 6개(sidebar/series-meta/search-feedback/result-header/pagination/mobil
 12 sub-task 전부 verify-task PASS(Knip 경고는 기존 barrel re-export false positive — 차단 안 됨, `docs/tech-debt-tracker.md` 대조 완료). Codex 직접수정분은 diff 교차 확인 후 의도·범위 일치 검증. 외과적 변경 위반은 D7(사용자 IDE 직접 편집) 외 0건. 커밋은 sub-task별 "한 commit = 한 의도"로 분리 완료(feat/sermons-archive 누적 ~21 commit).
 
 **PR #91 fix 2차** — Codex CHANGE_REQUEST의 #6 cover_image_url 회귀를 전수 grep으로 확인(`getAllSeries`/`getAllPreachers` 소비처 = `/sermons` 캐러셀 + admin 3 + `/sermons/all`). Claude 초기 소비처 감사가 admin·캐러셀을 누락 → #6 revert로 sermon-service.ts 무변경 복귀. fix 1~5는 verify PASS 재확인 예정. #6은 `docs/tech-debt-tracker.md` perf 항목으로 분리(별도 전용 쿼리 필요).
+
+## 회고
+
+- **잘된 것**: 12 sub-task를 단일 phase plan으로 통합해 관리했다. 커밋은 의도별로 분리했다(누적 ~21). Codex 계획 검증으로 sub-task 6개의 CR 1~5건을 구현 전 반영해 1차에서 PASS를 받았다.
+- **다음에 할 것**: 공유 함수 소비처 감사를 처음부터 전수로 한다. Claude 초기 감사가 admin·캐러셀을 빠뜨려 PR #91 #6에서 `cover_image_url` 회귀가 났고, Codex가 잡아 revert했다. `getAllSeries` 같은 공유 쿼리는 컬럼 축소 전 grep 전수 확인이 필수다.
+- **부채**: `getAllSeries`/`getAllPreachers` select 축소(perf)는 전용 쿼리가 필요해 보류했다. `docs/tech-debt-tracker.md` perf 항목으로 등록했다.

--- a/docs/exec-plans/completed/2026-05-16-sermons-detail-mockup.md
+++ b/docs/exec-plans/completed/2026-05-16-sermons-detail-mockup.md
@@ -1,6 +1,6 @@
 # sermons-detail-mockup
 
-- **상태**: 🟡 진행 중
+- **상태**: ✅ 완료 (2026-05-18)
 - **시작일**: 2026-05-16
 - **브랜치**: feat/sermons-detail-mockup
 - **Open questions**: none
@@ -136,5 +136,11 @@
 ## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
 ## 회고               ← 머지 후 completed/ 이동 시
 -->
+
+## 회고
+
+- **잘된 것**: mockup 충실 재작성(섹션·모바일 4탭/PC 스택·BottomSheet). 모바일 영상 재생 불가를 Codex 디버깅으로 근본원인(제스처 밖 postMessage) 규명·src-swap 해결. PR #95 자동리뷰 6건 전부 triage·reply, harness-gate 4/4.
+- **다음에 할 것**: 실기기 검증을 더 일찍 — Chrome 모바일 에뮬레이션은 autoplay 정책·sticky 헤더 겹침을 재현 못 함(D7·#5를 늦게 발견). React Compiler 신규 lint(set-state-in-effect/ref-in-render)를 설계 단계에 인지.
+- **부채**: 모바일 영상 재생/정지·BottomSheet·탭 sticky·Kakao(폰)·스켈레톤 속도 = 실기기 QA 미완(머지 후 develop preview에서 확인 필요). Kakao 공유는 Kakao Developers 콘솔 도메인 등록(localhost·dnchurch.vercel.app, 외부 설정) 필요 — `docs/tech-debt-tracker.md` 등록 권장.
 
 <!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/docs/exec-plans/completed/2026-05-16-sermons-interaction-polish.md
+++ b/docs/exec-plans/completed/2026-05-16-sermons-interaction-polish.md
@@ -1,6 +1,6 @@
 # sermons-interaction-polish
 
-- **상태**: 🟡 진행 중
+- **상태**: ✅ 완료 (2026-05-18)
 - **시작일**: 2026-05-16
 - **브랜치**: feat/sermons-interaction-polish
 - **Open questions**: none
@@ -98,5 +98,11 @@ Phase 7 인터랙션 잔여 마감: (7-1) 설교/시리즈 검색 입력 300ms �
 ## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
 ## 회고               ← 머지 후 completed/ 이동 시
 -->
+
+## 회고
+
+- **잘된 것**: 검색 300ms 디바운스 + 캐러셀 방향키 + useCarousel 서술 네이밍. stale 재-push 가드.
+- **다음에 할 것**: q→input 미러 effect는 처음부터 anti-pattern("you might not need an effect")이었고 디바운스 navigation과 경쟁해 입력 되돌림 버그(PR #95 #4) 유발 — 파생 state는 effect 미러보다 소유권을 명확히. React Compiler lint가 가드형 effect/ref-in-render를 막아 결국 effect 제거가 정답.
+- **부채**: URL→input 외부 동기화 제거로 back/forward 시 검색창 텍스트 미복원(결과는 정상) — 의도적 수용, 필요 시 후속 검토.
 
 <!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/docs/exec-plans/completed/2026-05-16-sermons-share-buttons.md
+++ b/docs/exec-plans/completed/2026-05-16-sermons-share-buttons.md
@@ -1,6 +1,6 @@
 # sermons-share-buttons
 
-- **상태**: 🟡 진행 중
+- **상태**: ✅ 완료 (2026-05-18)
 - **시작일**: 2026-05-16
 - **브랜치**: feat/sermons-phase7-finish
 - **Open questions**: none
@@ -99,5 +99,11 @@
 ## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
 ## 회고               ← 머지 후 completed/ 이동 시
 -->
+
+## 회고
+
+- **잘된 것**: 공유·저장을 SermonMeta로 일원화, 중복 SermonVideoTools 공유 제거. Codex CR(disclosure a11y·localStorage 가드·import 정리) 반영. 이후 드롭다운→BottomSheet로 모바일 디바이스 이탈까지 해소.
+- **다음에 할 것**: 8-2가 detail-mockup과 같은 파일(SermonMeta/MetaActions)을 건드려 브랜치 경계가 얽힘 — 상세 페이지 연속 작업은 처음부터 한 작업 스코프로 잡는 게 깔끔(브랜치 스택·단일 통합 PR로 귀결).
+- **부채**: 없음(특이). Kakao 동작은 [[sermons-detail-mockup]] D13(콘솔 도메인 등록) 참조.
 
 <!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/docs/exec-plans/completed/2026-05-16-sermons-video-preconnect.md
+++ b/docs/exec-plans/completed/2026-05-16-sermons-video-preconnect.md
@@ -1,6 +1,6 @@
 # sermons-video-preconnect
 
-- **상태**: 🟡 진행 중
+- **상태**: ✅ 완료 (2026-05-18)
 - **시작일**: 2026-05-16
 - **브랜치**: feat/sermons-video-preconnect
 - **Open questions**: none
@@ -92,5 +92,11 @@ preconnect는 연결만 데움 — 병목인 **플레이어 JS 다운로드·부
 ## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
 ## 회고               ← 머지 후 completed/ 이동 시
 -->
+
+## 회고
+
+- **잘된 것**: 첫재생 지연 완화를 위한 eager iframe + 접근(즉시로드 vs preconnect vs Player API)을 AskUserQuestion으로 사용자 확정.
+- **다음에 할 것**: 모바일 autoplay 정책(재생은 user-gesture 콜스택 내에서만)을 설계 단계에서 고려했어야 — postMessage ready-큐가 제스처 밖이라 모바일 재생 전무, detail-mockup D7에서야 Codex 디버깅으로 규명. 비공식 lite-youtube wire 의존의 한계.
+- **부채**: preboot 효과가 D7 src-swap(클릭 시 iframe navigation)으로 약화됨 — 첫재생 지연 최적화 재설계 시 공식 YT IFrame Player API(외부 스크립트 수용) 검토. `docs/tech-debt-tracker.md` 등록 권장.
 
 <!-- 검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙" 참조. 추상명사 금지, 구체화 4원소 최소 2개, Codex stdout verbatim + 풀이 1줄. -->

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -354,4 +354,29 @@
 - **영향 범위**: `src/services/sermon/sermon-service.ts`, `src/services/sermon/index.ts`, `feat/sermons-all-series` 브랜치 Phase 4 전반
 - **발견일**: 2026-05-15 (PR #92 #4 진단 중 동형 오류 발견)
 
+### 🟡 Kakao 공유 — 서빙 도메인 Kakao Developers 콘솔 미등록 (PR #95 D13)
+
+- **상태**: 🟡 외부 설정 필요 (코드 변경 아님)
+- **무엇**: 설교 상세 공유의 KakaoTalk 항목(`useKakaoShare`)이 데스크톱에서 `intent://...kakaolink` "no registered handler"로 실패. 데스크톱은 KakaoTalk 앱 부재로 본질적 한계지만, 실기기에서도 동작하려면 Kakao Developers 콘솔에 서빙 도메인 등록 필요
+- **조치**: Kakao Developers > 앱 > 플랫폼 > Web 사이트 도메인에 `http://localhost:3000`·`https://dnchurch.vercel.app`(및 운영 도메인) 등록 + 카카오 메시지/Link 활성, `NEXT_PUBLIC_KAKAO_API_KEY`가 해당 앱 JS 키인지 확인
+- **영향 범위**: `src/hooks/useKakaoShare.tsx`·`src/components/lib/KakaoScript.tsx`는 정상 — 콘솔 설정만
+- **발견일**: 2026-05-17 (PR #95 사용자 보고)
+
+### 🟡 설교 상세 영상 첫재생 지연 — preboot 약화 (PR #95 D7)
+
+- **상태**: 🟡 마이그레이션 가능 (수용된 트레이드오프)
+- **무엇**: 모바일 재생 불가 수정으로 `enablejsapi`/postMessage 큐 → 클릭 시 `src` autoplay swap 전환. iframe이 클릭 시 navigation돼 진입-시 preboot 효과(첫재생 지연 완화)가 대부분 무효화
+- **왜 수용**: postMessage ready-큐가 user-gesture 스택 밖이라 모바일 재생 자체가 안 됨(Codex 검증) — 정확성 > 지연 최적화
+- **마이그레이션 경로**: 첫재생 지연 재최적화 시 공식 YouTube IFrame Player API(외부 스크립트 수용) 도입 검토 — gesture 내 `playVideo` 호출로 preboot+모바일 재생 양립
+- **영향 범위**: `src/app/(content)/sermons/_component/SermonVideoPlayer/SermonVideoPlayer.tsx`
+- **발견일**: 2026-05-17 (PR #95, completed/2026-05-16-sermons-video-preconnect 회고)
+
+### 🟡 설교 섹션 모바일 실기기 QA 미완 (PR #95)
+
+- **상태**: 🟡 검증 필요 (자동검증 불가 항목)
+- **무엇**: 모바일 영상 단일탭 재생/정지, 탭바 sticky(헤더 오프셋·containing block), 공유 BottomSheet 터치, 스켈레톤 속도, Kakao(폰+KakaoTalk)는 tsc/lint/build로 검증 불가. Chrome 모바일 에뮬레이션도 autoplay 정책 미재현
+- **조치**: develop Vercel preview를 실기기에서 점검, 회귀 시 후속 폴리시
+- **영향 범위**: `/sermons/[id]` 모바일
+- **발견일**: 2026-05-17 (PR #95 머지, 실기기 검증 머지 후로 이월)
+
 <!-- last-audit: 2026-05-14 -->

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -91,7 +91,7 @@ function SermonMeta({ sermon, preacherLabel }: SermonMetaProps) {
       ) : (
         <span className={styles.series_tag_plain}>단독 설교</span>
       )}
-      <h1 className={styles.sermon_title}>{sermon.title}</h1>
+      <h2 className={styles.sermon_title}>{sermon.title}</h2>
       <div className={styles.meta_bar}>
         <div className={styles.meta_row}>
           {sermon.scripture && (

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -91,7 +91,7 @@ function SermonMeta({ sermon, preacherLabel }: SermonMetaProps) {
       ) : (
         <span className={styles.series_tag_plain}>단독 설교</span>
       )}
-      <h2 className={styles.sermon_title}>{sermon.title}</h2>
+      <h1 className={styles.sermon_title}>{sermon.title}</h1>
       <div className={styles.meta_bar}>
         <div className={styles.meta_row}>
           {sermon.scripture && (

--- a/src/app/(content)/sermons/_component/SermonListPage/SermonListPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonListPage/SermonListPage.module.scss
@@ -231,6 +231,17 @@ $radio-dot-size: 0.4rem;
   border: none;
   cursor: pointer;
 
+  // 아이콘 위치를 바꾸지 않고 탭 타깃만 ≥44px로 확장한다.
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: $spacing-48;
+    height: $spacing-48;
+    transform: translate(-50%, -50%);
+  }
+
   &:hover {
     color: $txt-primary;
   }

--- a/src/app/(content)/sermons/_component/SermonNoteEditor/SermonNoteEditor.module.scss
+++ b/src/app/(content)/sermons/_component/SermonNoteEditor/SermonNoteEditor.module.scss
@@ -27,6 +27,11 @@
     background: $bg-primary;
     border-color: $primary;
   }
+
+  &:focus-visible {
+    outline: $focus-ring-width solid $focus-ring-color;
+    outline-offset: $focus-ring-offset;
+  }
 }
 
 .hint {

--- a/src/app/(content)/sermons/_component/SermonNoteEditor/SermonNoteEditor.tsx
+++ b/src/app/(content)/sermons/_component/SermonNoteEditor/SermonNoteEditor.tsx
@@ -57,6 +57,7 @@ export default function SermonNoteEditor({ sermonId }: Props) {
         className={styles.textarea}
         value={note}
         onChange={handleChange}
+        aria-label="설교 노트"
         placeholder="설교를 들으며 메모를 남겨보세요..."
         rows={8}
       />


### PR DESCRIPTION
## 📋 개요 (Summary)

설교 섹션 마감. 머지 끝난 exec-plan 5건을 completed로 부킹하고, 마지막 미구현이던 접근성 점검 결함 4건을 수정한다.

> 두 의도가 한 브랜치에 있다. 커밋은 의도별로 분리했다. 부킹(Docs)과 a11y(Fix)는 아래에서 따로 설명한다.

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermons-a11y-perf` (+ 부킹: 기머지된 5 task의 completed 이관)
- **Exec Plan**: `docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md`
- **관련 ADR**: 해당 없음 (app 컴포넌트 국소 수정)
- **관련 tech debt**: `docs/tech-debt-tracker.md` — sermons 항목(부킹분)
- **작업 범위**: 접근성 8-3 점검·수정, 성능 8-4 점검, exec-plan 5건 부킹
- **제외한 범위**: 성능 결함 0(수정 없음), role=tab(D4 의도), Lighthouse 런타임 측정(브라우저 없음)

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- 레퍼런스 교차 확인 결과 sermons 마지막 미구현 = 접근성(8-3)·성능(8-4) 점검. 정적 점검에서 WCAG 실결함 4건 발견.
- 기머지된 sermons exec-plan 5건이 active에 잔류하고 상태가 거짓(`🟡 진행 중`)이었음.

**관련 이슈:** 없음 (세션 내 점검 기반)

---

## 🔧 주요 변경점 (Key Changes)

**접근성 수정 (Fix, `d0bbec1`):**

- `SermonDetailPage.tsx` h1→h2 — 공유 Hero가 페이지 h1 제공. /sermons/[id] 중복 h1·h3 스킵 해소. className 유지라 비주얼 무변경.
- `SermonNoteEditor.tsx` textarea `aria-label="설교 노트"` — 라벨 부재 해소.
- `SermonNoteEditor.module.scss` `:focus-visible` 링 — `outline:none`으로 키보드 focus 안 보이던 문제.
- `SermonListPage.module.scss` `.search_clear` `::before` 48px 히트영역 — 탭타깃 ~32px→≥44px, 아이콘 위치 불변.

**부킹 (Docs, `17488f6`·`b3d3f90`):**

- sermons exec-plan 5건 active→completed 이관. 수동 stash라 stale였던 상태를 `✅ 완료`로 정정. 회고 확인·작성.
- sermons tech-debt 25줄 등록.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 | 선택 | 이유 | 기각 대안 |
| --- | --- | --- | --- |
| 중복 h1 | SermonDetailPage h1→h2 | `news/bulletins/[id]` 등 타 상세는 Hero h1만 쓰는 컨벤션 | page h1 추가 → 중복 심화 |
| 탭타깃 확장 | `::before` 48px | 아이콘 시각 위치 불변 | min-width+center → 아이콘 ~20px 좌측 이동(회귀) |
| role=tab | 미적용 | detail-mockup D4에서 Codex 검증 후 ARIA tablist 의도 회피(disclosure) | role=tab 추가 → 설계 위반 |
| 한 브랜치 | 부킹+a11y 별 커밋 | 사용자 결정. sermons 마감 응집 | 분리 PR → 마이크로 과분할 |

> ⚠️ **트레이드오프:** Lighthouse 점수는 이 환경에 브라우저가 없어 런타임 미측정. Vercel preview에서 확인 권장.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 | 없음 |
| `verify-task` | `sermons-a11y-perf` — PASS, RUN_ID=`20260518-181604`, failed=0, warned=Knip |
| `harness-gate` | `sermons-a11y-perf` PASS |
| Codex 계획 검증 | CHANGE_REQUEST → D1·D2 반영 |
| Codex 1차 검증 | 1차 과지연 취소→Claude 대행(fix#4 회귀 교정)→Codex bounded 재검 PASS |
| Claude 2차 검증 | PASS |
| ADR 판단 | 불필요 (app 컴포넌트 국소) |
| 남은 warning | 기존 부채 Knip |

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 설교 노트 키보드 focus 표시, 스크린리더 노트 라벨, 검색 clear 버튼 탭 영역 확대. 설교 상세 제목이 h1→h2(시각 동일).
- **운영 / 릴리스 주의사항**: 없음.
- **롤백 시 영향**: 없음. a11y 마크업·스타일 한정.
- **먼저 볼 화면**: `/sermons/[id]` 노트 영역, `/sermons/all` 검색창 clear 버튼.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 부킹은 새 `complete-task`(상태 자동 ✅, #96)로 처리해 stale stash를 폐기·대체했다.
- 접근성 점검은 정적(코드)만. 실기기/Lighthouse는 Vercel preview에서 별도 확인.
- main/all/series h1 누락은 오탐 — `(content)/layout.tsx` 공유 Hero가 h1 제공.
