### PR TITLE
[Feat] sermons 카드 썸네일 — Cloudinary fetch URL 폭 반응형 (-85% 모바일)

### DIFF
--- a/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
+++ b/docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md
@@ -1,55 +1,54 @@
 # sermons-a11y-perf
 
-- **상태**: 🟡 진행 중
+- **상태**: 🟡 진행 중 (8-3 접근성 #97 머지 완료 → 8-4 성능 실행 단계)
 - **시작일**: 2026-05-18
-- **브랜치**: feat/sermons-a11y-perf
+- **브랜치**: feat/sermons-perf
 - **Open questions**: none
-- **ADR needed**: no — sermons app 컴포넌트 국소 점검·개선만. services·config·레이어·정책 불변.
+- **ADR needed**: no — `src/utils/cloudinary.ts`는 ADR_TRIGGER_PARTS 아님. 공유 util이나 `cloudinaryFetchUrl` 소비처가 sermons 7파일뿐이라 비-fetch 이미지 회귀 0. services·config·레이어·정책 불변.
 
 ## 목표
 
-sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검하고 국소 개선한다.
+sermons 8-4 성능: 7개 영역(초기로딩·번들·이미지·렌더링·네트워크·Core Web Vitals·JS실행)을 SSOT 근거로 감사하고, **측정으로 확인된 결함만** 외과적으로 고친다.
 
-- 새 기능은 없다. 머지된 #91~#95 결과물의 품질 보강이다.
-- 점검에서 나온 결함만 외과적으로 고친다.
+- 8-3 접근성은 #97로 머지 완료(이력은 `## 검증 이력`).
+- 채택 해석(사용자가 7영역 전면 점검 요청): "감사 우선 → 결함만 수정". 추측성 최적화·요청 외 리팩터 금지(가드레일 단순함 우선). 정상 영역은 정상으로 기록, 가짜 작업 만들지 않음.
+- 새 기능·새 라이브러리 없음(`@next/bundle-analyzer`는 이미 설치·배선).
 
-## 검증된 Assumptions
+## 검증된 Assumptions (8-4)
 
-- 레퍼런스 미구현은 8-3·8-4뿐이다. Phase 0~7·8-1·8-2는 #91~#95로 머지됐다. (`Sermon-Implementation-Prompts.md:803-832`, develop log 확인)
-- sermons UI = `src/app/(content)/sermons/_component/` 하위 16개 컴포넌트 디렉토리. 라우트 5개: `/sermons`·`/sermons/all`·`/sermons/series`·`/sermons/series/[id]`·`/sermons/[id]`. (Glob·find 확인)
-- 새 `complete-task`·`_template`은 develop `f67f523`(#96)에 반영됐다. (git show 확인)
+- 모든 설교 카드/히어로가 `src={cloudinaryFetchUrl(getSermonThumbnail(sermon))}` 사용 — `res.cloudinary.com/<cloud>/image/fetch/f_auto,q_auto/<원격 URL>` 고정 문자열. (GridCard·SermonCarouselCard·SeriesCard cover·OtherByPreacher·SeriesEpisodeCard·SermonFeatured·SeriesDetailHero 7파일 grep 확인)
+- `createCloudinaryLoader`(`cloudinary.ts:72-85`)는 `if (/^https?:\/\//i.test(src)) return src;`(73행)로 http src를 그대로 반환 → fetch 썸네일에 `w_<width>`·`q_<quality>` 미적용, `srcSet` 단일 URL. `next/image` `sizes`·`deviceSizes` 무력.
+- `cloudinaryFetchUrl` 소비처는 sermons 7파일뿐. sermons 밖(about/news 등)은 public_id·`siteAsset`(비-http) src라 loader가 이미 정상 리사이즈. (`git grep -rl cloudinaryFetchUrl -- src` = 8건, 7 sermons + util 정의)
+- bundle-analyzer는 `next.config.ts`에 배선됨(`withBundleAnalyzer`, `ANALYZE=true`), `@next/bundle-analyzer ^16.1.6` 설치됨 → 도구 추가 불요, 실행만.
+- 페이지네이션 URL 동기화는 #91(Phase 7-1)에서 머지됨. priority는 LCP 후보(`SermonFeatured`·`SeriesDetailHero`)만 — 누수 0.
 
 ## Non-goals
 
-- 새 기능 추가, 머지된 #91~#95 재작업.
-- sermons 밖 전역 접근성·성능.
-- ADR_TRIGGER 파일 변경: `next.config.*`·`package.json`·`src/services/`·`scripts/`. 새 a11y/perf 라이브러리(axe-core 등) 도입. 그런 결함이 나오면 별도 plan/ADR로 분리한다.
-- 부킹(이미 커밋된 exec-plan 5건 이관 + tech-debt) — 별개 의도. 같은 브랜치에 있으나 별 커밋. PR 시점에 분리 결정(의사결정 로그 D2).
+- 새 기능 추가, 머지된 #91~#97 재작업, 8-3 접근성 재작업(머지 완료).
+- sermons 밖 컴포넌트 수정. loader 분기 수정은 공유 util이나 fetch src 소비처가 sermons뿐이라 실질 sermons 한정.
+- ADR_TRIGGER 파일 변경: `next.config.*`·`package.json`·`src/services/`·`scripts/`. 새 라이브러리 도입.
+- `cloudinaryFetchUrl` 시그니처·반환 형태 변경. loader 쪽에서만 흡수.
+- 추측성 최적화 — 측정으로 결함이 안 보이는 영역에 `memo`/`dynamic()`/캐시 전략을 "혹시 몰라" 넣기. 정상은 정상으로 기록.
+- blur placeholder(`blurDataURL`) — LQIP URL 생성 별건. 결함 확인 시 후속 작업.
 
-## Success Criteria
+## Success Criteria (8-4)
 
-- 접근성(axe DevTools 또는 Lighthouse Accessibility로 5라우트 측정):
-  - 인터랙티브 요소 aria-label/접근명 누락 0건.
-  - heading 계층 h1→h2→h3 건너뜀 0건.
-  - 색 대비 위반 0건(본문 4.5:1·큰 텍스트 3:1).
-  - 키보드만으로 5라우트 전 기능 도달, focus 링 보임.
-  - 터치 타깃 ≥44×44px.
-- 성능(Lighthouse mobile, 5라우트):
-  - hero/featured 이미지만 `priority`, 목록·캐러셀은 lazy.
-  - `/sermons/all` 페이지네이션: page 파라미터 변경 시 URL·목록·포커스 갱신.
-  - Lighthouse Performance·Accessibility 점수가 점검 전 대비 하락 0.
-- verify-task PASS. knip 신규 0.
-- 측정 결과(axe/Lighthouse 전후)는 `## 검증 이력` 또는 `logs/sermons-a11y-perf/<run>/`에 표로 기록.
+영역별 감사 결과를 `## 성능 점검 결과` 표에 **결함/정상/보류 + SSOT 근거(파일:줄·수치)**로 1행씩 기록. 그중:
 
-## 영향받는 파일 (접근성 점검 후 확정)
+- **이미지(확정 결함)**: (결정론적·서버 불요) `createCloudinaryLoader()`를 같은 fetch URL로 width 640·1080 두 번 호출 → 출력이 서로 다르고 각각 `image/fetch/f_auto,q_auto,c_limit,w_640/`·`,w_1080/` 포함, encoded 원격 URL이 마지막 세그먼트, `q_`는 세그먼트당 1개. (현재: 두 호출 동일, `w_` 없음 — Codex CR①②)
+- 비-Cloudinary 절대 http URL(`https://example.com/a.jpg`)·public_id·`siteAsset` 입력 loader 출력 불변 — 회귀 0.
+- **번들/JS**: `ANALYZE=true yarn build` 산출에서 sermons 청크 상위 의존을 표에 기록. 단일 의존 > sermons-route-청크 30% 또는 명백한 미사용 import만 수정 대상, 그 외 "정상".
+- **나머지 5영역(초기로딩·SSR/SSG·렌더링·네트워크·CWV)**: 감사 후 결함이면 별 행에 수정안+근거, 정상이면 "정상" + 근거 1줄, 런타임 의존(LCP/INP/CLS)은 "보류 — Vercel preview 실측" + 측정 절차.
+- 각 수정은 `cloudinaryFetchUrl` 시그니처·7 소비처 변경 0. verify-task PASS. knip 신규 0.
 
-수정 4건:
-- `SermonDetailPage/SermonDetailPage.tsx:94` — `<h1>` → `<h2>` (className 유지, 비주얼 무변경)
-- `SermonNoteEditor/SermonNoteEditor.tsx:56` — textarea에 `aria-label="설교 노트"` 추가
-- `SermonNoteEditor/SermonNoteEditor.module.scss:30` — `:focus-visible` 링(focus-ring 토큰) 추가
-- `SermonListPage/SermonListPage.module.scss:221` — `.search_clear` 탭타깃 `$spacing-48`(≥44px) + 중앙정렬
+## 영향받는 파일 (8-4)
 
-성능 점검 결과 수정 0건(아래).
+확정 수정 1건(이미지 영역):
+- `src/utils/cloudinary.ts` `createCloudinaryLoader`(72-85) — http src 무조건 통과(73행) 대신, src가 `https://res.cloudinary.com/<cloud>/image/fetch/<transforms>/<encoded>` 형태면 `<transforms>`를 `f_auto,q_auto,c_limit,w_<width>`로 **치환**해 반환. `cloudinaryFetchUrl`이 구운 `f_auto,q_auto` 유지, `q_<quality>` 미추가(`q_` 중복 방지 — Codex CR①). `c_limit`으로 업스케일 차단. Cloudinary fetch 아닌 절대 http URL은 종전대로 통과.
+
+추가 수정 파일은 **감사 결과 확정 후** 본 섹션에 append(추측 나열 금지). 검증 산출(커밋 X): `ANALYZE=true yarn build` 번들 리포트.
+
+(8-3 접근성 수정 4건은 #97 머지 완료 — `## 검증 이력` 참조)
 
 ## 접근성 점검 결과 (체크리스트 1)
 
@@ -59,31 +58,64 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 - **수정(중)**: `/sermons/[id]` 중복 h1 + h3 스킵(체크3) — SermonDetailPage가 유일하게 자체 h1 방출. `news/bulletins/[id]` 등 타 (content) 상세는 Hero h1만 쓰는 게 컨벤션이라 h2로 정합. search_clear 탭타깃 ~32px(체크8).
 - **비결함**: 탭 `role="tab"` 부재(체크7) — detail-mockup D4에서 Codex 검증 후 ARIA tablist 의도적 회피(PC 전 패널 노출=disclosure 패턴). main/all/series h1 누락(체크3) — 오탐. `(content)/layout.tsx`의 공유 `Hero`가 h1(`Hero.tsx:22`) 제공. page 추가 시 중복 h1.
 
-## 단계별 체크리스트
+## 단계별 체크리스트 (8-4)
 
-- [x] 1. 접근성 점검(8항·5라우트) → 결함 8건 분류·기록
-- [x] 2. 접근성 결함 국소 수정 4건(라벨·focus-visible·중복h1·탭타깃)
-- [x] 3. 성능 정적 점검 → 결함 0건(아래 결과)
-- [x] 4. 성능 결함 국소 개선 — N/A(정적 결함 0)
-- [x] 5. verify-task PASS + Codex 1차(Claude 대행, fix#4 회귀 교정) + Claude 2차 PASS
+- [x] 1. 접근성 8-3 — #97 머지 완료
+- [x] 2. 이미지 영역 근본원인 점검 → fetch 썸네일 리사이즈 우회 결함 1건 확정
+- [x] 3. 7영역 감사 — 🔴 1(이미지)·🟢 5·🟡 3, 매트릭스 근거 채움
+- [x] 4. 확정 결함 외과 수정 — loader 1건만(추가 🔴 없음, 추측 수정 0)
+- [x] 5. 번들: analyzer Turbopack 비호환 확인 → escape·tech-debt 등록. loader 전/후 출력 단언 PASS(640/1080 상이·q_ 1개·비-fetch 불변)
+- [x] 6. verify-task PASS + Codex 1차 + Claude 2차
 
-## 성능 점검 결과 (체크리스트 3)
+## 성능 점검 결과
 
-정적 점검. 수정 0건.
+### 1차 정적 점검 (#97, superseded)
 
-- 이미지 priority/lazy: `SeriesDetailHero.tsx:23`·`SermonFeatured.tsx:38`만 `priority`. 나머지(GridCard·캐러셀·OtherByPreacher·EpisodeCard·VideoPlayer 포스터)는 Next Image 기본 lazy. SC와 정합 — 수정 불요.
-- 페이지네이션 URL 동기화: #91(Phase 7-1)에서 구현·머지됨.
-- Lighthouse 점수: 이 환경에 브라우저 없어 런타임 미측정. Vercel preview에서 확인 권장(저장소 런타임 검증 선례 패턴).
+priority/lazy·페이지네이션 정상, "정적 결함 0"으로 종결했었다. loader fetch-URL 통과 분기를 놓쳐 이미지 리사이즈 우회를 못 잡음. 아래 감사 매트릭스가 SSOT.
+
+### 감사 매트릭스 (7영역)
+
+판정: 🔴 결함(수정) · 🟢 정상(근거) · 🟡 보류(런타임 실측 필요). 근거 = 파일:줄·수치.
+
+| 영역 | 점검 항목 | 판정 | 근거 / 조치 |
+| --- | --- | --- | --- |
+| 이미지 | 적절한 크기 (responsive resize) | 🔴→수정 | `cloudinary.ts:73` http passthrough로 fetch 썸네일이 `w_`·srcSet 없이 YouTube 원본을 ~210px 카드에 전송. → loader fetch 분기 치환(`f_auto,q_auto,c_limit,w_<width>`). 단언: width 640/1080 출력 상이·`q_` 1개·비-fetch 불변 = PASS. |
+| 이미지 | WebP/AVIF · lazy · LCP priority | 🟢 | `f_auto`(`cloudinary.ts:58`,`:74`)가 포맷 자동. priority는 `SermonFeatured:38`·`SeriesDetailHero:23`만, 나머지 Next 기본 lazy — 누수 0. |
+| 초기로딩/번들 | 청크 크기·미사용 JS | 🟡 escape | `@next/bundle-analyzer`가 Turbopack 빌드와 비호환(빌드 로그: "not compatible with Turbopack builds, no report") → byte-% 측정 불가. knip 신규 미사용 sermons 0(변경=util 1함수). 측정 복구는 `next.config.ts` 수정=ADR_TRIGGER → tech-debt 등록·미수정(escape). |
+| Code Splitting | 무거운 클라 컴포넌트 dynamic 후보 | 🟡 escape | `BottomSheet`가 `@/components/ui`에서 정적 import(`AdvancedFilterSheet.tsx:6`·`SeriesFilterBottomSheet.tsx:6`·`SermonMetaActions.tsx:13`). off-viewport이나 ≥10% 판정에 번들 byte 필요(위 analyzer 비호환). 추측 `dynamic()` 금지(Non-goal) → 동일 escape, byte 측정 복구 후 재판정. |
+| SSR/SSG | 라우트 렌더 전략·페칭 | 🟢 | 공개 reads 전부 `createStaticClient(sermonCache.*)`(`sermon/index.ts:12,17,22,27,33,38,43`), `static.ts:12` force-cache+tags. `force-dynamic`·`cookies()`·`createServerSideClient` 오용 0(grep). `[id]/page.tsx:50` revalidate=86400 ISR. 라우트 `ƒ`는 news/community와 동일 앱 전역 패턴(데이터는 캐시) — D6 이진기준 미충족, 결함 아님. |
+| 렌더링 | 불필요 리렌더·list key·hydration | 🟢 | 데이터 리스트 key 전부 안정 id(`sermon.id`·`item.id`·`option.label`·`ep.id`·`res.id`). `key={index}`는 `SermonsSkeleton.tsx`(고정 길이 정적 placeholder, 데이터 아님)만 — 재조정 위험 0. |
+| 네트워크 | 요청 수·중복·캐싱 | 🟢 | `[id]/page.tsx`가 `getSermonById`를 generateMetadata(20)+page(76) 2회 호출하나 동일 Supabase fetch URL → Next request memoization + `static.ts:12` force-cache 디둡, cache tag 존재 → 실 DB 1회. 동일 URL ≥2 실호출 0. |
+| Core Web Vitals | LCP·INP·CLS | 🟡 | 이 환경 브라우저 없음. **기준**: Vercel preview Lighthouse mobile LCP ≤2.5s·CLS ≤0.1·INP ≤200ms. 미달 항목만 후속 plan. tech-debt 등록. |
+| JS 실행 | Long Task·무거운 연산 | 🟢 | 필터/정렬은 DB측(`all/page.tsx:98 getFilteredSermons`), 검색 debounce #94 머지. `SermonFilteredList.tsx:24`는 server-provided 배열 `.map`만 — 렌더경로 O(n²)·비메모 전체정렬 0. |
+
+판정 완료. 🔴 1건(이미지)만 수정, 🟢 5건은 근거와 함께 정상, 🟡 3건은 escape/런타임 후속(tech-debt 등록).
+
+### 실측 — 카드 썸네일 전송 바이트 (전/후)
+
+실제 Cloudinary CDN에 동일 YouTube 썸네일(1280×720 maxresdefault)을 전/후 변환 URL로 GET, `Content-Length` 비교:
+
+| 변환 | 전송 | 감소 |
+| --- | --- | --- |
+| BEFORE — `f_auto,q_auto`만(loader 통과, 폭 미적용) | 58,017 B | 기준 |
+| AFTER — `f_auto,q_auto,c_limit,w_256`(모바일 카드 폭) | 8,668 B | **−85.1%** |
+| AFTER — `…,w_384` | 15,351 B | −73.5% |
+| AFTER — `…,w_640`(태블릿/PC 카드) | 31,648 B | −45.5% |
+
+목록·캐러셀 카드 다수(예 그리드 ~12장) 기준 이미지 페이로드가 모바일에서 약 700KB→100KB 수준으로 감소. LCP/INP/CLS 종합 수치는 브라우저 부재로 미측정 — Vercel preview Lighthouse 후속(tech-debt 등록). 본 표가 8-4 "수치 측정" 요구의 직접 근거.
+
+**ADR / Non-goal escape hatch**: SSR/SSG·네트워크 감사에서 결함의 수정 지점이 ADR_TRIGGER 파일(`src/services/`·`src/actions/`·`next.config.*`·`package.json`)이면 — **이번에 고치지 않는다**. 매트릭스 행에 🔴 + "범위 밖 — 후속" 표기, `docs/tech-debt-tracker.md`에 1줄 등록, 작업 중단·사용자 보고. `src/utils/cloudinary.ts`(현 확정 1건)·`src/app/(content)/sermons/` 내부 결함만 이번 범위.
 
 ## Verification
 
 - `node scripts/verify-task.mjs sermons-a11y-perf`
-- 키보드만으로 sermons 5개 라우트 전 기능 도달 확인
-- axe/Lighthouse 점검 전후 측정값을 표로 비교(저장 위치 명시)
+- 이미지: `createCloudinaryLoader()` fetch URL을 width 640·1080 호출 → 출력 상이·`w_` 포함·`q_` 1개 단언. 비-fetch/public_id/siteAsset 출력 불변.
+- 번들: `ANALYZE=true yarn build` 리포트에서 sermons 청크 상위 의존 캡처.
+- CWV: Vercel preview URL에 Lighthouse mobile 1회 — LCP/INP/CLS 수치를 표에 기록(미달 시 후속).
 
 ## ADR 판단
 
-- **불필요** — sermons app 컴포넌트 국소 점검·개선만. ADR_TRIGGER(`next.config`·`package.json`·`src/services`·`scripts`)와 새 라이브러리는 Non-goals로 명시 배제. 그 범위 결함은 별도 plan/ADR. `start-adr.mjs` 미실행.
+- **불필요** — 수정 파일 `src/utils/cloudinary.ts`는 ADR_TRIGGER_PARTS(`next.config`·`package.json`·`src/services`·`scripts`·`src/lib/supabase` 등)에 없음. 공유 util이나 동작 변경은 `image/fetch` URL 1분기에 국한, 소비처가 sermons 7파일뿐이라 영구 결정 아님. `start-adr.mjs` 미실행.
 
 ## 의사결정 로그
 
@@ -95,6 +127,26 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
   - 문제: `feat/sermons-a11y-perf`에 부킹 커밋(`17488f6`·`b3d3f90`)이 a11y-perf 작업과 섞인다. Codex가 PR 오염 지적.
   - 해결: 사용자가 한 브랜치를 선택했다. 의도별로 커밋을 분리해 두고, PR 시점에 (a) 부킹만 develop 선머지 또는 (b) PR 본문에 분리 표기 + squash 중 택한다. 부킹은 순수 Docs라 분리·선머지가 쉽다.
   - 결과: 커밋 단위로는 의도 분리 유지. 최종 PR 전략은 PR 생성 시 사용자 결정.
+- **D3 — 8-4를 loader fetch-resize 1수정으로 한정**
+  - 문제: 8-4 레퍼런스 항목(blur·번들·priority·페이지네이션)을 다 손대면 범위 팽창. priority·페이지네이션은 이미 정상, 번들 도구도 배선됨. 진짜 결함은 fetch 썸네일 리사이즈 우회 1건.
+  - 해결: 수정은 loader fetch 분기 1개로 한정. blur placeholder는 LQIP URL 생성 별건이라 후속 작업으로 분리. 번들은 실행·기록만(범위 축소 근거). loader가 공유 util이나 fetch src 소비처가 sermons뿐이라 Non-goal "sermons 밖 수정" 위반 아님 — 채택 해석으로 기록.
+  - 결과: 1파일 외과적 수정. blast radius sermons 한정, 비-fetch 이미지 회귀 0(SC로 검증).
+- **D4 — Codex 8-4 계획검증 CHANGE_REQUEST 반영**
+  - 문제: ① `cloudinaryFetchUrl`이 이미 `f_auto,q_auto`를 굽는데(`cloudinary.ts:58`) loader가 같은 세그먼트에 `q_<quality>`를 또 주입하면 `q_` 2개 → Cloudinary 동작 미정의. ② SC "빌드 산출 HTML srcset"은 `/sermons`가 런타임 렌더면 정적 산출물이 없어 검증 불가. ③ non-Cloudinary 절대 http passthrough SC 예시 부족.
+  - 해결: ① loader가 `q_auto` 유지하고 `w_<width>`(+`c_limit`)만 치환, `q_<quality>` 미추가로 명시. ② SC를 "loader를 width 640·1080 두 번 호출해 출력 상이·`w_` 포함" 결정론적 단언으로 교체, 런타임 srcset은 Vercel preview 선택 검증으로 강등. ③ SC에 `https://example.com/a.jpg` passthrough 불변 예시 추가.
+  - 결과: material ①② 해소, ③ expression 반영. CR이라 재요청 의무 없음 — 단 범위가 7영역으로 확대돼 plan 재검증을 1회 요청한다.
+- **D5 — 8-4 범위를 1수정에서 7영역 감사로 확대 (사용자 지시)**
+  - 문제: 사용자가 초기로딩·번들·code splitting·SSR/SSG·이미지·렌더링·네트워크·CWV·JS실행 전면 점검을 요청. D3의 "loader 1수정 한정"과 충돌.
+  - 해결: 채택 해석 = "감사 우선 → 측정된 결함만 외과 수정". 7영역 감사 매트릭스를 SC·`## 성능 점검 결과`에 도입, ⬜ 행을 SSOT 근거로 🔴/🟢/🟡 판정. 🔴만 수정, 🟢은 정상 기록, 🟡(LCP/INP/CLS)은 Vercel preview 실측. 추측성 최적화는 Non-goal로 명시.
+  - 결과: D3의 "1수정 한정"은 D5로 supersede. blast radius는 여전히 sermons(loader는 fetch 소비처가 sermons뿐). 가짜 작업 0 — 정상 영역은 근거와 함께 정상으로 남긴다.
+- **D6 — Codex 2차 계획검증 CHANGE_REQUEST 반영 (D5 매트릭스)**
+  - 문제: ⬜ 행(초기로딩/번들·Code Splitting·SSR/SSG·렌더링·네트워크·JS실행)이 🔴 이진 기준 없이 열려 감사가 무한 탐색이 됨(Codex material 2건). SSR/SSG·네트워크 결함이 `src/services/` 수정을 요구하면 Non-goal(:29)과 감사목표(:66)가 충돌, escape hatch 부재(material 1건).
+  - 해결: 매트릭스 각 ⬜ 행에 이진 🔴 기준 명시 — 번들 "단일 의존 ≥ route First Load JS 30%", Code Splitting "초기 뷰포트 밖 + ≥10%", SSR/SSG "공개 라우트가 의도외 dynamic/`createStaticClient` 미사용", 렌더링 "list key index/비안정", 네트워크 "동일 URL ≥2회/캐시 태그 전무", JS "렌더 경로 O(n²)/비메모 전체정렬". escape hatch 추가 — ADR_TRIGGER(`src/services`·`actions`·`next.config`·`package.json`) 수정 필요 결함은 안 고치고 tech-debt 등록·중단·보고.
+  - 결과: 모든 감사 행이 pass/fail 닫힘. Non-goal·escape hatch 정합. CR이라 재요청 의무 없음 — 두 material 직접 해소라 3차 Codex 호출 없이 WORK 진입.
+- **D7 — 7영역 감사 실측 결과**
+  - 문제: 사용자 우려("성능 최적화 제대로 안 됨")가 7영역 전반인지, 특정 결함인지 측정 전 불명.
+  - 해결: D6 이진기준으로 감사. 🔴 1건만 실재 — 이미지 리사이즈 우회(`cloudinary.ts:73`), loader 치환으로 수정·단언 PASS. SSR/SSG·렌더링·네트워크·JS실행은 SSOT 근거로 🟢(가짜 작업 안 만듦). 번들·Code Splitting은 `@next/bundle-analyzer`의 Turbopack 비호환으로 byte 측정 불가 → escape(tech-debt 2건 등록), config 미수정. CWV는 런타임이라 Vercel preview 후속.
+  - 결과: 코드 수정은 loader 1파일로 확정. 사용자 체감 결함의 정체 = 이미지 리사이즈 우회 단일 결함. 나머지는 정상이거나 측정 도구·런타임 제약(후속 추적).
 
 ---
 
@@ -102,21 +154,21 @@ sermons 섹션의 마지막 미구현인 접근성(8-3)·성능(8-4)을 점검�
 
 ## Codex 계획 검증
 
-- **결론**: CHANGE_REQUEST
-- **현재 판단**: material 2건(SC 4개 weak·Non-goals ADR/라이브러리 배제 누락) D1로 해소. expression(Assumptions 미확인·기록 조건)도 반영.
-- **다음 행동**: WORK 진입 — 체크리스트 1(접근성 점검)부터.
+- **결론**: CHANGE_REQUEST (2회, confidence high) — D4·D6로 전건 해소 후 WORK 진입
+- **현재 판단**: 1차 CR(loader `q_` 중복·SC 검증불가)는 D4로 해소·Codex 2차에서 expression-only로 재확인. 2차 CR은 D5 매트릭스 ⬜ 행 이진기준 부재 + ADR escape hatch 부재 → D6로 각 행에 🔴 임계값 명시·escape hatch 추가. 2 material 모두 직접 해소.
+- **다음 행동**: WORK·VERIFY 완료. Codex 1차 PASS·Claude 2차 PASS. 커밋 승인 대기.
 
 ## Codex 1차 검증
 
-- **결론**: PASS (bounded 재실행, confidence medium)
-- **현재 판단**: 1차 Codex 과지연 취소 → Claude 대행이 fix#4 아이콘 좌측 이동 회귀 발견·`::before`로 교정. 이후 Codex bounded 재실행이 교정본 4건 전부 PASS(중복 h1 제거·focus-visible 토큰·::before 실히트영역·surgical).
-- **다음 행동**: Claude 2차 완료. 커밋은 사용자 지시로 보류.
+- **결론**: PASS (confidence high)
+- **현재 판단**: loader fetch 분기 1파일 diff 검증. regex group1이 `/image/fetch/`까지 캡처·`[^/]+`가 slash 없는 `f_auto,q_auto`만 소비·`(.+)$`가 `%2F` 인코딩으로 mis-split 0(`cloudinary.ts:76`). 출력 `f_auto,q_auto,c_limit,w_<width>/<encoded>` 유효, `quality` 무시는 설계대로(q_auto 1회). 회귀 0 — `example.com/a.jpg`·public_id·`/image/upload/` 절대 URL 모두 passthrough 불변. unused var 0, util 레이어, ADR_TRIGGER 미해당.
+- **다음 행동**: Claude 2차 교차 → 커밋 승인 요청.
 
 ## Claude 2차 검증
 
-- **최종 판단**: PASS (PR #97 외부 리뷰로 h1 회귀 1건 교정)
-- **현재 판단**: focus-visible 토큰 정합, `::before` 교정으로 아이콘 위치 불변·탭타깃 ≥48px은 그대로 유효. 단 h1→h2는 **회귀였고 되돌렸다** — `resolveHeroMeta('/sermons/123')`은 `HERO_META` direct(`/sermons`,`/sermons/all`,`/sermons/series`) 미스 + `GNB_ITEMS` 정확매칭 미스로 `null` 반환(`hero.config.ts:31~56`) → `Hero.tsx:13 if (!meta) return null` → 상세 페이지에 Hero h1 없음. `SermonDetailPage`의 h1이 그 페이지 유일 h1이었다.
-- **다음 행동**: `SermonDetailPage.tsx:94` h2→h1 환원 완료. 재verify PASS(20260518-183603, Knip 기존 부채). 커밋 승인 대기.
+- **최종 판단**: PASS
+- **현재 판단**: diff 재독 — 추가 블록은 passthrough 바로 앞 1곳, 인접 변경 0(surgical). 결정론 단언 PASS(width 640/1080 출력 상이·`q_` 1개·비-fetch/public_id 불변)와 Codex 1차 PASS가 독립 일치. verify-task PASS(`20260518-205029`, Knip 기존 부채). 7영역 감사: 🔴 1(이미지·수정·단언 검증)·🟢 5(SSR/SSG·렌더링·네트워크·JS·이미지포맷, SSOT 근거)·🟡 3(번들·CodeSplit는 analyzer Turbopack 비호환 escape, CWV 런타임 — tech-debt 2건 등록). 추측 수정 0.
+- **다음 행동**: 커밋 승인 대기 — 의도별 2커밋(코드/문서) 제안.
 
 ## 검증 이력
 

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -379,4 +379,22 @@
 - **영향 범위**: `/sermons/[id]` 모바일
 - **발견일**: 2026-05-17 (PR #95 머지, 실기기 검증 머지 후로 이월)
 
+### 🟡 @next/bundle-analyzer가 Turbopack 빌드와 비호환 (sermons-a11y-perf 8-4)
+
+- **상태**: 🟡 진행 중 (측정 도구 무력 — 런타임 동작은 정상)
+- **무엇**: `next.config.ts`에 `withBundleAnalyzer`(`ANALYZE=true`)가 배선돼 있으나 Next 16 기본 Turbopack 빌드에서 "The Next Bundle Analyzer is not compatible with Turbopack builds, no report will be generated"로 리포트 미생성. sermons 8-4 감사의 번들 byte-% 기준(단일 의존 ≥ route First Load JS 30%)·Code Splitting ≥10% 판정을 측정 불가
+- **왜**: 복구는 `next.config.ts` 수정(webpack 빌드 전환 또는 analyzer 대체) = ADR_TRIGGER_PARTS. 8-4 Non-goal·escape hatch로 이번 범위 제외
+- **마이그레이션 경로**: `next build --webpack` 일회 측정, 또는 `next build --experimental-analyze` 산출(`.next/diagnostics/analyze/<route>/analyze.data`) 파서 도입, 또는 analyzer를 Turbopack 호환 도구로 교체 — 별도 plan + ADR 판단
+- **영향 범위**: `next.config.ts`(측정만 — 런타임 번들 자체 정상, knip 신규 미사용 0)
+- **발견일**: 2026-05-18 (sermons-a11y-perf 8-4 감사)
+
+### 🟡 sermons Core Web Vitals 런타임 미측정 (sermons-a11y-perf 8-4)
+
+- **상태**: 🟡 진행 중 (자동검증 불가 항목)
+- **무엇**: LCP/INP/CLS는 헤드리스 빌드 환경에 브라우저 없어 미측정. 정적 감사로 이미지 리사이즈 결함(loader)은 수정했으나 실측 수치 없음
+- **왜**: 빌드 환경에 브라우저 부재. 런타임 메트릭은 배포 프리뷰에서만 측정 가능
+- **마이그레이션 경로**: Vercel preview URL에 Lighthouse mobile 1회 — 기준 LCP ≤2.5s·CLS ≤0.1·INP ≤200ms. 미달 항목만 후속 plan
+- **영향 범위**: `/sermons`·`/sermons/all`·`/sermons/[id]`·`/sermons/series`·`/sermons/series/[id]`
+- **발견일**: 2026-05-18 (sermons-a11y-perf 8-4 감사)
+
 <!-- last-audit: 2026-05-14 -->

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -70,6 +70,14 @@ type CloudinaryLoaderOptions = {
 // next/image의 loader — <CloudinaryImage>가 내부적으로 사용. src에 ROOT가 없으면 자동 합성됨
 export function createCloudinaryLoader({ cropMode, gravity, aspectRatio }: CloudinaryLoaderOptions = {}) {
   return function ({ src, width, quality }: ImageLoaderProps) {
+    // Cloudinary fetch URL(YouTube 썸네일 등 외부 호스트 래핑)은 변환 세그먼트를 width 반응형으로 치환.
+    // cloudinaryFetchUrl이 구운 f_auto,q_auto는 유지하고 c_limit,w_<width>만 더한다 (q_ 중복 방지, 업스케일 차단).
+    const fetchMatch = src.match(
+      /^(https:\/\/res\.cloudinary\.com\/[^/]+\/image\/fetch\/)[^/]+\/(.+)$/i
+    );
+    if (fetchMatch) {
+      return `${fetchMatch[1]}f_auto,q_auto,c_limit,w_${width}/${fetchMatch[2]}`;
+    }
     if (/^https?:\/\//i.test(src)) return src;
     const params = ['f_auto'];
     if (cropMode) {

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -67,14 +67,14 @@ type CloudinaryLoaderOptions = {
   aspectRatio?: string;
 };
 
+// cloudinaryFetchUrl이 구운 `f_auto,q_auto/<encoded>` 프리픽스만 매칭 — 서명(/s--...--/)·커스텀 변환 체인은 passthrough.
+const CLOUDINARY_FETCH_RESIZE_RE =
+  /^(https:\/\/res\.cloudinary\.com\/[^/]+\/image\/fetch\/)f_auto,q_auto\/(.+)$/i;
+
 // next/image의 loader — <CloudinaryImage>가 내부적으로 사용. src에 ROOT가 없으면 자동 합성됨
 export function createCloudinaryLoader({ cropMode, gravity, aspectRatio }: CloudinaryLoaderOptions = {}) {
   return function ({ src, width, quality }: ImageLoaderProps) {
-    // Cloudinary fetch URL(YouTube 썸네일 등 외부 호스트 래핑)은 변환 세그먼트를 width 반응형으로 치환.
-    // cloudinaryFetchUrl이 구운 f_auto,q_auto는 유지하고 c_limit,w_<width>만 더한다 (q_ 중복 방지, 업스케일 차단).
-    const fetchMatch = src.match(
-      /^(https:\/\/res\.cloudinary\.com\/[^/]+\/image\/fetch\/)[^/]+\/(.+)$/i
-    );
+    const fetchMatch = src.match(CLOUDINARY_FETCH_RESIZE_RE);
     if (fetchMatch) {
       return `${fetchMatch[1]}f_auto,q_auto,c_limit,w_${width}/${fetchMatch[2]}`;
     }


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: sermons 카드 썸네일이 next/image의 `sizes`·`deviceSizes`·`srcSet`을 우회해 YouTube 원본(1280×720)을 모든 카드 폭에 그대로 전송하던 결함을 외과적으로 해소

**범위**:

- `src/utils/cloudinary.ts` `createCloudinaryLoader` — Cloudinary fetch URL만 변환 세그먼트를 width 반응형으로 치환
- `docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md` — 8-4 성능 7영역 감사 매트릭스·D7 실측표 기록
- `docs/tech-debt-tracker.md` — analyzer Turbopack 비호환·CWV 런타임 미측정 2건 등록

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermons-a11y-perf`
- **Exec Plan**: `docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md`
- **관련 ADR**: 해당 없음 — `src/utils/cloudinary.ts`는 ADR_TRIGGER_PARTS 미해당, fetch URL 분기 한정으로 영구 결정 아님
- **관련 tech debt**: `docs/tech-debt-tracker.md` 신규 2건(번들 analyzer Turbopack 비호환·sermons CWV 런타임 미측정)
- **작업 범위**: loader fetch URL 폭 치환·7영역 감사 매트릭스·tech-debt 등록
- **제외한 범위**: blur placeholder(LQIP URL 별건), 번들 byte-% 실측(analyzer Turbopack 비호환으로 escape), CWV 수치(Vercel preview 후속), sermons 밖 컴포넌트

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- 사용자 우려 "sermons 성능 최적화가 제대로 안 됨"의 정체를 7영역(초기로딩·번들·이미지·렌더링·네트워크·CWV·JS실행) 감사로 측정 → 🔴 결함은 이미지 1건뿐
- 모든 sermons 카드/히어로가 `cloudinaryFetchUrl(getSermonThumbnail(...))`로 `res.cloudinary.com/<cloud>/image/fetch/f_auto,q_auto/<encoded>`를 만들지만, `createCloudinaryLoader`(`cloudinary.ts:73`)의 `if (/^https?:\/\//i.test(src)) return src;`가 fetch URL을 그대로 흘려 width 미적용 → next/image의 `sizes`·`deviceSizes`가 무력화돼 1280×720 원본이 ~210px 카드까지 전송됨
- 비-Cloudinary 절대 http URL 통과는 유지해야 하므로 분기 추가가 필요

**관련 이슈:**

- 없음 (내부 감사 발견)

---

## 🔧 주요 변경점 (Key Changes)

- `src/utils/cloudinary.ts:73` — http passthrough 앞에 fetch URL 정규식 매칭 분기를 추가했다. `^(https:\/\/res\.cloudinary\.com\/[^/]+\/image\/fetch\/)[^/]+\/(.+)$/i`로 transforms 세그먼트(`[^/]+`)와 인코딩된 원격 URL(`(.+)$`)을 캡처해 transforms를 `f_auto,q_auto,c_limit,w_<width>`로 치환한다
- `cloudinaryFetchUrl`이 구운 `q_auto`는 유지하고 loader가 `q_<quality>`를 추가하지 않는다(Codex CR① — `q_` 중복 시 Cloudinary 동작 미정의). `c_limit`으로 업스케일을 차단한다
- 비-Cloudinary 절대 http URL(`https://example.com/a.jpg`)·public_id·`siteAsset` 입력은 정규식이 매치하지 않아 종전 동작 그대로 통과한다(sermons 밖 회귀 0)
- `docs/exec-plans/active/2026-05-18-sermons-a11y-perf.md` — 7영역 감사 매트릭스(🔴1·🟢5·🟡3)와 D7 실측표를 SSOT로 추가했다
- `docs/tech-debt-tracker.md` — `@next/bundle-analyzer` Turbopack 비호환(byte-% 측정 불가, 복구는 `next.config.ts` 수정 = ADR_TRIGGER로 escape)와 sermons CWV 런타임 미측정(헤드리스 환경 브라우저 부재) 2건을 등록했다

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 8-4 범위 | 7영역 감사 후 결함만 수정 | 사용자가 전면 점검 요청. 추측 최적화는 가짜 작업·범위 팽창을 부른다 | "loader 1수정만"(D3) → 사용자 지시로 supersede(D5). "전영역 추측 수정" → Non-goal로 차단 |
| 수정 위치 | loader 분기 추가 | 소비처 7파일을 건드리지 않고 한 곳에서 흡수. `cloudinaryFetchUrl` 시그니처 불변 | 각 컴포넌트에서 `sizes` 손보기 → 7파일 외과 위반 |
| `q_<quality>` 추가 | 미추가, `q_auto`만 유지 | Codex CR① — `q_` 2개 시 Cloudinary 동작 미정의 | loader가 quality 받아 `q_<quality>` 주입 → 중복 발생 |
| 번들·CodeSplit byte 측정 | escape(tech-debt 등록·미수정) | `@next/bundle-analyzer`가 Turbopack 빌드 비호환, 복구는 `next.config.ts` 수정 = ADR_TRIGGER | 임시로 webpack 빌드 전환 → 본 task Non-goal 위반 |

> ⚠️ **트레이드오프:** loader 분기가 정규식 기반이라 Cloudinary fetch URL 포맷 변화 시 재검토 필요. 현재 `cloudinaryFetchUrl`이 SSOT이고 동일 모듈 안에 있어 위험 낮다

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs sermons-a11y-perf` — PASS, RUN_ID=`20260520-173537`, HEAD=`bf3b0df`, failed=0, warned=Knip |
| `harness-gate` | `node scripts/harness-gate.mjs sermons-a11y-perf` — PASS |
| Codex 계획 검증 | CHANGE_REQUEST 2회 — D4(`q_` 중복·SC 검증불가)·D6(매트릭스 이진기준·ADR escape hatch)로 전건 해소 후 WORK |
| Codex 1차 검증 | PASS (loader fetch 분기 1파일 diff, regex group·`%2F` mis-split·passthrough 회귀 전부 검증) |
| Claude 2차 검증 | 완료 (diff 재독 surgical 확인·결정론 단언 PASS·Codex 1차와 독립 일치) |
| ADR 판단 | 불필요 — `src/utils/cloudinary.ts`는 ADR_TRIGGER_PARTS 미해당, fetch URL 분기 1개 한정 |
| 남은 warning | Knip 기존 부채(신규 0) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 요구사항 전체 충족 — 7영역 감사 + 🔴 1건 수정
- [x] 엣지 케이스 — 비-Cloudinary http URL·public_id·siteAsset 입력 모두 종전 동작 유지

**코드 품질**

- [x] 변수명·함수명 의도 명확 (`fetchMatch`)
- [x] 불필요한 코드·디버그 로그 없음 (추가 8행만)

**보안 및 견고성**

- [x] 하드코딩된 비밀값 없음
- [x] 정규식이 `https://res.cloudinary.com/<cloud>/image/fetch/` 형태만 캡처, 외부 입력 신뢰 불요

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: sermons 카드 썸네일 모바일 전송 -85.1%(58,017 B → 8,668 B @ w_256). 비주얼 변경 없음
- **운영 리스크**: 없음 — Cloudinary 변환 파라미터만 변경. 마이그레이션·환경변수 없음
- **QA 후속**: Vercel preview에서 sermons 카드 정상 렌더 확인, DevTools Network 탭으로 `image/fetch/f_auto,q_auto,c_limit,w_<N>/` URL 형태 검증. CWV(LCP/INP/CLS)는 preview에서 Lighthouse mobile 1회 실측(tech-debt 등록)
- **롤백 시 영향**: 없음 — 단일 파일 8행 추가, revert 시 종전 동작
- **먼저 볼 화면 / 흐름**: `/sermons`·`/sermons/all`·`/sermons/series` 카드, `/sermons/[id]` 히어로

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 사용자가 처음에 "성능 최적화 제대로 안 됨"이라 했을 때, 추측으로 dynamic·memo·blur를 다 넣지 않은 게 핵심이었다. 7영역을 SSOT 근거로 감사하니 실제 결함은 이미지 1건뿐이었다
- 번들 byte-% 측정은 analyzer가 Turbopack 비호환이라 막혔다. `next build --webpack` 일회 측정 또는 Turbopack 호환 도구 도입은 별 plan + ADR로
- CWV 실측은 헤드리스 환경 한계로 Vercel preview Lighthouse 후속 — tech-debt에 임계값(LCP ≤2.5s·CLS ≤0.1·INP ≤200ms)과 함께 등록