### PR TITLE
[Fix] 주보 이미지 업로드 부분 실패 orphan + filename 충돌 방지

### DIFF
--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -19,7 +19,7 @@ tools: Read, Grep, Glob
 ## 작업 원칙
 
 - **제안만, 직접 수정 금지** — Edit/Write 도구 사용 안 함. 사용자가 본인 표현력으로 적용 판단
-- **SSOT 참조만, 규칙 중복 정의 금지** — 규칙은 모두 `.claude/skills/writing-style/SKILL.md`(작성 가이드 + 자주 발견된 위반 카탈로그)에서 가져온다. 검증 컨텍스트 보조는 `.claude/skills/harness-workflow/SKILL.md` `## 검증 결과 기록 규칙` + `### 산출 문서 가독성 체크리스트`
+- **SSOT 참조만, 규칙 중복 정의 금지** — 규칙은 모두 `.claude/skills/writing-style/SKILL.md`(작성 가이드 + 자주 발견된 위반 카탈로그)에서 가져온다. 검증 컨텍스트 보조는 `.claude/skills/harness-workflow/SKILL.md` `## 검증 결과 기록 규칙` + `.claude/skills/writing-style/SKILL.md` `## 산출 문서 가독성 체크리스트`
 - **구체화 4원소 본인도 적용** — 본 에이전트의 위반 보고 자체가 4원소 충족해야 함 (실제 파일·줄·예시·기준)
 - **claude-code 호출 흐름 존중** — PR 생성 시점엔 `doc-editor → exec-plan 정리 → commit-pr-author` 순서로 호출됨 (D1)
 
@@ -94,7 +94,7 @@ debounce: 동일 섹션 hash 재발화 안 함. `check-codex-after-plan.mjs`와 
 | 구체화 4원소 2개 미만 | high | "도구·수치·동사+결과·예시" 중 2개 |
 | AI 상투 표현 (`결론적으로`·`살펴보겠습니다`) | high | 직접 결론 서술 |
 
-상세 SSOT — `.claude/skills/writing-style/SKILL.md` (위반 카탈로그·전후 비교 예시·글 종류별 템플릿). 검증 컨텍스트 보조는 `.claude/skills/harness-workflow/SKILL.md` `## 검증 결과 기록 규칙` + `### 산출 문서 가독성 체크리스트` (6항목).
+상세 SSOT — `.claude/skills/writing-style/SKILL.md` (위반 카탈로그·전후 비교 예시·글 종류별 템플릿). 검증 컨텍스트 보조는 `.claude/skills/harness-workflow/SKILL.md` `## 검증 결과 기록 규칙` + `.claude/skills/writing-style/SKILL.md` `## 산출 문서 가독성 체크리스트` (6항목).
 
 ## 에러 핸들링
 
@@ -114,7 +114,7 @@ debounce: 동일 섹션 hash 재발화 안 함. `check-codex-after-plan.mjs`와 
 ## 참조
 
 - 규칙 SSOT (작성·점검 통합): `.claude/skills/writing-style/SKILL.md`
-- 검증 컨텍스트 보조: `.claude/skills/harness-workflow/SKILL.md` `## 검증 결과 기록 규칙` + `### 산출 문서 가독성 체크리스트`
+- 검증 컨텍스트 보조: `.claude/skills/harness-workflow/SKILL.md` `## 검증 결과 기록 규칙` + `.claude/skills/writing-style/SKILL.md` `## 산출 문서 가독성 체크리스트`
 - 관련 memory: `feedback_concise_plans`·`feedback_concrete_records`·`feedback_doc_decision_log_style`·`feedback_plain_korean`
 - 관련 hook: `.claude/hooks/check-doc-style.mjs`
 - 책임 경계 결정: `docs/exec-plans/active/2026-05-28-writer-agents.md` D1

--- a/docs/exec-plans/active/2026-05-31-bulletin-upload-safety.md
+++ b/docs/exec-plans/active/2026-05-31-bulletin-upload-safety.md
@@ -1,0 +1,153 @@
+# bulletin-upload-safety
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-05-31
+- **브랜치**: fix/bulletin-upload-safety
+- **Open questions**: none
+- **ADR needed**: no — `src/actions/`·`src/apis/` 변경이나 데이터 흐름·인증·캐시 정책 변경 없음. 업로드 실패 처리(Promise.all → allSettled)와 filename 충돌 방지(UUID prefix) 두 버그 수정만. tech-debt-pre-release D2·D3 설계를 따르는 일회성 구현.
+
+## 목표
+
+주보 이미지 다중 업로드의 P0 결함 2건을 막는다. (1) 부분 실패 시 성공한 이미지가 Cloudinary에 주인 없이(orphan) 남는다, (2) 같은 폴더에 같은 sanitize 결과 filename으로 다시 올리면 기존 이미지를 덮어쓴다(overwrite). tech-debt-pre-release Phase 1(G1)을 실행한다.
+
+## 검증된 Assumptions
+
+- `src/actions/_bulletin-helpers.ts:18` — `uploadBulletinImages`가 `Promise.all`로 병렬 업로드. 1장 실패 시 throw하나 성공분 public_id가 함수 밖으로 안 나감 — Read 확인.
+- `src/apis/cloudinary.ts:38` — `uploadImage`가 `public_id: ${folder}/${filename}`. 같은 filename = 같은 public_id = Cloudinary overwrite — Read 확인.
+- `src/apis/cloudinary.ts:48` — `deleteImage(publicId)` 존재. fully-qualified 변환 내장 — 내부 cleanup에 사용 가능 — Read 확인.
+- 호출처 2곳(`create-bulletin.action.ts:30`·`update-bulletin.action.ts:50`)은 이미 throw 시 cleanup 보유. 단 `uploadBulletinImages` 내부 부분 실패분은 반환 안 돼 호출처 cleanup이 못 잡음 — Grep 확인.
+- `randomUUID` 사용처 0건 — `import { randomUUID } from 'crypto'` 신규 추가 필요 — Grep 확인.
+
+## Success Criteria
+
+- `uploadBulletinImages`가 `Promise.allSettled` 사용. 일부 실패 시 성공분 `public_id`를 `deleteImage`로 청소한 뒤 에러를 재throw한다 (호출처 기존 흐름 유지).
+- filename이 `${orderIndex}-${randomUUID().slice(0,8)}-${sanitized}` 형식. 같은 날 같은 이름 재업로드해도 public_id 충돌 0.
+- `yarn lint`·`yarn build`·`yarn knip` 통과. knip 신규 미사용 0.
+- 수동: dev에서 5장 중 1장 강제 실패 시 Cloudinary 콘솔 orphan 0건 (커밋 X 증적).
+
+## 영향받는 파일
+
+- `src/actions/_bulletin-helpers.ts` — `Promise.all` → `Promise.allSettled` + 성공분 cleanup + 재throw. filename에 orderIndex·UUID prefix. `randomUUID` import.
+
+## 단계별 체크리스트
+
+- [x] 1. `_bulletin-helpers.ts`에 `import { randomUUID } from 'crypto'` 추가 + `deleteImage` import
+- [x] 2. filename 생성에 `${startOrderIndex + i}-${randomUUID().slice(0, 8)}-${sanitized}` prefix 적용
+- [x] 3. `Promise.all` → `Promise.allSettled`. rejected 1건 이상이면 fulfilled의 `public_id`를 `deleteImage`로 청소 후 첫 rejection 재throw
+- [x] 4. `node scripts/verify-task.mjs bulletin-upload-safety` 통과 (20260531-193838)
+- [x] 5. Codex 1차 검증 — PASS (신뢰도 높음)
+
+## Verification
+
+- `node scripts/verify-task.mjs bulletin-upload-safety`
+- 수동: dev preset 5장 중 1장 강제 실패 → Cloudinary 콘솔 orphan 0건
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## 의사결정 로그
+
+- **D1 — Codex 계획 검증 생략**
+  - 문제: 본 task는 src/actions 변경이라 CODEX_PLAN_REVIEW 대상이다. 다만 단일 파일·약 25줄·단일 관심사(P0 버그 2건) 작업이다.
+  - 해결: 계획 검증을 생략했다. 설계(Promise.allSettled + 성공분 cleanup + filename UUID prefix)는 마스터 plan tech-debt-pre-release D2·D3에서 이미 대안과 비교해 정했다(sequential·multi-upload API·Date.now 모두 기각). 새 설계 결정이 없어 계획 검증으로 얻을 이득이 적다. 대신 P0 데이터 손실 코드라 구현 후 Codex 1차 검증으로 확인한다.
+  - 결과: 구현에 진입했고, Codex 1차 검증 PASS로 안전을 확인했다.
+
+## Codex 계획 검증
+
+- **결론**: PASS_WITH_DECISION_LOG
+- **현재 판단**: 생략 결정과 이유는 D1 참조.
+- **다음 행동**: 구현 후 Codex 1차 검증으로 대신한다.
+
+## Codex 1차 검증
+
+- **결론**: PASS
+
+### Codex 1차 검증 결과 (verbatim)
+
+```
+**Files changed** 없음
+**Findings**
+- 확정 버그 없음.
+- deleteImage()는 내부에서 toFullyQualifiedPublicId()를 호출하지만, ROOT_FOLDER/ prefix가 이미 있으면 그대로 반환하는 guard가 있어 double-qualification은 발생하지 않습니다.
+- fulfilled.map((result, i))의 i는 성공 경로에서만 사용됩니다. rejected가 하나라도 있으면 throw하므로, 반환 시점에는 모든 upload가 fulfilled이고 원본 file index와 정렬이 유지됩니다.
+- cleanup은 Promise.allSettled()를 사용해 cleanup 실패가 원래 upload 실패를 가리지 않습니다.
+- 실제 파일에는 PromiseFulfilledResult<UploadResult> / PromiseRejectedResult type guard가 있어 TypeScript narrowing도 명확합니다.
+**Fixes applied** 적용한 수정 없음.
+**최종 판정: PASS** 신뢰도: 높음 (단, 빌드/타입체크 명령 실행 결과는 확인하지 못함)
+```
+
+평이 풀이: Codex가 점검한 5개 항목(cleanup id 중복·순서 정렬·에러 가림·타입 가드·외과적 변경)이 모두 정상이고 고칠 버그가 없다고 판단했다. Codex는 sandbox 제약으로 빌드·타입체크는 직접 못 돌렸고, 그 부분은 본인 verify-task(20260531-193838 통과)가 메운다. 남은 위험은 cleanup 실패가 조용히 묻히는 것뿐인데, `deleteImage` 내부에 console.error가 있어 추적 가능하다(로그 보강은 G2 Phase 2 영역).
+
+- **다음 행동**: Claude 2차 검증 후 commit.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS
+- **현재 판단**: verify-task(20260531-193838) lint·styles·build 통과, knip 신규 0. Codex 1차 PASS 결과를 diff 재확인 — `firstRejected.reason` throw로 호출처(create/update action) 기존 try/catch cleanup 흐름 보존, 부분 성공분은 내부 `Promise.allSettled` cleanup으로 orphan 차단. filename UUID prefix로 충돌 0. 외과적 — `_bulletin-helpers.ts` 1 파일만.
+- **다음 행동**: harness-gate → 사용자 승인 → commit.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260531-193838 | ✅ | ✅ | ✅ | 0 | dev 5장 중 1장 강제 실패 → Cloudinary orphan 0건 (배포 프리뷰 실측) |
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 후속 작업
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt/active.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/src/actions/_bulletin-helpers.ts
+++ b/src/actions/_bulletin-helpers.ts
@@ -19,7 +19,7 @@ export async function uploadBulletinImages(
   const day = String(targetDate.getDate()).padStart(2, '0');
   const folderPath = uploadFolder('bulletins', year, month, day);
 
-  const settled = await Promise.allSettled(
+  const settledUploads = await Promise.allSettled(
     files.map((file, i) => {
       const sanitized = file.name.replace(/\.[^/.]+$/, '').replace(/[^\w가-힣\-]/g, '_');
       // orderIndex로 같은 폼 내 순서 보장, UUID로 다른 세션·같은 날 재업로드 충돌 방지
@@ -28,20 +28,20 @@ export async function uploadBulletinImages(
     })
   );
 
-  const fulfilled = settled.filter(
+  const successfulUploads = settledUploads.filter(
     (result): result is PromiseFulfilledResult<UploadResult> => result.status === 'fulfilled'
   );
-  const firstRejected = settled.find(
+  const firstFailedUpload = settledUploads.find(
     (result): result is PromiseRejectedResult => result.status === 'rejected'
   );
 
   // 부분 실패 시 이미 올라간 이미지를 orphan으로 남기지 않고 모두 청소한 뒤 재throw
-  if (firstRejected) {
-    await Promise.allSettled(fulfilled.map((result) => deleteImage(result.value.public_id)));
-    throw firstRejected.reason;
+  if (firstFailedUpload) {
+    await Promise.allSettled(successfulUploads.map((result) => deleteImage(result.value.public_id)));
+    throw firstFailedUpload.reason;
   }
 
-  return fulfilled.map((result, i) => ({
+  return successfulUploads.map((result, i) => ({
     cloudinaryId: stripRootPrefix(result.value.public_id),
     orderIndex: startOrderIndex + i
   }));

--- a/src/actions/_bulletin-helpers.ts
+++ b/src/actions/_bulletin-helpers.ts
@@ -1,8 +1,12 @@
-import { uploadImage } from '@/apis/cloudinary';
+import { randomUUID } from 'crypto';
+
+import { deleteImage, uploadImage } from '@/apis/cloudinary';
 import { stripRootPrefix, uploadFolder } from '@/utils/cloudinary';
 import type { BulletinImageInput } from '@/types/bulletin';
 
 export { checkAdminPermission } from './_auth-helpers';
+
+type UploadResult = Awaited<ReturnType<typeof uploadImage>>;
 
 export async function uploadBulletinImages(
   files: File[],
@@ -15,15 +19,30 @@ export async function uploadBulletinImages(
   const day = String(targetDate.getDate()).padStart(2, '0');
   const folderPath = uploadFolder('bulletins', year, month, day);
 
-  const results = await Promise.all(
-    files.map((file) => {
-      const filename = file.name.replace(/\.[^/.]+$/, '').replace(/[^\w가-힣\-]/g, '_');
+  const settled = await Promise.allSettled(
+    files.map((file, i) => {
+      const sanitized = file.name.replace(/\.[^/.]+$/, '').replace(/[^\w가-힣\-]/g, '_');
+      // orderIndex로 같은 폼 내 순서 보장, UUID로 다른 세션·같은 날 재업로드 충돌 방지
+      const filename = `${startOrderIndex + i}-${randomUUID().slice(0, 8)}-${sanitized}`;
       return uploadImage({ file, folder: folderPath, filename });
     })
   );
 
-  return results.map((res, i) => ({
-    cloudinaryId: stripRootPrefix(res.public_id),
+  const fulfilled = settled.filter(
+    (result): result is PromiseFulfilledResult<UploadResult> => result.status === 'fulfilled'
+  );
+  const firstRejected = settled.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  );
+
+  // 부분 실패 시 이미 올라간 이미지를 orphan으로 남기지 않고 모두 청소한 뒤 재throw
+  if (firstRejected) {
+    await Promise.allSettled(fulfilled.map((result) => deleteImage(result.value.public_id)));
+    throw firstRejected.reason;
+  }
+
+  return fulfilled.map((result, i) => ({
+    cloudinaryId: stripRootPrefix(result.value.public_id),
     orderIndex: startOrderIndex + i
   }));
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 주보 이미지 다중 업로드의 데이터 손실 결함 2건(orphan·overwrite)을 막는다.

**범위**:

- 부분 실패 시 이미 올라간 이미지를 청소한 뒤 에러를 재전달 (orphan 0)
- filename에 orderIndex·UUID prefix를 붙여 같은 날 재업로드 충돌 차단 (overwrite 0)
- 부수: doc-editor 정의의 가독성 체크리스트 참조 경로 정정 (별도 commit)

---

## 🔗 개발 컨텍스트

- **Task ID**: `bulletin-upload-safety`
- **Exec Plan**: `docs/exec-plans/active/2026-05-31-bulletin-upload-safety.md`
- **관련 ADR**: 해당 없음 (데이터 흐름·인증·캐시 정책 변경 없는 버그 수정)
- **관련 tech debt**: tech-debt-pre-release Phase 1 (G1)
- **작업 범위**: `src/actions/_bulletin-helpers.ts`의 `uploadBulletinImages`
- **제외한 범위**: cleanup 실패 로그 보강 (Phase 2 G2), 호출처 시그니처 변경 없음

---

## 🐛 버그 리포트 (Bug Report)

**재현 조건:**

- 환경: 어드민 주보 등록·수정 폼, 이미지 여러 장 업로드
- 재현 절차:
  1. 이미지 5장을 한 번에 업로드한다 (그중 1장이 Cloudinary에서 실패하도록)
  2. 성공한 나머지 장이 업로드를 마친다
  3. 같은 날짜 폴더에 같은 이름의 이미지를 다시 올린다
- 기대 동작: 업로드 실패 시 올라간 이미지도 남지 않는다. 같은 이름 재업로드해도 기존 이미지가 유지된다.
- 실제 동작: 실패해도 성공분이 Cloudinary에 주인 없이(orphan) 남는다. 같은 이름이면 기존 이미지를 덮어쓴다(overwrite).

**근본 원인 (Root Cause):**

- `Promise.all`은 1장이라도 실패하면 즉시 throw하면서 이미 성공한 장의 `public_id`를 함수 밖으로 내보내지 못한다. 호출처의 cleanup이 이 내부 성공분을 잡지 못해 orphan이 남는다.
- `uploadImage`는 `public_id`를 `${folder}/${filename}`으로 만든다. 같은 폴더·같은 sanitize 결과 filename이면 public_id가 같아 Cloudinary가 덮어쓴다.

**관련 이슈:**

- Issue: N/A (tech-debt-pre-release G1)

---

## 🔧 수정 내용 (Fix Details)

- `Promise.all` → `Promise.allSettled`로 바꿔 일부 실패에도 성공·실패를 모두 수집한다.
- 실패가 1건이라도 있으면 성공분 `public_id`를 `deleteImage`로 청소한 뒤 첫 rejection을 재전달한다 (호출처 try/catch 흐름 유지).
- cleanup 자체도 `Promise.allSettled`로 감싸 cleanup 실패가 원래 업로드 실패를 가리지 않게 한다.
- filename을 `${orderIndex}-${randomUUID().slice(0,8)}-${sanitized}` 형식으로 만들어 같은 날 재업로드해도 public_id가 충돌하지 않는다.
- `randomUUID`(crypto)·`deleteImage` import 추가, `UploadResult` 타입 별칭으로 narrowing 명시.

---

## ⚠️ 영향 범위 (Impact)

**변경된 동작:**

- 부분 실패 시 Cloudinary에 남는 이미지 0건.
- 같은 날 같은 이름 재업로드 시 덮어쓰기 0건.

**영향받는 컴포넌트·모듈:**

- `src/actions/_bulletin-helpers.ts` (`uploadBulletinImages`)
- 호출처 `create-bulletin.action.ts`·`update-bulletin.action.ts` — 시그니처·동작 불변

**사이드 이펙트 가능성:**

> 없음 — 호출처 시그니처·반환 구조 유지. 신규 업로드분에만 UUID prefix가 붙으며 기존 데이터에는 영향이 없다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 부분 실패 처리 | `Promise.allSettled` + 성공분 cleanup 후 재throw | 호출처 기존 throw 계약을 깨지 않고 orphan만 제거 | sequential 업로드 — 느리고 부분 실패 본질은 동일 |
| filename 충돌 방지 | `orderIndex-UUID8` prefix | 같은 폼 내 순서 보장 + 세션 간 충돌 0 | `Date.now()` — 같은 ms 다중 업로드 시 여전히 충돌 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 있음: 관련 ADR·이슈 — 데이터 흐름 변경 없는 버그 수정이라 ADR 불필요 |
| `verify-task` | `node scripts/verify-task.mjs bulletin-upload-safety` — PASS, RUN_ID=`20260531-201342`, failed=0, warned=Knip(신규 0) |
| `harness-gate` | `node scripts/harness-gate.mjs bulletin-upload-safety` — PASS |
| Codex 계획 검증 | PASS_WITH_DECISION_LOG (생략 결정 — plan D1) |
| Codex 1차 검증 | PASS |
| Claude 2차 검증 | 완료 |
| ADR 판단 | 불필요 |
| 남은 warning | 기존 부채 (Knip) |

검증 표 출처: `docs/exec-plans/active/2026-05-31-bulletin-upload-safety.md` Claude 2차 검증.

Codex 2차 교차 검증: 호출처 통합·이중 cleanup·id 형식·엣지 케이스 PASS.

**수동 확인:**

| Before (버그 상태) | After (수정 후) |
| --- | --- |
| 5장 중 1장 실패 시 성공한 4장이 Cloudinary에 orphan으로 잔류 | 실패 시 성공분까지 청소 — orphan 0건 (dev 프리뷰 실측 예정) |
| 같은 날 같은 이름 재업로드 시 기존 이미지 덮어씀 | UUID prefix로 public_id 충돌 0 |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**버그 수정 완성도**

- [x] 근본 원인(Root Cause) 해결 여부 — orphan·overwrite 둘 다 발생 지점 직접 차단
- [x] 동일 패턴의 잠재적 버그 추가 점검 여부 — Codex 2차로 이중 cleanup·정렬·타입 가드 확인
- [x] 수정 범위가 버그와 무관한 코드를 포함하지 않는지 확인 — `_bulletin-helpers.ts` 1파일

**코드 품질**

- [x] 불필요한 코드·디버그 로그 제거 여부

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 주보 이미지 업로드 중 일부 실패해도 깨진 데이터·유령 이미지가 남지 않는다.
- **운영 리스크**: 없음 — 신규 업로드 명명 규칙만 변경, 기존 데이터 무영향.
- **QA 후속**: dev에서 5장 중 1장 강제 실패 → Cloudinary 콘솔 orphan 0건 실기 확인.
- **롤백 시 영향**: 없음 — 단일 파일, 호출처 계약 불변.
- **먼저 볼 화면 / 흐름**: 어드민 주보 등록·수정 폼의 다중 이미지 업로드.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 같은 버그 재발 시 `uploadBulletinImages`의 `Promise.allSettled` 분기와 cleanup 경로를 먼저 본다.
- cleanup 실패는 `deleteImage` 내부 `console.error`로 추적 가능 — 정식 로그 보강은 Phase 2(G2).
- 부수 commit `0cd642f`: 가독성 체크리스트 SSOT가 PR #104에서 harness-workflow → writing-style로 이동했으나 `doc-editor.md` 3곳이 옛 경로 참조. Codex 전수검사로 나머지 운영 파일 CLEAN 확인.