### PR TITLE
[Chore] 배포 전 부채 정리 Phase 2~6 — Supabase 로깅·드로어 버그·Cloudinary·토큰·focus-ring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ pre-commit 훅은 lint-staged로 변경 파일만 자동 검사 — error는 차
 
 ## ⚠️ Gotchas
 
-- `supabase` (named export from `client.ts`) deprecated → `getSupabaseBrowserClient()` 사용
+- 브라우저 클라이언트는 `getSupabaseBrowserClient()` 사용 (구 `supabase` named export는 제거됨)
 - Server Action과 뮤테이션은 **항상** `createServerSideClient()` (캐시 없음)
 - 공개 데이터 캐싱은 `createStaticClient()`, `createServerSideClient()` 아님
 - `_variables.scss`와 `_mixins.scss`는 `additionalData`로 자동 주입됨 — 각 `.module.scss`에서 `@import` 하지 않음

--- a/docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md
+++ b/docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md
@@ -208,21 +208,21 @@
 
 ## Codex 계획 검증
 
-- **결론**: 미요청
-- **현재 판단**: 미요청
-- **다음 행동**: Codex 계획 검증 후 갱신
+- **결론**: PASS_WITH_DECISION_LOG — 마스터 플랜의 사전 Codex 검토는 별도 단계로 돌리지 않았다. 대신 구현 중 드러난 설계 결함 2건을 Codex 설계 검증으로 보정하고 D11·D12에 남겼다
+- **현재 판단**: 7개 그룹의 우선순위·범위는 유효했다. 드로어 effect cleanup과 Cloudinary public_id 전용 가정은 구현 단계에서 결함으로 확인돼 대안을 채택했다
+- **다음 행동**: Phase 7(G6)·tech-debt 이관은 머지 후 처리
 
 ## Codex 1차 검증
 
-- **결론**: 미요청
-- **현재 판단**: 미요청
-- **다음 행동**: 구현 diff 생성 후 갱신
+- **결론**: PASS — 드로어(D11)·Cloudinary OG(D12) 설계 검증과 PR #108 diff 객관 리뷰 모두 보고할 이슈 0건
+- **현재 판단**: lazy 브라우저 클라이언트·OG null 처리·getKakaoShareUrl fallback·focus-ring mixin·apis→app 레이어 방향을 Codex가 점검해 결함 없음
+- **다음 행동**: Claude 2차 교차 확인
 
 ## Claude 2차 검증
 
-- **최종 판단**: 미작성
-- **현재 판단**: 미작성
-- **다음 행동**: verify-task 후 갱신
+- **최종 판단**: PASS
+- **현재 판단**: verify-task(run 20260602-001031) ESLint·stylelint·Build 통과, Knip은 기존 부채. 드로어 뒤로가기와 /sermons/3 OG 이미지는 Chrome 실측으로 확인. Gemini·Codex 리뷰 0 이슈
+- **다음 행동**: harness-gate 통과 후 머지
 
 ## 검증 이력
 

--- a/docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md
+++ b/docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md
@@ -1,6 +1,6 @@
 # tech-debt-pre-release
 
-- **상태**: 🟡 진행 중
+- **상태**: 🟡 거의 완료 — Phase 1~6을 처리했다(부채 그룹 G1·G2·G7·G3·G5·G4, PR #105와 `chore/pre-release-prep` 브랜치). Phase 7(G6)은 사용자 결정으로 후속으로 미뤘고, Phase 8(tech-debt 이관)은 머지 후에 한다
 - **시작일**: 2026-05-22
 - **브랜치**: phase별 분기 — `feat/sermons-publish-ssot` 머지 후 base branch에서 신설
 - **Open questions**:
@@ -58,47 +58,47 @@
   - [ ] dev preset 1장 강제 실패 수동 검증 — Cloudinary 콘솔 orphan 0건 확인 (배포 프리뷰 실측 대기)
   - [x] PR prefix: `Fix`
 
-- [ ] **Phase 2 — G2: Supabase silent fallback 로깅 (P0)**
-  - [ ] `getSiteCollection` — **백틱 템플릿 리터럴 필수**: `if (error) console.error(\`[site-collections] ${key}\`, error)` (싱글쿼트 사용 시 `${key}` 치환 안 되고 문자열 그대로 출력)
-  - [ ] `getSiteSettings`·`getActiveStaff` — 동일 패턴 (백틱 + `${변수}` 치환)
-  - [ ] PR prefix: `Fix`
+- [x] **Phase 2 — G2: Supabase silent fallback 로깅 (P0)** — chore/pre-release-prep, 2026-06-01
+  - [x] `getSiteCollection`·`getSiteSettings` — 쿼리 결과에서 error를 destructure해 백틱 `console.error` 1줄 기록
+  - [x] `getActiveStaff` — about `getPastorPageData`에서 결과 error 로깅 (getActiveStaff는 재사용 쿼리 빌더라 소비처에서 로깅)
+  - [x] PR prefix: `Fix`
 
-- [ ] **Phase 3 — G7: 잔재 정리 (P3 · 작은 마감)**
-  - [ ] `client.ts`의 `export const supabase` 제거, 2 호출처를 `getSupabaseBrowserClient()`로 교체
-  - [ ] CLAUDE.md gotcha 1줄 갱신 — `supabase named export deprecated` 항목 삭제
-  - [ ] `useDrawerHistory` pathname effect에 guarded cleanup 패턴 도입 — `if (pushed.current && history.state?.__drawer === true) { history.replaceState({ ...history.state, __drawer: undefined }, '', window.location.href); pushed.current = false; }`로 Drawer-pushed history entry의 `__drawer` 키만 제거 + 기존 history.state 다른 키(Next.js router 내부 state) 보존. **`history.back()` 금지** — route commit 직후 effect가 실행되면 방금 이동한 history entry를 되돌려 사용자가 이전 페이지로 튕김 (Drawer 안 Link 사용 시). **`replaceState` guard 필수** — Drawer가 push하지 않은 entry(Next.js router push)는 절대 건드리지 않음. 이 G7이 훅 수정을 맡음. sitemap D4는 BottomNav '전체'를 `openDrawer`에 **연결**해 이 훅을 쓰기만 함(수정 없음).
-  - [ ] PR prefix: `Refactor`
+- [x] **Phase 3 — G7: 잔재 정리 (P3 · 작은 마감)** — chore/pre-release-prep, 2026-06-01. 의도가 둘이라 commit 분리(Refactor: supabase / Fix: drawer)
+  - [x] `client.ts`의 `export const supabase` 제거, auth.ts 6함수·SessionContextProvider effect를 `getSupabaseBrowserClient()`로 교체
+  - [x] CLAUDE.md gotcha 갱신
+  - [x] useDrawerHistory 뒤로가기 버그 — ⚠️ **플랜의 effect cleanup 폐기**(D11 참조). 라우트 이동 직후 현재 history 항목이 새 경로라 `history.state.__drawer` guard가 절대 발동 안 함(Codex CHANGE_REQUEST + Chrome 실측 확인). 대신 `MobileNavigation`의 Link 5개에 `replace` 추가 — 드로어 열림 시 현재 항목이 sentinel이라 그 항목을 목적지로 교체해 가짜 항목 제거. 훅은 미수정. Chrome 실측: 드로어 링크 이동 후 뒤로가기 1회로 이전 페이지, history.length 불변(3→3)
+  - [x] PR prefix: `Refactor`(supabase) / `Fix`(drawer)
 
-- [ ] **Phase 4 — G3: Cloudinary 품질·preset (P1)**
-  - [ ] `createCloudinaryLoader`의 `q_${quality || 85}` → `q_auto:good` 일괄 전환
-  - [ ] `utils/cloudinary.ts`에 `getOgImageUrl(publicId)`·`getKakaoShareUrl(publicId)`·`getThumbnailUrl(publicId)` 함수 추가 (각 use-case 변환 파라미터 고정)
-  - [ ] OG metadata 사이트의 `generateMetadata`에서 신규 함수로 교체
-  - [ ] PR prefix: `Feat`
+- [x] **Phase 4 — G3: Cloudinary 품질·preset (P1)** — chore/pre-release-prep, 2026-06-01
+  - [x] 업로드 로더 `q_${quality || 85}` → `q_${quality || 'auto:good'}` (Next quality 인자 우선, 기본 auto:good)
+  - [x] `getOgImageUrl`(1200x630)·`getKakaoShareUrl`(800x400) 추가 — ⚠️ **플랜이 빠뜨린 외부 URL 처리 보완**(D12): public_id는 image/upload, 외부 URL(YouTube 썸네일)은 image/fetch로 같은 변환. `getThumbnailUrl`은 호출처가 없어 제외(knip 미사용 방지)
+  - [x] OG 이미지(sermons/[id]·series/[id]·bulletins/[id] 상세)를 getOgImageUrl로 교체
+  - [x] 카카오 공유(SermonDetailPage·bulletins)를 getKakaoShareUrl로 교체. Chrome 실측: /sermons/3 og:image가 fetch 변환 URL로 HTTP 200 image/jpeg
+  - [x] PR prefix: `Feat`
 
-- [ ] **Phase 5 — G5: typography 토큰 + about hex (P1)**
-  - [ ] `font-size: 0.9rem` 3건(SermonCard·NoticeTable·NoticeCategoryFilter) → `$font-size-11` 또는 `$font-size-12` 상향
-  - [ ] `0.8rem` 7건은 모두 padding/transform 용도(font-size 0건) → `$spacing-*` 토큰 분리
-  - [ ] about 영역 hex 1건(`serving-people/page.module.scss` `#eee`) 시맨틱 토큰 매핑
-  - [ ] PR prefix: `Style`
+- [x] **Phase 5 — G5: typography 토큰 + about hex (P1)** — chore/pre-release-prep, 2026-06-01
+  - [x] `font-size: 0.9rem` 3건(SermonCard·NoticeTable·NoticeCategoryFilter) → `$font-size-11`(1.1rem). fluid typography라 9px급→11px급 상향
+  - [x] `0.8rem` 7건 → `$spacing-8` — ⚠️ 고정 0.8rem 토큰이 없어 `$spacing-8`로 바꿨다. 데스크톱은 0.8rem 그대로이고 모바일만 0.6rem으로 줄어든다. 사용자 승인 후 적용
+  - [x] about `serving-people/page.module.scss` `#eee` → `$border-subtle`
+  - [x] PR prefix: `Style`
 
-- [ ] **Phase 6 — G4: focus-ring + `$beige-300` + home Hover Border (P1)**
-  - [ ] home Hover Border 남은 사례 rg 재카운트 — `:hover` 안 `border-color`/`border` 패턴 (Open question 해소)
-  - [ ] `$focus-ring-strong` 토큰 신설(`2px solid $primary-active`), `focus-ring($variant)` mixin 도입
-  - [ ] NoticeControlBar 4건·NoticeDrawer 2건·NoticeTable 2건 mixin 호출로 교체
-  - [ ] Pagination·ListItem·SermonNoteEditor는 변형 그대로 mixin 인자 전달
-  - [ ] `$bg-card-warm`·`$bg-gradient-warm-end` semantic 신설, QuickAccess·SermonVideoPlayer 사용처 치환
-  - [ ] home Hover Border 남은 사례가 있으면 hover-lift/shadow/text-underline 패턴으로 교체
-  - [ ] PR prefix: `Style` 또는 `Refactor`
+- [x] **Phase 6 — G4: focus-ring + `$beige-300` + home Hover Border (P1)** — chore/pre-release-prep, 2026-06-01. commit 분리(Style: $beige / Refactor: focus-ring)
+  - [x] home Hover Border 재카운트 — 2026-05-07 home cleanup에서 이미 해소 확인. FeedContent:25 `border-color` transition은 탭 활성/비활성 상태 전환이라 위반 아님. 추가 작업 없음
+  - [x] `$focus-ring-strong-color`($primary-active) 토큰 + `focus-ring($variant, $offset)` mixin 도입 — ⚠️ 플랜의 `$focus-ring-strong` 대신 색 토큰으로, `@content`로 border-radius 같은 추가 속성 수용
+  - [x] NoticeControlBar 4·NoticeDrawer 2·NoticeTable 2(안쪽 offset) mixin 교체
+  - [x] ListItem(안쪽 offset)·SermonNoteEditor mixin 교체. Pagination은 focus-visible 규칙 없음. admin은 box-shadow 패턴이라 범위 밖
+  - [x] `$bg-secondary-deep` 1개 신설(플랜의 2토큰을 같은 값·의미라 통합), QuickAccess·SermonVideoPlayer 치환
+  - [x] PR prefix: `Style`($beige) / `Refactor`(focus-ring)
 
-- [ ] **Phase 7 — G6: `app/→apis` 단계 정리 (P2)**
+- [ ] **Phase 7 — G6: `app/→apis` 단계 정리 (P2)** — 이번 PR 범위 밖. 사용자 결정으로 P0·작은마감·P1(G2·G7·G3·G5·G4)까지만 처리, G6는 후속
   - [ ] `about/serving-people/page.tsx`의 `getActiveStaff` 호출을 services 경유로 이동
   - [ ] home `Banner.tsx`/`AboutOurChurch.tsx` server component 전환 가능성 확인 — 가능하면 fetcher 경유, 불가능하면 이 plan 대상 아님으로 분리
   - [ ] auth 4건·UserProfileModal 1건은 이 plan 대상 아님 → 후속 작업 섹션에 기록
   - [ ] PR prefix: `Refactor`
 
 - [ ] **Phase 8 — 마무리**
-  - [ ] `docs/tech-debt-tracker.md`에서 처리 항목을 활성 → 해결됨으로 이동, 일부 처리 항목은 카운트만 갱신
-  - [ ] last-audit 날짜 갱신
+  - [ ] tech-debt active → resolved 이동(G2·G7×2·G3·G5·G4 해소분) + tracker 카운트 — chore/pre-release-prep 머지 후 complete-task에서
+  - [x] last-audit 날짜 — 같은 브랜치 첫 Docs commit에서 2026-06-01로 갱신됨
 
 ## Verification
 
@@ -172,6 +172,16 @@
   - 문제: 8건 일괄 정리 시 auth 정책(client 직접 호출 정당성)·home server component 전환 확인이 묶여 PR 비대화.
   - 해결: 일괄(정책 결정 부담)·현상 유지(부채 남음) 대신 단계 분리. about/serving-people 1건 즉시 services 경유, home Banner/AboutOurChurch 2건은 server component 전환 가능 시 fetcher로(불가능 시 후속), auth 4건은 따로 task에서 정책 결정, UserProfileModal 1건은 client signOut 정당화로 disable 주석 유지.
   - 결과: 이 phase에서 3건 정리(8→5), 남은 건 후속 작업 섹션에 기록.
+
+- **D11 — G7 드로어 뒤로가기: 플랜의 effect cleanup 폐기, Link `replace`로 전환**
+  - 문제: 플랜이 제시한 pathname effect의 `history.state?.__drawer === true` guard는 라우트 이동 직후 현재 history 항목이 새 경로라 절대 참이 안 된다. `replaceState`는 현재 항목만 바꿔서 묻힌 sentinel 항목을 못 지운다. Codex 검증도 CHANGE_REQUEST.
+  - 해결: 훅을 고치는 대신 `MobileNavigation`의 Link 5개에 `replace`를 붙였다. 드로어가 열린 상태에선 현재 history 항목이 sentinel이라, `<Link replace>`가 그 항목을 목적지로 교체해 가짜 항목을 남기지 않는다. 이유 — `history.back()` 비동기 경쟁이 없고 변경이 1파일로 좁다.
+  - 결과: Chrome 실측에서 드로어 링크 이동 후 뒤로가기 1회로 이전 페이지에 도달하고, history.length가 3에서 3으로 그대로다. 드로어만 열고 뒤로가기 시 페이지 유지·닫힘 회귀도 없다.
+
+- **D12 — G3 OG/공유 preset: 외부 URL도 image/fetch로 변환**
+  - 문제: 플랜의 `getOgImageUrl(publicId)`는 Cloudinary public_id만 가정했으나, 설교 OG 이미지는 `getSermonThumbnail`이 외부 YouTube 썸네일 URL을 돌려주는 경우가 많아 변환이 안 걸린다.
+  - 해결: helper가 입력을 분기한다 — public_id는 image/upload, 외부 URL은 image/fetch 경로로 같은 변환을 적용(Codex 설계). `getThumbnailUrl`은 호출처가 없어 추가하지 않았다(knip 미사용 방지).
+  - 결과: `/sermons/3` og:image가 YouTube 썸네일을 fetch 변환한 1200x630 URL로 생성되고 HTTP 200 image/jpeg를 돌려준다.
 
 ## 후속 작업
 

--- a/docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md
+++ b/docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md
@@ -52,11 +52,11 @@
   - [ ] `feat/sermons-publish-ssot` 머지 또는 stash 정리 후 base 확정
   - [ ] Open question(task-id 부여 방식) 결정 — phase별 신설로 결정 시 `start-task.mjs` phase 진입마다 호출
 
-- [ ] **Phase 1 — G1: Bulletin 업로드 안전성 (P0)**
-  - [ ] `_bulletin-helpers.ts` `Promise.all` → `Promise.allSettled`, fulfilled의 `public_id`를 `deleteImage`로 정리 후 rejection 재throw
-  - [ ] filename에 `${orderIndex}-${randomUUID().slice(0,8)}-${sanitized}` prefix 적용
-  - [ ] dev preset 1장 강제 실패 수동 검증 — Cloudinary 콘솔 orphan 0건 확인
-  - [ ] PR prefix: `Fix`
+- [x] **Phase 1 — G1: Bulletin 업로드 안전성 (P0)** — PR #105 머지 완료 (별도 plan `completed/2026-05-31-bulletin-upload-safety`)
+  - [x] `_bulletin-helpers.ts` `Promise.all` → `Promise.allSettled`, fulfilled의 `public_id`를 `deleteImage`로 정리 후 rejection 재throw
+  - [x] filename에 `${orderIndex}-${randomUUID().slice(0,8)}-${sanitized}` prefix 적용
+  - [ ] dev preset 1장 강제 실패 수동 검증 — Cloudinary 콘솔 orphan 0건 확인 (배포 프리뷰 실측 대기)
+  - [x] PR prefix: `Fix`
 
 - [ ] **Phase 2 — G2: Supabase silent fallback 로깅 (P0)**
   - [ ] `getSiteCollection` — **백틱 템플릿 리터럴 필수**: `if (error) console.error(\`[site-collections] ${key}\`, error)` (싱글쿼트 사용 시 `${key}` 치환 안 되고 문자열 그대로 출력)

--- a/docs/exec-plans/completed/2026-05-01-tech-debt-cleanup-phase1-5.md
+++ b/docs/exec-plans/completed/2026-05-01-tech-debt-cleanup-phase1-5.md
@@ -1,11 +1,19 @@
 # tech-debt-cleanup-phase1-5
 
-- **상태**: 📋 대기 (phase1 머지 후 시작)
-- **시작일**: 2026-05-01 (생성), 시작 미정
-- **브랜치**: 미정 (phase1 머지 후 결정)
+- **상태**: ⚠️ 폐기 (2026-06-01) — 전제로 잡은 위반 10건이 다른 작업으로 2건까지 줄었다. 남은 2건은 정당한 패턴이라 별도 작업이 필요 없다. 아래 폐기 사유 참조.
+- **시작일**: 2026-05-01 (생성), 시작하지 않음
+- **브랜치**: 없음 (착수 전 폐기)
 - **선행**: `tech-debt-cleanup-phase1` 머지 완료
 
-## 목표
+## 폐기 사유
+
+- **무엇이 바뀌었나**: 이 계획서는 `react-hooks/set-state-in-effect` 위반 10건(NoticeControlBar·AdvancedFilterSheet·SeriesBrowserSheet·SermonVideoTools·useListFilters·SermonListPage·Modal·BottomNav·DesktopHeader·useMediaQuery)을 고치려 만들었다. 2026-06-01 기준 이 10개 파일에는 위반이 남아 있지 않다.
+- **왜 사라졌나**: 위반 9건은 그 사이 진행한 컴포넌트 리팩터(useDialog 통합·SermonListPage 재구조 등) 과정에서 자연스럽게 없어졌다. active.md "ESLint `react-hooks/set-state-in-effect` (2건, 9건 정리됨)" 항목이 같은 내용을 추적한다.
+- **남은 2건은 다른 파일**: 지금 남은 위반은 `ConfirmModal/index.tsx:48`·`useDrawerHistory.ts:52` 두 곳뿐이고, 둘 다 외부 동기화가 정당한 패턴이라 line-disable + 사유 주석으로 유지한다. 이 계획서가 노린 10개 파일과 겹치지 않는다.
+- **확인**: `rg "react-hooks/set-state-in-effect" src -l` → 2 hits(ConfirmModal·useDrawerHistory). 이 계획서의 10개 대상 파일은 0 hit.
+- **남은 추적**: 위 2건은 active.md 항목과 tech-debt-pre-release Phase 3(G7, useDrawerHistory 정리)에서 다룬다.
+
+## 목표 (폐기됨)
 
 `react-hooks/set-state-in-effect` 룰 위반 10건을 케이스별로 검토·해결한다. ESLint errors를 0으로 만들어 `yarn lint` exit 0을 달성한다.
 

--- a/docs/exec-plans/completed/2026-05-31-bulletin-upload-safety.md
+++ b/docs/exec-plans/completed/2026-05-31-bulletin-upload-safety.md
@@ -1,6 +1,6 @@
 # bulletin-upload-safety
 
-- **상태**: 🟡 진행 중
+- **상태**: ✅ 완료 (2026-05-31)
 - **시작일**: 2026-05-31
 - **브랜치**: fix/bulletin-upload-safety
 - **Open questions**: none
@@ -151,3 +151,27 @@
 - 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
 -->
 
+
+## 회고
+
+### 잘 된 것
+
+- 주보 업로드 P0 결함 2건(고아 이미지와 덮어쓰기)을 트랜잭션식 롤백과 멱등 파일명으로 막았다. 호출처인 create action과 update action의 계약을 유지해 외과적 변경에 머물렀다.
+- Codex 1차 검증으로 단독 정확성을 확인하고, 2차 교차 검증에서 호출처 통합, 이중 cleanup, id 형식, 엣지 케이스를 점검했다. 두 라운드 모두 PASS로 통과했다.
+- doc-editor를 실전 plan에 처음 적용해 5건을 반영했다. "도구를 시연만 하고 실전엔 안 쓴다"는 직전 세션의 모순을 해소했다.
+- Gemini G2(변수명 시맨틱)는 반영하고 G1(헬퍼 추출)과 문서 GD1·GD2(기호 압축)는 유예했다. PR #103의 3라운드 cycle 교훈으로 일회성 문서 표현은 유예하는 판단을 적용했다.
+
+### 다음에 할 것
+
+- cleanup 실패 로그 보강은 tech-debt-pre-release Phase 2(G2)에서 처리한다.
+- 수동 검증: dev preset에서 5장 중 1장을 강제 실패시켜 Cloudinary 콘솔 orphan 0건을 실측한다.
+- 트랙 B 잔여 작업: sitemap-consistency-fix, supabase-cost-pass-1.
+
+### 발견된 부채·관찰
+
+- doc-editor가 기호잇기(·/+/→)를 못 잡고 Gemini가 보완했다. 같은 가독성 SSOT인데 두 점검자의 커버리지가 갈린다. 같은 유형이 반복되면 doc-editor 체크리스트 보강 또는 문서 lint를 검토한다.
+- Codex 좀비 2건(22시간·26시간)이 shared runtime을 점유해 새 Codex CLI 호출을 막았다. PowerShell `Stop-Process`로 정리했다. codex-companion cancel이 Git Bash 슬래시 파싱 에러로 실패할 때의 우회 패턴을 확정했다.
+
+### 본 task의 본질
+
+첫 제품 기능 작업이다(이전 #103과 #104는 harness와 docs였다). 이번 작업으로 하네스 검증 사이클(Codex 1차와 2차, doc-editor, Gemini)이 제품 코드에도 작동함을 확인했다. P0 데이터 손실을 외과적 수정으로 막아 포트폴리오의 "업로드 안정성 개선" 스토리를 확보했다.

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -6,10 +6,10 @@
 
 ## 위치
 
-| 파일 | 내용 | 항목 수 (2026-05-31) |
+| 파일 | 내용 | 항목 수 (2026-06-01) |
 | --- | --- | --- |
-| [`tech-debt/active.md`](tech-debt/active.md) | 진행 중·미해결 부채 | 35 |
-| [`tech-debt/resolved.md`](tech-debt/resolved.md) | 해결된 부채 (회고·검색용) | 9 |
+| [`tech-debt/active.md`](tech-debt/active.md) | 진행 중·미해결 부채 | 34 |
+| [`tech-debt/resolved.md`](tech-debt/resolved.md) | 해결된 부채 (회고·검색용) | 11 |
 
 ## 형식
 
@@ -35,5 +35,5 @@
 - 형식 일관성 가이드: ADR 0011 (의사결정 로그 형식)
 - 부채 발견 → 등록 흐름: `.claude/skills/complete-task/SKILL.md`
 
-<!-- last-audit: 2026-05-21 -->
+<!-- last-audit: 2026-06-01 -->
 <!-- 변경 이력은 docs/exec-plans/completed/ 또는 git log 참조 -->

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -72,14 +72,15 @@
 - **확인**: `yarn lint:styles | grep "primitive 토큰 직접 사용"` (현재 143건)
 - **발견일**: 2026-05-10 (stylelint-primitive-guardrail PR 도입 시 정확 카운트)
 
-### 🟡 SCSS 하드코딩 색상 (49건)
+### 🟡 SCSS 하드코딩 색상 (23건)
 
 - **무엇**: `.module.scss` 파일 곳곳에서 hex 색상(`#xxxxxx`) 직접 사용. 토큰 변수가 아님
 - **왜**: stylelint 도입 전에 작성된 코드. 신규 작성은 stylelint warn으로 차단됨 (CLAUDE.md "하드코딩 절대 금지" 규칙)
 - **마이그레이션 경로**: 각 hex 값을 `src/styles/tokens/_color.scss`의 의미 단위 변수로 매핑 → 모두 해결 시 `.stylelintrc.json`의 `color-no-hex` 룰을 `warning` → 기본(error)로 올림
-- **영향 범위**: 약 49건, 주요 발생 위치는 `sermons/_component/`, `news/bulletins/_component/`, `admin/sermons/SermonForm/` 하위
-- **확인**: `yarn lint:styles` (warning으로 표시)
+- **영향 범위**: 23건 (14 파일), 주요 발생 위치는 `sermons/_component/`, `news/bulletins/_component/` 하위
+- **확인**: `rg "#[0-9a-fA-F]{3,8}" -g "*.module.scss" src` → 23 hits
 - **발견일**: 2026-05-01 (stylelint 도입 시)
+- **2026-06-01 재확인**: #102 admin 토큰 통합 작업으로 admin hex가 토큰에 흡수돼 49건에서 23건(14 파일)으로 줄었다. tech-debt-pre-release plan의 5월 26일 재측정값과 일치한다.
 
 ### 🟢 SCSS 네이밍 패턴 위반 (12건)
 
@@ -238,25 +239,9 @@
 - **영향 범위**: `src/apis/cloudinary.ts`
 - **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
 
-### 🟡 bulletin 이미지 filename 충돌 위험
-
-- **무엇**: `src/actions/_bulletin-helpers.ts:20`에서 업로드 filename은 sanitize만 수행하고 uniqueness suffix 없음. 같은 날(`uploads/bulletins/YYYY/MM/DD`) 동일 이름 파일 재업로드 시 `public_id` 중복으로 overwrite 가능
-- **왜**: 단순 sanitize만으로 충분하다고 판단(날짜별 폴더 분리 가정). 실제로는 같은 날 같은 이름 파일 재업로드 시나리오가 가능
-- **마이그레이션 경로**: filename에 `${orderIndex}-${randomUUID().slice(0,8)}-${name}` 같은 prefix 추가. orderIndex만으로도 같은 폼 내 중복은 방지되지만, 다른 세션/같은 날 재업로드는 UUID로 보호
-- **영향 범위**: `src/actions/_bulletin-helpers.ts`
-- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
-
-### 🟡 bulletin 업로드 부분실패 orphan asset
-
-- **무엇**: `src/actions/_bulletin-helpers.ts:18` `Promise.all` 병렬 업로드 — 1장이라도 실패하면 throw로 끝나고, 이미 업로드 성공한 자산은 Cloudinary에 orphan으로 남음
-- **왜**: 초기 구현에서 happy-path만 고려. cleanup 정책 미정의
-- **마이그레이션 경로**: `Promise.allSettled` + fulfilled 결과의 `public_id`를 `deleteImage()`로 cleanup 후 rejection 재throw. sermon 업로드(`actions/sermon.action.ts`의 `removeStorageObjects`) 패턴 참고
-- **영향 범위**: `src/actions/_bulletin-helpers.ts`, `src/apis/cloudinary.ts`
-- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
-
 ### 🟢 Cloudinary 이미지 품질 `q_85` 고정 → `q_auto` 전환 검토
 
-- **무엇**: `src/utils/cloudinary.ts:72`의 loader가 `q_85` 고정. Cloudinary 공식 권장은 `q_auto` (또는 `q_auto:good`) — 컨텐츠별 최적 품질로 자동 조정
+- **무엇**: `src/utils/cloudinary.ts:90`의 업로드 로더(`createCloudinaryLoader`)가 `q_${quality || 85}`로 기본 화질 85% 고정. Cloudinary 공식 권장은 `q_auto`(또는 `q_auto:good`)로, 컨텐츠별 최적 품질로 자동 조정한다. 외부 호스트 fetch URL(`cloudinaryFetchUrl:58`·resize `:79`)은 이미 `q_auto`를 쓴다. 이번 부채는 업로드 로더 기본값 1곳만 남는다
 - **왜**: 명시적 품질 관리 의도. 자동화 결과 품질 변동성 우려로 보류
 - **마이그레이션 경로**: 일부 use-case(`hero`, `bulletin`)에서 A/B 비교 후 `q_auto:good` 전환. PSNR/SSIM 또는 시각 검토로 품질 회귀 없음 확인 → 전체 전환
 - **영향 범위**: `src/utils/cloudinary.ts`, 모든 `<CloudinaryImage>` 사용처

--- a/docs/tech-debt/resolved.md
+++ b/docs/tech-debt/resolved.md
@@ -4,6 +4,20 @@
 
 ---
 
+### ✅ bulletin 업로드 부분 실패 시 orphan 이미지 잔존 (2026-05-31 해소, PR #105)
+
+- **부채**: `uploadBulletinImages`가 `Promise.all`로 5장을 병렬 업로드한다. 1장이라도 실패하면 throw로 끝나는데, 이미 올라간 이미지는 Cloudinary에 주인 없이(orphan) 남았다
+- **해소**: `Promise.allSettled`로 바꿔, 일부 실패 시 성공한 `public_id`를 `deleteImage`로 모두 청소한 뒤 첫 rejection을 재throw한다. 호출처(create-bulletin·update-bulletin action)의 기존 try/catch cleanup 흐름은 그대로 둔다
+- **확인**: `src/actions/_bulletin-helpers.ts:22-42` Read 확인. verify-task(20260531-193838) lint·styles·build 통과
+- **참고**: exec-plan `completed/2026-05-31-bulletin-upload-safety`, tech-debt-pre-release Phase 1(G1)
+
+### ✅ bulletin 이미지 filename 충돌로 기존 자산 overwrite (2026-05-31 해소, PR #105)
+
+- **부채**: 업로드 filename이 sanitize만 거쳐서, 같은 날 폴더(`uploads/bulletins/YYYY/MM/DD`)에 같은 이름 파일을 다시 올리면 `public_id`가 겹쳐 기존 이미지를 덮어썼다
+- **해소**: filename을 `${orderIndex}-${randomUUID().slice(0,8)}-${sanitized}` 형식으로 바꿨다. orderIndex는 같은 폼 안 순서를 지킨다. 8자리 UUID는 다른 세션이나 같은 날 다시 올려도 충돌을 막는다
+- **확인**: `src/actions/_bulletin-helpers.ts:24-27` Read 확인. 같은 이름으로 다시 올려도 public_id 충돌 0
+- **참고**: exec-plan `completed/2026-05-31-bulletin-upload-safety`, tech-debt-pre-release Phase 1(G1)
+
 ### ✅ nav pathname 매칭이 segment boundary 무시 (2026-05-31 해소)
 
 - **부채**: `isActiveGnb`·`resolveBreadcrumbSegments`·`isActiveBottomNav`·`resolveSiblingTabs`가 그냥 `pathname.startsWith(href)`로 매칭했다 — `/newsroom`이 `/news`에, `/about-us`가 `/about`에 걸리는 형제 prefix 오탐이 생길 수 있었다. resolver마다 경계 규칙(`startsWith` 단독 / `startsWith(href+'/')` / `===`)도 달랐다

--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabase/client';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
 
 interface Credentials {
   email: string;
@@ -8,6 +8,7 @@ interface Credentials {
 }
 
 export async function signUp({ email, password, name, username }: Credentials) {
+  const supabase = getSupabaseBrowserClient();
   const { data, error } = await supabase.auth.signUp({
     email,
     password,
@@ -24,6 +25,7 @@ export async function signUp({ email, password, name, username }: Credentials) {
 }
 
 export async function signInWithPassword({ email, password }: Credentials) {
+  const supabase = getSupabaseBrowserClient();
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
     password
@@ -35,6 +37,7 @@ export async function signInWithPassword({ email, password }: Credentials) {
 }
 
 export async function signInWithKakao(redirect = '/') {
+  const supabase = getSupabaseBrowserClient();
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: 'kakao',
     options: {
@@ -47,12 +50,14 @@ export async function signInWithKakao(redirect = '/') {
 }
 
 export async function signOut() {
+  const supabase = getSupabaseBrowserClient();
   const { error } = await supabase.auth.signOut();
 
   if (error) throw error;
 }
 
 export async function requestPasswordResetEmail(email: string) {
+  const supabase = getSupabaseBrowserClient();
   const { data, error } = await supabase.auth.resetPasswordForEmail(email, {
     redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/reset-password`
   });
@@ -62,6 +67,7 @@ export async function requestPasswordResetEmail(email: string) {
 }
 
 export async function updatePassword(password: string) {
+  const supabase = getSupabaseBrowserClient();
   const { data, error } = await supabase.auth.updateUser({
     password
   });

--- a/src/apis/site-collections.ts
+++ b/src/apis/site-collections.ts
@@ -10,11 +10,13 @@ export const getSiteCollection = async <T extends Record<string, unknown>>(
     cache: 'force-cache'
   });
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('site_collections')
     .select('items')
     .eq('key', key)
     .maybeSingle();
+
+  if (error) console.error(`[site-collections] ${key} 조회 실패`, error);
 
   return (data?.items ?? []) as T[];
 };

--- a/src/apis/site-settings.ts
+++ b/src/apis/site-settings.ts
@@ -8,10 +8,12 @@ export const getSiteSettings = async (keys: string[]): Promise<SiteSettings> => 
     cache: 'force-cache'
   });
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from('site_settings')
     .select('key, value')
     .in('key', keys);
+
+  if (error) console.error(`[site-settings] ${keys.join(', ')} 조회 실패`, error);
 
   return Object.fromEntries((data ?? []).map(({ key, value }) => [key, value]));
 };

--- a/src/app/(content)/about/page.module.scss
+++ b/src/app/(content)/about/page.module.scss
@@ -210,7 +210,7 @@
 .gallery_tag {
   display: inline-block;
   margin-bottom: $spacing-4;
-  padding: 0.3rem 0.8rem;
+  padding: 0.3rem $spacing-8;
   background: $white;
   border: 0.1rem solid $border-card;
   border-radius: $radius-circle;
@@ -389,8 +389,8 @@
     content: '';
     position: absolute;
     top: 0.6rem;
-    left: 0.8rem;
-    right: 0.8rem;
+    left: $spacing-8;
+    right: $spacing-8;
     height: 0.1rem;
     background: $beige-150;
   }

--- a/src/app/(content)/about/serving-people/page.module.scss
+++ b/src/app/(content)/about/serving-people/page.module.scss
@@ -69,7 +69,7 @@ $image_max_width: 20rem;
   margin: 5rem 0;
   width: 100%;
   height: 1px;
-  border: 1px solid #eee;
+  border: 1px solid $border-subtle;
 
   @include respond($breakpoint-tablet-sm) {
     margin: 3rem 0;

--- a/src/app/(content)/about/vision/page.module.scss
+++ b/src/app/(content)/about/vision/page.module.scss
@@ -372,7 +372,7 @@
   @include respond-up($breakpoint-pc-sm) {
     width: 1.2rem;
     height: 1.2rem;
-    margin-top: 0.8rem;
+    margin-top: $spacing-8;
   }
 }
 

--- a/src/app/(content)/news/bulletins/[id]/page.tsx
+++ b/src/app/(content)/news/bulletins/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import MainContainer from '@/components/layout/container/MainContainer';
 import { BoardHeader, BoardBody, BoardFooter, BoardListLink } from '@/components/board';
-import { getCloudinaryUrl } from '@/utils/cloudinary';
+import { getOgImageUrl, getKakaoShareUrl } from '@/utils/cloudinary';
 import { generateFileDownloadList } from '@/utils/file';
 import { isNumeric } from '@/utils/validator';
 import { getAllBulletinIds, getBulletinById, getAdjacentBulletins } from '@/services/bulletin';
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
 
   const title = `${bulletin.title}`;
   const description = '이번 주 교회 주보에서 예배 일정과 소식을 살펴보세요.';
-  const firstImage = bulletin.bulletin_images?.[0];
+  const ogImage = getOgImageUrl(bulletin.bulletin_images?.[0]?.cloudinary_id);
 
   return {
     title,
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     openGraph: {
       title,
       description,
-      images: firstImage ? [{ url: getCloudinaryUrl(firstImage.cloudinary_id) }] : []
+      images: ogImage ? [{ url: ogImage }] : []
     }
   };
 }
@@ -73,7 +73,7 @@ export default async function BulletinDetail({ params }: { params: Promise<{ id:
         userName="관리자"
         createdAt={created_at}
         userId={author_id ?? ''}
-        thumbnail={imageIds[0] ? getCloudinaryUrl(imageIds[0]) : ''}
+        thumbnail={getKakaoShareUrl(imageIds[0]) ?? ''}
         id={id.toString()}
         updateLink={`/news/bulletins/${id}/update`}
       />

--- a/src/app/(content)/news/bulletins/_component/BulletinForm.module.scss
+++ b/src/app/(content)/news/bulletins/_component/BulletinForm.module.scss
@@ -10,7 +10,7 @@
   }
 
   input {
-    padding: 0.8rem 1rem;
+    padding: $spacing-8 1rem;
     width: 100%;
     border: 1px solid #ccc;
     border-radius: 0.4rem;

--- a/src/app/(content)/news/bulletins/_component/CreateBulletinButton.module.scss
+++ b/src/app/(content)/news/bulletins/_component/CreateBulletinButton.module.scss
@@ -2,7 +2,7 @@
   text-align: right;
 
   a {
-    padding: 0.8rem 1rem;
+    padding: $spacing-8 1rem;
     width: 10rem;
     border: 1px solid black;
     border-radius: 0.4rem;

--- a/src/app/(content)/news/notices/_component/NoticeCategoryFilter.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeCategoryFilter.module.scss
@@ -37,7 +37,7 @@
 }
 
 .count {
-  font-size: 0.9rem;
+  font-size: $font-size-11;
   opacity: 0.5;
 
   .selected & {

--- a/src/app/(content)/news/notices/_component/NoticeControlBar.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeControlBar.module.scss
@@ -47,9 +47,7 @@
     color: $txt-primary;
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: 2px;
+  @include focus-ring('strong') {
     border-radius: 2px;
   }
 }
@@ -78,10 +76,7 @@
     color: $txt-primary;
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: 2px;
-  }
+  @include focus-ring('strong');
 }
 
 .category_btn {
@@ -103,10 +98,7 @@
     color: $txt-primary;
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: 2px;
-  }
+  @include focus-ring('strong');
 }
 
 .search_form {
@@ -165,9 +157,7 @@
     color: $txt-primary;
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: 2px;
+  @include focus-ring('strong') {
     border-radius: 2px;
   }
 }

--- a/src/app/(content)/news/notices/_component/NoticeDrawer.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeDrawer.module.scss
@@ -123,10 +123,7 @@
     background-color: $bg-hover;
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: 2px;
-  }
+  @include focus-ring('strong');
 }
 
 .title {
@@ -203,9 +200,7 @@
     color: $txt-primary;
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: 2px;
+  @include focus-ring('strong') {
     border-radius: 2px;
   }
 }

--- a/src/app/(content)/news/notices/_component/NoticeTable.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeTable.module.scss
@@ -44,10 +44,7 @@
     background-color: rgba(192, 57, 43, 0.025);
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: -2px;
-  }
+  @include focus-ring('strong', calc(-1 * #{$focus-ring-offset}));
 }
 
 .col_pin {
@@ -200,10 +197,7 @@
     background-color: rgba(192, 57, 43, 0.025);
   }
 
-  &:focus-visible {
-    outline: 2px solid $primary-active;
-    outline-offset: -2px;
-  }
+  @include focus-ring('strong', calc(-1 * #{$focus-ring-offset}));
 }
 
 .mobile_top {

--- a/src/app/(content)/news/notices/_component/NoticeTable.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeTable.module.scss
@@ -143,7 +143,7 @@
 .badge_file {
   padding: 0.2rem 0.6rem;
   border-radius: 0.3rem;
-  font-size: 0.9rem;
+  font-size: $font-size-11;
   font-weight: $font-weight-semibold;
   color: $primary-active;
   background: $primary-subtle;

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -7,7 +7,7 @@ import {
   incrementSermonViewCount
 } from '@/services/sermon';
 import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
-import { getCloudinaryUrl } from '@/utils/cloudinary';
+import { getOgImageUrl } from '@/utils/cloudinary';
 import type { SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
 
@@ -24,7 +24,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const preacherLabel = formatPreacherLabel(sermon.preacher);
   const description = sermon.summary ?? `${preacherLabel}의 설교`;
   const thumbnail = getSermonThumbnail(sermon);
-  const ogImage = thumbnail ? getCloudinaryUrl(thumbnail) : null;
+  const ogImage = thumbnail ? getOgImageUrl(thumbnail) : null;
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL}/sermons/${id}`;
 
   return {

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -9,7 +9,7 @@ import SermonOtherByPreacher from '../SermonOtherByPreacher/SermonOtherByPreache
 import SermonMetaActions from './SermonMetaActions';
 import SermonDetailSections from './SermonDetailSections';
 import { formattedDate } from '@/utils/date';
-import { cloudinaryFetchUrl, getCloudinaryUrl } from '@/utils/cloudinary';
+import { cloudinaryFetchUrl, getKakaoShareUrl } from '@/utils/cloudinary';
 import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
 import type { SermonWithRelations } from '@/types/sermon';
 import styles from './SermonDetailPage.module.scss';
@@ -80,7 +80,7 @@ function SermonMeta({ sermon, preacherLabel }: SermonMetaProps) {
   const series = sermon.sermon_series;
   const seriesOrder = sermon.series_order;
   const thumbnail = getSermonThumbnail(sermon);
-  const shareImageUrl = thumbnail ? getCloudinaryUrl(thumbnail) : undefined;
+  const shareImageUrl = getKakaoShareUrl(thumbnail) ?? undefined;
 
   return (
     <div className={styles.meta_block}>

--- a/src/app/(content)/sermons/_component/SermonNoteEditor/SermonNoteEditor.module.scss
+++ b/src/app/(content)/sermons/_component/SermonNoteEditor/SermonNoteEditor.module.scss
@@ -28,10 +28,7 @@
     border-color: $primary;
   }
 
-  &:focus-visible {
-    outline: $focus-ring-width solid $focus-ring-color;
-    outline-offset: $focus-ring-offset;
-  }
+  @include focus-ring();
 }
 
 .hint {

--- a/src/app/(content)/sermons/_component/SermonVideoPlayer/SermonVideoPlayer.module.scss
+++ b/src/app/(content)/sermons/_component/SermonVideoPlayer/SermonVideoPlayer.module.scss
@@ -71,7 +71,7 @@
   gap: $content-gap-s;
   width: 100%;
   aspect-ratio: 16 / 9;
-  background: linear-gradient(135deg, $beige-150, $beige-300);
+  background: linear-gradient(135deg, $bg-secondary, $bg-secondary-deep);
   border: 1px dashed $border-primary;
 
   @include respond-up($breakpoint-tablet) {

--- a/src/app/(content)/sermons/series/[id]/page.tsx
+++ b/src/app/(content)/sermons/series/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { LayoutContainer } from '@/components/layout';
 import { getSeriesDetail } from '@/services/sermon';
-import { getCloudinaryUrl } from '@/utils/cloudinary';
+import { getOgImageUrl } from '@/utils/cloudinary';
 import SeriesDetailHero from '../../_component/SeriesDetailPage/SeriesDetailHero';
 import EpisodeGrid from '../../_component/SeriesDetailPage/EpisodeGrid';
 import styles from '../../_component/SeriesDetailPage/SeriesDetailPage.module.scss';
@@ -28,9 +28,7 @@ export async function generateMetadata({
   const { series } = data;
   const title = series.title;
   const description = series.description ?? '대구동남교회 강해 설교 시리즈';
-  const image = series.cover_image_url
-    ? getCloudinaryUrl(series.cover_image_url)
-    : null;
+  const image = getOgImageUrl(series.cover_image_url);
   const canonical = `${process.env.NEXT_PUBLIC_SITE_URL}/sermons/series/${id}`;
 
   return {

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -1,7 +1,7 @@
 $icon_box_size: 4.2rem;
 
 .quick_wrap {
-  background: $beige-300;
+  background: $bg-secondary-deep;
 }
 
 .quick_container {

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -59,7 +59,7 @@ $icon_box_size: 4.2rem;
 
     .arrow {
       opacity: 1;
-      transform: translateX(0.8rem);
+      transform: translateX($spacing-8);
     }
   }
 }

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -43,7 +43,7 @@ $thumb-sub-w: 14rem;
   top: $spacing-8;
   left: $spacing-8;
   z-index: 1;
-  font-size: 0.9rem;
+  font-size: $font-size-11;
   font-weight: $font-weight-bold;
   color: $navy-950;
   background: $gold-600;

--- a/src/components/layout/Header/MobileNavigation.tsx
+++ b/src/components/layout/Header/MobileNavigation.tsx
@@ -34,9 +34,9 @@ export default function MobileNavigation() {
           <strong>대구동남교회</strong>입니다.
         </div>
         <div className={styles.auth_links}>
-          <Link href="/login">로그인</Link>
+          <Link href="/login" replace>로그인</Link>
           <span className={styles.nav_divider} />
-          <Link href="/sign-up">회원가입</Link>
+          <Link href="/sign-up" replace>회원가입</Link>
         </div>
       </div>
 
@@ -53,6 +53,7 @@ export default function MobileNavigation() {
                   <div className={styles.menu_row}>
                     <Link
                       href={item.href}
+                      replace
                       className={clsx(styles.menu_header, styles.menu_link, isActive && styles.active)}
                     >
                       {item.label}
@@ -70,6 +71,7 @@ export default function MobileNavigation() {
                 ) : (
                   <Link
                     href={item.href}
+                    replace
                     className={clsx(styles.menu_header, isActive && styles.active)}
                   >
                     {item.label}
@@ -83,6 +85,7 @@ export default function MobileNavigation() {
                         <li key={child.href}>
                           <Link
                             href={child.href}
+                            replace
                             className={clsx(
                               styles.sub_link,
                               pathname === child.href && styles.active

--- a/src/components/ui/ListItem/ListItem.module.scss
+++ b/src/components/ui/ListItem/ListItem.module.scss
@@ -21,10 +21,7 @@
     background-color: $bg-hover;
   }
 
-  &:focus-visible {
-    outline: $spacing-2 solid $border-focus;
-    outline-offset: calc(-1 * #{$spacing-2});
-  }
+  @include focus-ring($offset: calc(-1 * #{$focus-ring-offset}));
 }
 
 .selected {

--- a/src/context/SessionContextProvider.tsx
+++ b/src/context/SessionContextProvider.tsx
@@ -11,7 +11,7 @@ import {
   useCallback,
   useMemo
 } from 'react';
-import { supabase } from '@/lib/supabase/client';
+import { getSupabaseBrowserClient } from '@/lib/supabase/client';
 import { AuthError, PostgrestError, Session } from '@supabase/supabase-js';
 import { getProfileById } from '@/apis/user';
 import { REDIRECT_AFTER_LOGIN_KEY } from '@/constants/auth';
@@ -81,6 +81,7 @@ function SessionContextProvider({ children }: PropsWithChildren) {
   );
 
   useEffect(() => {
+    const supabase = getSupabaseBrowserClient();
     const {
       data: { subscription }
     } = supabase.auth.onAuthStateChange(handleAuthStateChange);

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -3,14 +3,6 @@
 import { createBrowserClient } from '@supabase/ssr';
 import type { Database } from '@/types/database.types';
 
-/**
- * @deprecated `use getSupabaseBrowserClient`
- * */
-export const supabase = createBrowserClient<Database>(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-);
-
 let client: ReturnType<typeof createBrowserClient> | undefined;
 
 export function getSupabaseBrowserClient() {

--- a/src/services/about/index.ts
+++ b/src/services/about/index.ts
@@ -90,6 +90,7 @@ export const getHubPageData = async (): Promise<{
 
 export const getPastorPageData = async (): Promise<{ pastor: PastorData | null }> => {
   const result = await getActiveStaff();
+  if (result.error) console.error('[about] getActiveStaff 조회 실패', result.error);
   const rows = (result.data ?? []) as StaffType[];
   return { pastor: toPastorData(findSeniorPastor(rows)) };
 };

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -226,6 +226,18 @@
   }
 }
 
+/// :focus-visible outline 패턴 SSOT. 폭·offset은 $focus-ring-* 토큰 고정.
+/// $variant: 'default'($border-focus) / 'strong'($primary-active 강조).
+/// $offset: 기본은 바깥 링, calc(-1 * #{$focus-ring-offset}) 전달 시 안쪽(테두리 잘림 방지).
+@mixin focus-ring($variant: 'default', $offset: $focus-ring-offset) {
+  &:focus-visible {
+    outline: $focus-ring-width solid
+      if($variant == 'strong', $focus-ring-strong-color, $focus-ring-color);
+    outline-offset: $offset;
+    @content;
+  }
+}
+
 /// 썸네일 위 재생 힌트 — 흰 아이콘 + 검정 opacity 배경. 위치·표시 동작 포함 단일 소스.
 /// 카드: 데스크톱 hover 시 노출 / 모바일(hover 미지원) 항상 노출. 부모에 `:hover` reveal 추가.
 /// rgba($black,..) = SKILL rgba 투명도 예외. `-sm` 카드 / `-lg` Featured 큰 CTA.

--- a/src/styles/tokens/_color.scss
+++ b/src/styles/tokens/_color.scss
@@ -81,6 +81,7 @@ $txt-on-dark-nav-faint: #6b7280;
 $bg-primary: $beige-50; // 페이지 전체 기본 배경
 $bg-card: $white; // 카드 배경 — $border-card와 쌍
 $bg-secondary: $beige-150; // 섹션·카드 정적 면 (decorative neutral) ★
+$bg-secondary-deep: $beige-300; // $bg-secondary보다 진한 따뜻한 면 — QuickAccess 배경·영상 그라데이션 끝
 $bg-beige-subtle: $beige-100; // 가장 옅은 beige 섹션 면 (secondary보다 옅음)
 $bg-hover: rgba($navy-800, 0.06); // 인터랙티브 hover 피드백 (cool, 면 종류 무관) — v4
 $bg-accent-subtle: rgba(196, 146, 74, 0.12); // CTA 섹션·환영 배너 (Gold 12% tint)

--- a/src/styles/tokens/_semantic.scss
+++ b/src/styles/tokens/_semantic.scss
@@ -100,5 +100,8 @@ $focus-ring-width: $spacing-2;
 /// 0.2rem — focus-visible outline-offset
 $focus-ring-offset: $spacing-2;
 
-/// $border-focus 별칭 — focus ring 색
+/// $border-focus 별칭 — focus ring 색 (기본)
 $focus-ring-color: $border-focus;
+
+/// 강조 focus ring 색 — Notice 등 인터랙티브 컨트롤
+$focus-ring-strong-color: $primary-active;

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -48,6 +48,22 @@ export const getCloudinaryUrl = (publicId: string) =>
 export const getCloudinaryDownloadUrl = (publicId: string) =>
   `${BASE_URL}/fl_attachment/${normalizePublicId(publicId)}`;
 
+// OG·카카오 공유처럼 <Image> 밖에서 쓰는 고정 변환 URL 빌더.
+// public_id는 image/upload, 외부 URL(YouTube 썸네일 등)은 image/fetch 경로로 같은 변환을 적용한다.
+const buildTransformedUrl = (input: string, transform: string): string | null => {
+  if (!CLOUD_NAME) return null;
+  if (/^https?:\/\//i.test(input)) {
+    return `https://res.cloudinary.com/${CLOUD_NAME}/image/fetch/${transform}/${encodeURIComponent(input)}`;
+  }
+  return `${BASE_URL}/${transform}/${normalizePublicId(input)}`;
+};
+
+export const getOgImageUrl = (input: string | null | undefined): string | null =>
+  input ? buildTransformedUrl(input, 'c_fill,w_1200,h_630,g_auto,f_auto,q_auto') : null;
+
+export const getKakaoShareUrl = (input: string | null | undefined): string | null =>
+  input ? buildTransformedUrl(input, 'c_fill,w_800,h_400,g_auto,f_auto,q_auto') : null;
+
 // 외부 호스트(YouTube 썸네일 등)를 Cloudinary fetch URL로 감싸 next/image의 res.cloudinary.com remotePattern을 통과시키는 helper.
 // public ID(http(s):// 미접두) 입력은 fetch가 아니라 image/upload 변환 대상이므로 그대로 반환 — 호출부에서 <CloudinaryImage> loader가 처리.
 export const cloudinaryFetchUrl = (remoteUrl: string | null): string | null => {
@@ -87,7 +103,7 @@ export function createCloudinaryLoader({ cropMode, gravity, aspectRatio }: Cloud
     } else {
       params.push('c_limit');
     }
-    params.push(`w_${width}`, `q_${quality || 85}`);
+    params.push(`w_${width}`, `q_${quality || 'auto:good'}`);
     return `${BASE_URL}/${params.join(',')}/${normalizePublicId(src)}`;
   };
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 배포 전 기술 부채를 현재 코드에 맞춰 정리한다 (마스터 플랜 Phase 2~6).

**범위**:

- Supabase 공개 조회 실패 로깅 + 구 named export 제거 (G2·G7)
- 드로어 뒤로가기 버그 수정 + Cloudinary 전송 최적화 (G7·G3)
- typography·spacing 토큰화 + focus-ring SSOT 통일 (G5·G4)

---

## 🔗 개발 컨텍스트

- **Task ID**: `tech-debt-pre-release` (verify run `20260602-001031`)
- **Exec Plan**: `docs/exec-plans/active/2026-05-22-tech-debt-pre-release.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: `docs/tech-debt/active.md`, `docs/tech-debt/resolved.md`
- **작업 범위**: Phase 2(G2 Supabase 로깅) · Phase 3(G7 supabase 잔재 제거 + 드로어 버그) · Phase 4(G3 Cloudinary) · Phase 5(G5 typography) · Phase 6(G4 focus-ring)
- **제외한 범위**: Phase 7(G6 레이어 정리) — 사용자 결정으로 이번 범위 밖. Phase 1(주보)은 PR #105로 이미 머지.

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제 / 목적:**
배포 전 누적된 부채를 한 번에 정리한다. 공개 데이터 조회가 조용히 빈 값으로 떨어져 원인 추적이 어렵던 문제, 구 supabase named export 잔존, 드로어 뒤로가기 동작 불일치, OG·공유 이미지 미최적화, 스타일 리터럴·focus outline 중복을 함께 해소한다.

**관련 이슈:**

- Issue: # N/A

---

## 🔧 주요 변경점 (Key Changes)

- Supabase 공개 데이터 조회 실패를 서버 로그에 남겨 silent fallback을 추적 (`src/apis/site-collections.ts`·`site-settings.ts`·`services/about`) — Phase 2
- 구 `supabase` named export 제거, 브라우저 클라이언트를 `getSupabaseBrowserClient()`로 통일 (`src/lib/supabase/client.ts`·`apis/auth.ts`) — Phase 3
- 드로어를 열고 메뉴 이동 시 가짜 history 항목을 제거해 뒤로가기 1회로 이전 페이지 도달 (`src/components/layout/Header/MobileNavigation.tsx` Link `replace`) — Phase 3
- Cloudinary OG·공유 이미지 변환 함수(`getOgImageUrl`·`getKakaoShareUrl`) 도입, 업로드 화질 `q_auto:good` (`src/utils/cloudinary.ts`) — Phase 4
- typography 0.9rem·spacing 0.8rem 리터럴을 토큰으로 교체, about 구분선 `#eee` 제거 — Phase 5
- `$beige-300` primitive 직접 사용 제거, `$bg-secondary-deep` 시맨틱 토큰 도입 (`src/styles/tokens/_color.scss`) — Phase 6
- focus-visible outline을 `focus-ring` mixin SSOT로 10곳 통일 (`src/styles/_mixins.scss`) — Phase 6
- 완료 plan 2건 이관, 부채 수치 갱신, Phase 2~6 완료 표시 (`docs/`)

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 드로어 뒤로가기 처리 | `MobileNavigation` Link에 `replace` 추가 | 드로어가 열린 상태에선 현재 history 항목이 sentinel이라 replace가 그 항목을 목적지로 교체해 가짜 항목을 안 남긴다 | 플랜의 effect cleanup — 라우트 이동 후 현재 항목이 새 경로라 guard가 발동 안 함 (Codex CHANGE_REQUEST, D11) |
| Cloudinary OG/공유 변환 | 입력을 분기 — public_id는 image/upload, 외부 URL은 image/fetch | 설교 OG가 외부 YouTube 썸네일이라 fetch 경로로 같은 변환을 걸어야 한다 | public_id만 가정한 플랜 함수 — 외부 URL 미적용 (Codex 설계, D12) |
| focus-ring 토큰 통일 | `focus-ring($variant, $offset)` mixin + `$focus-ring-strong-color` | outline 10곳의 색·폭·offset SSOT 확보, `@content`로 border-radius 같은 추가 속성 수용 | 토큰만 신설하고 블록 유지 — 중복 SSOT 부재 그대로 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs tech-debt-pre-release` (run 20260602-001031) — PASS. ESLint·stylelint·Build 통과, Knip은 기존 부채 경고 |
| `harness-gate` | develop 머지 전 실행 |
| Codex 계획 검증 | 미요청 — 마스터 플랜은 기존, 이번 PR은 구현 배치 |
| Codex 1차/설계 검증 | 드로어(D11)·Cloudinary OG(D12) 설계 PASS |
| Claude 2차 검증 | verify-task PASS + diff 재확인 완료. 드로어·OG는 Chrome 실측 확인 |
| ADR 판단 | 불필요 (구조·라이브러리·레이어·정책 변경 없음) |
| 남은 warning | 기존 부채 (Knip) |

---

## 👀 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 드로어 메뉴 이동 후 뒤로가기가 1회로 이전 페이지에 도달한다. 작은 글자(공지 배지 등)가 9px급에서 11px급으로 커진다. OG·공유 이미지가 고정 변환으로 통제된다.
- **운영 리스크**: 없음 (환경변수·마이그레이션·스크립트 실행 불필요).
- **QA 후속**: 드로어 뒤로가기와 `/sermons/3` OG 이미지는 Chrome 실측으로 확인했다. 머지 후 배포 프리뷰에서 OG 미리보기 1회 재확인을 권장한다.
- **롤백 시 영향**: 없음 (되돌리면 이전 동작으로 복귀).
- **먼저 볼 흐름**: 모바일 뷰포트 → 하단 메뉴 → 드로어 링크 클릭 → 뒤로가기 1회.

---

## 📝 메모

Phase 7(G6 레이어 정리)은 사용자 결정으로 분리했다. tech-debt active → resolved 이관은 머지 후 complete-task에서 한다. 다음 작업은 마스터 플랜의 Phase 7부터 이어가면 된다.
