### PR TITLE
[Docs] tech-debt-pre-release 완료 이관 + 해소 부채 9건 정리 (Phase 8)

### DIFF
--- a/.claude/skills/styles/SKILL.md
+++ b/.claude/skills/styles/SKILL.md
@@ -65,7 +65,7 @@ description: SCSS 파일 생성/수정, 스타일 작성, 디자인 토큰 사�
 - **Gray**: `$gray-900` `$gray-700` `$gray-500` `$gray-400` `$gray-300` `$gray-200` `$gray-100` `$gray-50` `$black` `$white`
 - **Navy (Brand · Primary Action · Interactive cool)**: `$navy-950` `$navy-900` `$navy-800` `$navy-600`
 - **Gold (Accent)**: `$gold-600` `$gold-400` `$gold-100`
-- **Beige (Warm Decorative Surface)**: `$beige-50` `$beige-100` `$beige-150` `$beige-200` `$beige-300` — 정적 면 전용. (`$beige-50/100/150/200` = `$bg-primary`/`$bg-beige-subtle`/`$bg-secondary`/`$border-card`로 매핑 완료; `$beige-300`은 미정)
+- **Beige (Warm Decorative Surface)**: `$beige-50` `$beige-100` `$beige-150` `$beige-200` `$beige-300` — 정적 면 전용. (`$beige-50/100/150/200/300` = `$bg-primary`/`$bg-beige-subtle`/`$bg-secondary`/`$border-card`/`$bg-secondary-deep`로 매핑 완료)
 - **Status**: `$green-500` `$green-100` `$red-500` `$red-100` `$orange-600` `$orange-100`
 
 ### Semantic (역할 기반 — 컴포넌트에서 직접 사용)
@@ -75,11 +75,11 @@ description: SCSS 파일 생성/수정, 스타일 작성, 디자인 토큰 사�
 `$txt-image-subtle` (이미지 위 보조) `$txt-dark-muted` (다크배경 보조) `$txt-dark-faint` (다크배경 약한)
 
 **Background**
-- 정적 warm: `$bg-primary`(beige-50, 페이지 배경) `$bg-card`(#fff, 카드·패널) `$bg-secondary`(beige-150, 섹션·카드 정적 면) `$bg-beige-subtle`(beige-100, 가장 옅은 섹션 면) `$bg-accent-subtle`(gold 12% tint, CTA·배너 면)
+- 정적 warm: `$bg-primary`(beige-50, 페이지 배경) `$bg-card`(#fff, 카드·패널) `$bg-secondary`(beige-150, 섹션·카드 정적 면) `$bg-secondary-deep`(beige-300, 더 진한 정적 면) `$bg-beige-subtle`(beige-100, 가장 옅은 섹션 면) `$bg-accent-subtle`(gold 12% tint, CTA·배너 면)
 - 인터랙티브 cool: `$bg-hover`(navy 6% rgba) — 면 종류 무관, hover/active 피드백 전용 ★
 - 다크: `$bg-dark` `$bg-dark-card` `$bg-dark-nav`(헤더·푸터)
 
-> v4: `$bg-tertiary` **삭제**. hover 피드백은 `$bg-hover`로, 더 깊은 warm 면이 필요하면 `$bg-secondary` 재사용.
+> v4: `$bg-tertiary` **삭제**. hover 피드백은 `$bg-hover`로, 더 깊은 warm 면이 필요하면 `$bg-secondary-deep`을 쓴다.
 
 **Border**
 `$border-primary` `$border-subtle` `$border-strong` `$border-focus` `$border-warm`(cream·gold 배경 위)
@@ -139,6 +139,7 @@ primitive를 쓰려는 순간 이 표를 먼저 확인한다.
 | `$beige-100` | `$bg-beige-subtle` | 가장 옅은 섹션 면 |
 | `$beige-150` | `$bg-secondary` | 섹션·카드 정적 면 |
 | `$beige-200` | `$border-card` | 카드·섹션 외곽 테두리 |
+| `$beige-300` | `$bg-secondary-deep` | QuickAccess 배경·영상 그라데이션 끝 |
 | `$white` | `$txt-inverse` / `$bg-card` | 다크 배경 위 텍스트 / 카드·패널 배경 |
 
 **예외 — semantic 미정 (사용처에 로컬 주석 필수)**

--- a/docs/exec-plans/completed/2026-05-22-tech-debt-pre-release.md
+++ b/docs/exec-plans/completed/2026-05-22-tech-debt-pre-release.md
@@ -1,6 +1,6 @@
 # tech-debt-pre-release
 
-- **상태**: 🟡 거의 완료 — Phase 1~6을 처리했다(부채 그룹 G1·G2·G7·G3·G5·G4, PR #105와 `chore/pre-release-prep` 브랜치). Phase 7(G6)은 사용자 결정으로 후속으로 미뤘고, Phase 8(tech-debt 이관)은 머지 후에 한다
+- **상태**: ✅ 완료 (2026-06-02)
 - **시작일**: 2026-05-22
 - **브랜치**: phase별 분기 — `feat/sermons-publish-ssot` 머지 후 base branch에서 신설
 - **Open questions**:
@@ -223,6 +223,25 @@
 - **최종 판단**: PASS
 - **현재 판단**: verify-task(run 20260602-001031) ESLint·stylelint·Build 통과, Knip은 기존 부채. 드로어 뒤로가기와 /sermons/3 OG 이미지는 Chrome 실측으로 확인. Gemini·Codex 리뷰 0 이슈
 - **다음 행동**: harness-gate 통과 후 머지
+
+## 회고
+
+### 잘 된 것
+
+- 배포 전 P0·P1 부채 5개 그룹(G2·G7·G3·G5·G4)을 9 commit·1 PR(#108)로 정리했다. verify-task·Gemini·Codex 객관 리뷰가 모두 0 이슈로 끝났다.
+- 한 commit = 한 의도로 분리했다. G7은 supabase 잔재(Refactor)와 드로어 버그(Fix)로, G4는 $beige(Style)와 focus-ring(Refactor)으로 나눴다. 사용자에게 그룹별로 승인받아 진행했다.
+- 동작이 바뀌는 부분은 Claude in Chrome으로 실측했다. 드로어는 뒤로가기 1회·history.length 불변, Cloudinary OG는 /sermons/3에서 HTTP 200 image/jpeg를 확인했다.
+
+### 다음에 할 것
+
+- G6(`app/→apis` 직접 호출 3건을 services 경유로)은 사용자 결정으로 분리했다. active.md "app/→apis 직접 호출" 부채 항목이 추적한다.
+- 주보 업로드 orphan 실기기 QA(G1 잔여), bulletin 폼 border hex(black·#ccc), getThumbnailUrl 소비처가 생기면 추가.
+- supabase-cost-pass-1(성능)은 별도 plan으로 남아 있다.
+
+### 발견된 부채·관찰
+
+- 플랜의 사전 설계가 세 곳에서 틀렸다. 드로어 history guard는 라우트 이동 후 발동 안 함, Cloudinary 함수는 외부 YouTube URL을 빠뜨림, spacing 0.8rem→토큰은 무손실이 아니라 반응형 값 변경. 다음 plan은 History API 타이밍·외부 URL·반응형 스케일을 구현 전에 실측하거나 Codex로 검증하는 게 좋다.
+- Codex 백그라운드 호출이 샌드박스 셸 오류로 1회 부분 실패했다(Cloudinary 설계). diff·파일을 1개로 좁혀 Read하게 하면 회피된다.
 
 ## 검증 이력
 

--- a/docs/tech-debt-tracker.md
+++ b/docs/tech-debt-tracker.md
@@ -6,10 +6,10 @@
 
 ## 위치
 
-| 파일 | 내용 | 항목 수 (2026-06-01) |
+| 파일 | 내용 | 항목 수 (2026-06-02) |
 | --- | --- | --- |
-| [`tech-debt/active.md`](tech-debt/active.md) | 진행 중·미해결 부채 | 34 |
-| [`tech-debt/resolved.md`](tech-debt/resolved.md) | 해결된 부채 (회고·검색용) | 11 |
+| [`tech-debt/active.md`](tech-debt/active.md) | 진행 중·미해결 부채 | 25 |
+| [`tech-debt/resolved.md`](tech-debt/resolved.md) | 해결된 부채 (회고·검색용) | 20 |
 
 ## 형식
 
@@ -35,5 +35,5 @@
 - 형식 일관성 가이드: ADR 0011 (의사결정 로그 형식)
 - 부채 발견 → 등록 흐름: `.claude/skills/complete-task/SKILL.md`
 
-<!-- last-audit: 2026-06-01 -->
+<!-- last-audit: 2026-06-02 -->
 <!-- 변경 이력은 docs/exec-plans/completed/ 또는 git log 참조 -->

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -4,18 +4,6 @@
 
 ---
 
-### 🟢 `supabase` named export deprecated (2건 남음)
-
-- **무엇**: `src/lib/supabase/client.ts`의 `supabase` named export
-- **왜**: 초기에 단일 client 인스턴스로 시작했으나, 용도별 분리(browser/server-side/static/admin) 필요해짐
-- **마이그레이션 경로**: 남아 있는 2건을 `getSupabaseBrowserClient()`로 교체 → named export 자체 제거
-- **영향 범위** (2건):
-  - `src/context/SessionContextProvider.tsx:14`
-  - `src/apis/auth.ts:1`
-- **확인**: `rg "import \{ supabase \} from" src` → 2 hits
-- **발견일**: 미상 (CLAUDE.md Gotchas에 기존 기록)
-- **재확인일**: 2026-05-21 (다수 → 2건으로 축소 확인)
-
 ### 🟡 `app/ → apis/` 직접 호출 (레이어 위반, 8건)
 
 - **무엇**: 페이지·홈 컴포넌트가 `services/` 경유 없이 `apis/`를 직접 import
@@ -32,36 +20,6 @@
 - **발견일**: 2026-05-01 (ESLint 레이어 룰 도입 시)
 - **2026-05-02**: `worship/page.tsx` 해소 (`services/worship/` 도입) — 10건 → 9건
 - **2026-05-21**: `about/location/page.tsx` 해소 (`services/about/getLocationPageData` 경유) — 9건 → 8건
-
-### 🟢 focus-ring 패턴 통일 (10곳)
-
-- **무엇**: globals 외 10곳의 `:focus-visible` outline이 색·width·offset가 제각각. 색은 `$primary`/`$primary-active`/`$border-focus`/`$border-primary` 4종, width는 `0.2rem`/`2px` 혼재, offset은 양수·음수 혼재
-- **왜**: focus-ring 토큰(`$focus-ring-{width,offset,color}`)이 도입되기 전(2026-05-10 이전) 영역별로 자유롭게 작성됨. globals만 본 PR에서 토큰화 완료
-- **마이그레이션 경로**: 영역별 분리 PR로 새 토큰(또는 신설 mixin) 적용. 음수 offset(NoticeTable)·`$primary-active` 사용(NoticeDrawer/Table/ControlBar)·`$border-primary` 사용(Pagination)이 의도인지 케이스별 검토 후 통일 또는 토큰 다양성 추가
-- **영향 범위** (10곳):
-  - `src/components/ui/Pagination/Pagination.module.scss:39-40` — `$border-primary` 사용 (의도 검토 필요)
-  - `src/components/ui/ListItem/ListItem.module.scss:25-26` — `$border-focus` + negative offset
-  - `src/app/(content)/news/notices/_component/NoticeDrawer.module.scss:127-128, 207-208` — `$primary-active` + 2px
-  - `src/app/(content)/news/notices/_component/NoticeTable.module.scss:48-49, 204-205` — `$primary-active` + negative offset
-  - `src/app/(content)/news/notices/_component/NoticeControlBar.module.scss:51-52, 82-83, 107-108, 169-170` — `$primary-active` + 2px (4곳 동일 패턴)
-- **확인**: `rg ':focus|outline' src -g '*.scss'` (focus-state 전반 추적성 — outline-ring 외 :focus·:focus-within·outline:none 패턴도 함께 노출)
-- **발견일**: 2026-05-10 (transition-focus-tokens PR EXPLORE)
-
-### 🟢 useDrawerHistory: 라우트 이동 시 drawer history entry 미정리
-
-- **무엇**: `useDrawerHistory.ts`에서 drawer 열린 상태로 링크 클릭 등 라우트 이동이 발생하면, `history.pushState({ __drawer: true }, '')` 엔트리가 스택에서 제거되지 않아 뒤로가기 스택에 중복 URL이 남을 수 있음
-- **왜**: 초기 구현에서 `pathname` 변경 시 `setDrawerOpen(false)` 처리만 하고 쌓인 history entry 정리 정책이 미정의
-- **마이그레이션 경로**: `pathname` effect 또는 unmount cleanup에서 `history.back()` 또는 `history.replaceState` 호출로 entry 제거 정책 결정 후 적용
-- **영향 범위**: `src/hooks/useDrawerHistory.ts`, `src/components/layout/BottomNav/BottomNav.tsx`
-- **발견일**: 2026-05-10 (PR #81 Codex 리뷰)
-
-### 🟢 services/about: Supabase error silent fallback 로깅 부재
-
-- **무엇**: `getSiteCollection<T>` 및 `getSiteSettings`가 Supabase `error` 필드를 무시하고 빈 배열/기본값으로 fallback. 운영 중 DB 오류가 발생해도 로그 없이 빈 화면으로 렌더됨
-- **왜**: `worshipService`만 try/catch 보호. 나머지 API 호출은 silent fallback 정책으로 작성 (사용자 결정)
-- **마이그레이션 경로**: `error && console.error(...)` 최소 로깅 추가. 중요도에 따라 Sentry 등 외부 에러 추적 연동 검토
-- **영향 범위**: `src/apis/site-collections.ts`, `src/services/about/index.ts`
-- **발견일**: 2026-05-10 (PR #81 Codex 리뷰)
 
 ### 🟡 SCSS primitive 토큰 직접 사용 (143건)
 
@@ -144,34 +102,6 @@
 - **마이그레이션 경로**: 도입 결정 시 별도 ADR로 처리 — `_color.scss`에 dark 토큰 추가, `[data-theme="dark"]` 또는 `prefers-color-scheme` 셀렉터로 시맨틱 레이어 오버라이드
 - **발견일**: 2026-05-04 (design-system-v3, Tier 2 보류)
 
-### 🟢 about/ 경로 SCSS 정리 (1건 남음)
-
-- **무엇**: `src/app/(content)/about/serving-people/page.module.scss:72`의 `border: 1px solid #eee` hex 하드코딩 1건
-- **왜**: 디자인·내용 미확정으로 design-system-v3 pilot에서 제외됐던 영역. 그동안 about/page.module.scss 본체에 있던 hex 3종(`#eee`, `#f8f8f8`, `#fde5cf`)은 about-page-redesign(2026-05-08)에서 토큰으로 치환됨
-- **마이그레이션 경로**: `border: 1px solid #eee` → semantic border 토큰 매핑(`$border-card` 또는 `$border-subtle` 후보)
-- **영향 범위** (1건):
-  - `src/app/(content)/about/serving-people/page.module.scss:72`
-- **확인**: `rg "#[0-9a-fA-F]{3,6}" src/app/(content)/about -g "*.module.scss"` → 1 hit
-- **2026-05-21 갱신**: about/page.module.scss 본체 hex 3종 + 리터럴 2건 모두 해소됨. 남은 건 serving-people 1건뿐이라 항목 범위 축소
-- **발견일**: 2026-05-04 (design-system-v3 Non-goals)
-
-### 🟢 typography 리터럴 0.8rem / 0.9rem 토큰 부재 (10건)
-
-- **무엇**: 8/9px 리터럴(`0.8rem`·`0.9rem`)이 모듈 곳곳에 박혀 있음. font-size 3건 + padding 4건 + 위치(left/right) 2건 + margin 1건 + translate 1건 = 10건
-- **왜**: 현재 typography primitive는 `$font-size-11`이 최저. font-size 외 padding/위치 값은 spacing 토큰 체계(가장 작은 값이 `$spacing-4`=0.4rem)에서도 0.8rem 사용 가능한지 디자인 검토 필요
-- **마이그레이션 경로**:
-  - font-size 3건: (a) `$font-size-9`/`$font-size-8` 신규 primitive 도입 또는 (b) 디자인 검토 후 `$font-size-11`/`$font-size-12`로 상향
-  - 그 외 7건: spacing 토큰(`$spacing-8`)으로 치환 가능한지 케이스별 확인
-- **영향 범위** (10건):
-  - font-size: `src/app/_component/home/SermonCard.module.scss:46`, `src/app/(content)/news/notices/_component/NoticeCategoryFilter.module.scss:40`, `NoticeTable.module.scss:146`
-  - padding: `src/app/(content)/news/bulletins/_component/CreateBulletinButton.module.scss:5`, `BulletinForm.module.scss:13`, `src/app/(content)/about/page.module.scss:213`
-  - left/right: `src/app/(content)/about/page.module.scss:392`, `page.module.scss:393`
-  - margin-top: `src/app/(content)/about/vision/page.module.scss:375`
-  - transform: `src/app/_component/home/QuickAccess.module.scss:62`
-- **확인**: `rg -n '0\.[89]rem' -g '*.module.scss' src/` → 10 hits
-- **2026-05-21 갱신**: `FeedContent.module.scss:223` 0.8rem은 해소됨. 다른 위치 9건이 새로 보이므로 카운트 갱신 (2건 → 10건). 처음 발견 시 font-size만 보던 시야에서 padding/위치/margin/transform까지 같이 보는 시야로 넓힘
-- **발견일**: 2026-05-04 (design-system-v3 Step 3)
-
 ### 🟢 FeedContent `.badge_category` mixin 미적용
 
 - **무엇**: `src/app/_component/home/FeedContent.module.scss`의 카테고리 뱃지가 신규 caption mixin을 적용받지 않은 채 직접 토큰 조합
@@ -195,29 +125,15 @@
 - **마이그레이션 경로**: `eslint-plugin-import`의 `no-relative-parent-imports` 또는 `eslint-plugin-boundaries` 도입 검토 (별도 EXEC_PLAN)
 - **발견일**: 2026-05-01 (Codex 리뷰)
 
-### 🟢 Hover Border 위반 — 디자인 시스템 v4 미완 남은 부분 (10건)
+### 🟢 Hover Border 위반 — admin 영역 남은 분 (5건)
 
-- **무엇**: hover 시 `border-color`/`border` 변경 — `.claude/skills/styles/SKILL.md` Hover 3원칙 #3 위반
-- **왜**: v4 마이그레이션이 sermons/news 영역에 한정. home/admin은 후속 phase로 분리
-- **마이그레이션 경로**:
-  - home(5건): hover에서 border 코드 제거, 필요 시 `hover-lift` 또는 shadow 강조로 대체
-  - admin(5건): admin 토큰 ADR 결정 후 일괄
-- **영향 범위**:
-  - home: `src/app/_component/home/{FeedContent,SermonCard,RecentSermons,NewHere,AboutOurChurch}.module.scss`
-  - admin: `src/components/admin/sermons/SermonListPage/{dropdown,table}.module.scss`, `src/components/admin/sermons/SermonForm/index.module.scss`, `src/components/admin/layout/{PageHeader,AdminHeader}/index.module.scss`
+- **무엇**: hover 시 `border-color`/`border` 변경 — `.claude/skills/styles/SKILL.md` Hover 3원칙 #3 위반. admin 5건만 남음
+- **왜**: v4 마이그레이션이 sermons/news 영역에 한정됐다. home은 2026-05-07 home cleanup에서 해소(resolved.md), admin은 admin 토큰 ADR 결정 후로 분리
+- **마이그레이션 경로**: admin 5건은 admin 토큰 통합(ADR 0012)이 끝났으니 hover border를 제거하고 `hover-lift`/shadow로 대체
+- **영향 범위** (admin 5건):
+  - `src/components/admin/sermons/SermonListPage/{dropdown,table}.module.scss`, `src/components/admin/sermons/SermonForm/index.module.scss`, `src/components/admin/layout/{PageHeader,AdminHeader}/index.module.scss`
+- **2026-06-02 갱신**: home 5건은 2026-05-07 home cleanup에서 이미 해소 확인(FeedContent transition은 탭 상태 전환이라 위반 아님). 10건 → admin 5건으로 축소
 - **발견일**: 2026-05-07 (Codex 디자인 시스템 audit)
-
-### 🟢 `$beige-300` semantic 매핑 부재 (2건 남음)
-
-- **무엇**: `$beige-300: #e8e6e1` primitive가 2 모듈에서 직접 사용 중인데 semantic 토큰 매핑이 없음
-- **왜**: 2026-05-08 about-page-redesign에서 사용자 명시 요청으로 `$cream-300 → $beige-300` 매핑되어 도입됐으나, 같은 plan 시점에 semantic 이름까지 짝지을 시간이 없어 SKILL.md에 *"미정"*으로 기록 후 보류
-- **마이그레이션 경로**: 사용처 2 모듈 패턴(QuickAccess background, SermonVideoPlayer gradient `linear-gradient(135deg, $beige-150, $beige-300)`)에서 의미 뽑아내기 → `$bg-secondary-deep` 또는 `$bg-gradient-end-warm` 같은 semantic 신설 → 사용처 일괄 치환 → SKILL.md 갱신
-- **영향 범위** (2 파일 2건):
-  - `src/app/_component/home/QuickAccess.module.scss:4` — `background: $beige-300`
-  - `src/app/(content)/sermons/_component/SermonVideoPlayer/SermonVideoPlayer.module.scss:74` — gradient end
-- **확인**: `rg '\$beige-300' src/app src/components` → 2 hits
-- **2026-05-21 갱신**: GridCard·SermonCard gradient에서 사라짐(언제 어느 PR에서 빠졌는지는 git blame 필요). 5건 → 2건으로 축소
-- **발견일**: 2026-05-10 (style-tokens-cleanup PR Codex 1차 BLOCK 검증 중 발견)
 
 ### 🟢 토큰 부채 — 디자인 시스템 v4 미완 남은 부분 (hex/rgba 직접 사용)
 
@@ -237,23 +153,6 @@
 - **왜**: dnchurch dev/prod preset의 dynamic folder mode에서 경험적으로 검증된 조합. Cloudinary 공식은 dynamic folder mode에서 `asset_folder` + `public_id_prefix` 또는 `use_asset_folder_as_public_id_prefix`를 권장
 - **마이그레이션 경로**: 단순화 시도 전 smoke test 필수 — `folder` 제거 / `asset_folder` 전환 각각 시도 후 결과 `public_id` 형태와 폴더 위치 확인. 검증 통과 시 단순화
 - **영향 범위**: `src/apis/cloudinary.ts`
-- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
-
-### 🟢 Cloudinary 이미지 품질 `q_85` 고정 → `q_auto` 전환 검토
-
-- **무엇**: `src/utils/cloudinary.ts:90`의 업로드 로더(`createCloudinaryLoader`)가 `q_${quality || 85}`로 기본 화질 85% 고정. Cloudinary 공식 권장은 `q_auto`(또는 `q_auto:good`)로, 컨텐츠별 최적 품질로 자동 조정한다. 외부 호스트 fetch URL(`cloudinaryFetchUrl:58`·resize `:79`)은 이미 `q_auto`를 쓴다. 이번 부채는 업로드 로더 기본값 1곳만 남는다
-- **왜**: 명시적 품질 관리 의도. 자동화 결과 품질 변동성 우려로 보류
-- **마이그레이션 경로**: 일부 use-case(`hero`, `bulletin`)에서 A/B 비교 후 `q_auto:good` 전환. PSNR/SSIM 또는 시각 검토로 품질 회귀 없음 확인 → 전체 전환
-- **영향 범위**: `src/utils/cloudinary.ts`, 모든 `<CloudinaryImage>` 사용처
-- **참고**: https://cloudinary.com/documentation/image_optimization
-- **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
-
-### 🟢 Cloudinary use-case별 preset 부재 (OG/카카오/다운로드)
-
-- **무엇**: `getCloudinaryUrl()`은 변환 없이 원본 URL 생성. OG 이미지·카카오 공유·다운로드 등 각 use-case에 적절한 사이즈/품질 변환이 일괄 적용되지 않음
-- **왜**: 초기에는 `<Image>` 컴포넌트만 사용하는 가정. OG/공유 등 외부 use-case 추가 시 case-by-case로 변환 추가
-- **마이그레이션 경로**: use-case별 명명된 preset 함수 도입 — 예: `getOgImageUrl(publicId)`, `getKakaoShareUrl(publicId)`, `getThumbnailUrl(publicId)`. 각각 `w`/`c`/`q`/`f` 조합 고정 → derived asset 종류 통제 → bandwidth/transformation 비용 절감
-- **영향 범위**: `src/utils/cloudinary.ts`, OG metadata 생성 사이트, 공유 버튼 컴포넌트
 - **발견일**: 2026-05-11 (PR #82 Codex 리뷰)
 
 ### 🟢 `CloudinaryImage` 불필요한 `'use client'` boundary

--- a/docs/tech-debt/resolved.md
+++ b/docs/tech-debt/resolved.md
@@ -12,9 +12,9 @@
 
 ### ✅ focus-ring 패턴 통일 (2026-06-02 해소, PR #108)
 
-- **부채**: `:focus-visible` outline이 10곳에 색·폭·offset 제각각으로 박혀 SSOT가 없었다
-- **해소**: `focus-ring($variant, $offset)` mixin(`@content`로 추가 속성 수용)과 `$focus-ring-strong-color` 토큰을 도입해 10곳(Notice 8·ListItem·SermonNoteEditor)을 교체했다
-- **확인**: 콘텐츠·ui의 raw `&:focus-visible` 0건. admin box-shadow 패턴은 범위 밖
+- **부채**: `:focus-visible` outline 10곳과 `Pagination.module.scss`의 `:focus` outline 1곳이 색·폭·offset을 직접 선언해 SSOT가 없었다
+- **해소**: `focus-ring($variant, $offset)` mixin(`@content`로 추가 속성 수용)과 `$focus-ring-strong-color` 토큰을 도입해 11곳(Notice 8·ListItem·SermonNoteEditor·Pagination)을 교체했다
+- **확인**: `rg -n ":focus|outline" src/components/ui/Pagination/Pagination.module.scss` → transition 선언 1건, focus outline 선언 0건. admin box-shadow 패턴은 범위 밖
 
 ### ✅ useDrawerHistory 라우트 이동 시 가짜 history 항목 (2026-06-02 해소, PR #108)
 
@@ -24,9 +24,9 @@
 
 ### ✅ services/about Supabase silent fallback 로깅 부재 (2026-06-02 해소, PR #108)
 
-- **부채**: `getSiteCollection`·`getSiteSettings`·`getActiveStaff`가 DB error를 삼키고 빈 값으로 fallback해 운영에서 검출이 안 됐다
-- **해소**: 세 조회 지점에서 error를 백틱 `console.error`로 1줄 기록했다. 빈 값 fallback은 유지(ADR 0006 silent fallback)
-- **확인**: Vercel 함수 로그에 `[domain] ... 조회 실패`가 출력된다
+- **부채**: `getSiteCollection`·`getSiteSettings`·`getActiveStaff`·`getWorshipGroupsSafe`가 DB error를 삼키고 빈 값으로 fallback해 운영에서 검출이 안 됐다
+- **해소**: 네 조회 흐름에서 error를 백틱 `console.error`로 1줄 기록했다. 빈 값 fallback은 유지(ADR 0006 silent fallback)
+- **확인**: Vercel 함수 로그에 `[domain] ... 조회 실패` 또는 `[about] getWorshipScheduleGroups 조회 실패`가 출력된다
 
 ### ✅ about/serving-people 구분선 #eee (2026-06-02 해소, PR #108)
 
@@ -43,8 +43,8 @@
 ### ✅ `$beige-300` semantic 매핑 부재 (2026-06-02 해소, PR #108)
 
 - **부채**: QuickAccess 배경과 SermonVideoPlayer 그라데이션이 primitive `$beige-300`을 직접 썼다
-- **해소**: `$bg-secondary-deep`($beige-300) 시맨틱 토큰을 신설해 두 곳을 치환했다. 플랜의 2토큰 제안은 같은 값·같은 의미라 1개로 통합했다
-- **확인**: `rg "\$beige-300" src/app src/components` → 0 hit. 값이 같아 시각 변화 0
+- **해소**: `$bg-secondary-deep`($beige-300) 시맨틱 토큰을 신설해 두 곳을 치환하고 `.claude/skills/styles/SKILL.md`의 매핑 표에도 추가했다. 플랜의 2토큰 제안은 같은 값·같은 의미라 1개로 통합했다
+- **확인**: `rg "\$beige-300" src/app src/components` → 0 hit. `rg "\$beige-300은 미정" .claude/skills/styles/SKILL.md` → 0 hit. 값이 같아 시각 변화 0
 
 ### ✅ Cloudinary 업로드 화질 q_85 고정 (2026-06-02 해소, PR #108)
 

--- a/docs/tech-debt/resolved.md
+++ b/docs/tech-debt/resolved.md
@@ -4,6 +4,60 @@
 
 ---
 
+### ✅ `supabase` named export deprecated 제거 (2026-06-02 해소, PR #108)
+
+- **부채**: `client.ts`의 deprecated `supabase` named export가 모듈 로드 시 클라이언트를 즉시 만들어 lazy 싱글톤과 인스턴스가 둘로 갈렸다
+- **해소**: export를 제거하고 `auth.ts` 6함수·SessionContextProvider를 `getSupabaseBrowserClient()` 호출로 교체했다. CLAUDE.md gotcha도 갱신했다
+- **확인**: `rg "import \{ supabase \}" src` → 0 hit
+
+### ✅ focus-ring 패턴 통일 (2026-06-02 해소, PR #108)
+
+- **부채**: `:focus-visible` outline이 10곳에 색·폭·offset 제각각으로 박혀 SSOT가 없었다
+- **해소**: `focus-ring($variant, $offset)` mixin(`@content`로 추가 속성 수용)과 `$focus-ring-strong-color` 토큰을 도입해 10곳(Notice 8·ListItem·SermonNoteEditor)을 교체했다
+- **확인**: 콘텐츠·ui의 raw `&:focus-visible` 0건. admin box-shadow 패턴은 범위 밖
+
+### ✅ useDrawerHistory 라우트 이동 시 가짜 history 항목 (2026-06-02 해소, PR #108)
+
+- **부채**: 드로어를 열고 메뉴로 이동하면 push한 sentinel 항목이 스택에 남아 뒤로가기를 두 번 눌러야 했다
+- **해소**: `MobileNavigation` Link 5개에 `replace`를 붙였다. 드로어가 열린 상태에선 현재 항목이 sentinel이라 그 항목을 목적지로 교체한다. 플랜의 effect cleanup은 라우트 이동 후 발동 불가로 폐기했다(D11)
+- **확인**: Chrome 실측 — 이동 후 뒤로가기 1회로 이전 페이지, history.length 불변
+
+### ✅ services/about Supabase silent fallback 로깅 부재 (2026-06-02 해소, PR #108)
+
+- **부채**: `getSiteCollection`·`getSiteSettings`·`getActiveStaff`가 DB error를 삼키고 빈 값으로 fallback해 운영에서 검출이 안 됐다
+- **해소**: 세 조회 지점에서 error를 백틱 `console.error`로 1줄 기록했다. 빈 값 fallback은 유지(ADR 0006 silent fallback)
+- **확인**: Vercel 함수 로그에 `[domain] ... 조회 실패`가 출력된다
+
+### ✅ about/serving-people 구분선 #eee (2026-06-02 해소, PR #108)
+
+- **부채**: `serving-people/page.module.scss`의 `.divide`가 `border: 1px solid #eee`로 hex를 하드코딩했다
+- **해소**: `$border-subtle`(얕은 구분선 토큰)로 교체했다
+- **확인**: about 영역 `.module.scss` hex 0건
+
+### ✅ typography 리터럴 0.8/0.9rem (2026-06-02 해소, PR #108)
+
+- **부채**: font-size 0.9rem 3곳과 0.8rem 7곳이 토큰 없이 박혀 있었다
+- **해소**: 0.9rem을 `$font-size-11`(접근성 상향)로, 0.8rem을 `$spacing-8`(반응형: 모바일 0.6rem, 데스크톱 0.8rem)로 바꿨다
+- **확인**: 해당 10곳의 0.8/0.9rem 리터럴 0건. Chrome 실측에서 배지 글자 1.1rem 적용
+
+### ✅ `$beige-300` semantic 매핑 부재 (2026-06-02 해소, PR #108)
+
+- **부채**: QuickAccess 배경과 SermonVideoPlayer 그라데이션이 primitive `$beige-300`을 직접 썼다
+- **해소**: `$bg-secondary-deep`($beige-300) 시맨틱 토큰을 신설해 두 곳을 치환했다. 플랜의 2토큰 제안은 같은 값·같은 의미라 1개로 통합했다
+- **확인**: `rg "\$beige-300" src/app src/components` → 0 hit. 값이 같아 시각 변화 0
+
+### ✅ Cloudinary 업로드 화질 q_85 고정 (2026-06-02 해소, PR #108)
+
+- **부채**: 업로드 로더가 `q_${quality || 85}`로 기본 화질을 85%로 고정했다
+- **해소**: `q_${quality || 'auto:good'}`로 바꿨다(Next가 quality 인자를 주면 그 값 우선, 기본은 auto:good). 외부 fetch 경로는 이미 q_auto
+- **확인**: `src/utils/cloudinary.ts:90` 로더가 q_auto:good
+
+### ✅ Cloudinary use-case preset 부재 (OG·카카오) (2026-06-02 해소, PR #108)
+
+- **부채**: OG·카카오 공유 이미지가 원본을 그대로 써서 크기·품질 통제가 없었다. 설교 OG는 외부 YouTube URL이라 변환도 안 걸렸다
+- **해소**: `getOgImageUrl`(1200x630)·`getKakaoShareUrl`(800x400)을 도입했다. public_id는 image/upload, 외부 URL은 image/fetch로 같은 변환을 건다(D12). sermons·series·bulletins OG와 공유에 연결했다
+- **확인**: `/sermons/3` og:image가 fetch 변환 URL로 HTTP 200 image/jpeg. `getThumbnailUrl`은 소비처가 없어 보류
+
 ### ✅ bulletin 업로드 부분 실패 시 orphan 이미지 잔존 (2026-05-31 해소, PR #105)
 
 - **부채**: `uploadBulletinImages`가 `Promise.all`로 5장을 병렬 업로드한다. 1장이라도 실패하면 throw로 끝나는데, 이미 올라간 이미지는 Cloudinary에 주인 없이(orphan) 남았다

--- a/src/components/ui/Pagination/Pagination.module.scss
+++ b/src/components/ui/Pagination/Pagination.module.scss
@@ -35,10 +35,7 @@
     background-color: $bg-hover;
   }
 
-  &:focus {
-    outline: 0.2rem solid $border-primary;
-    outline-offset: 0.2rem;
-  }
+  @include focus-ring();
 }
 
 .page_link.current {

--- a/src/services/about/index.ts
+++ b/src/services/about/index.ts
@@ -49,7 +49,8 @@ const getWorshipGroupsSafe = async (): Promise<{
 }> => {
   try {
     return await getWorshipScheduleGroups();
-  } catch {
+  } catch (error) {
+    console.error('[about] getWorshipScheduleGroups 조회 실패', error);
     return { sunday: [], weekday: [], school: [] };
   }
 };


### PR DESCRIPTION
## 📋 개요

PR #108(tech-debt-pre-release Phase 2~6) 머지에 따른 마무리(Phase 8). 완료된 exec-plan을 이관하고 해소된 부채를 정리한다. 문서만 변경한다.

## 🔗 컨텍스트

- **Exec Plan**: `docs/exec-plans/completed/2026-05-22-tech-debt-pre-release.md` (active → completed 이관)
- **원 구현 PR**: #108 (G2·G7·G3·G5·G4), #105 (G1)
- **관련 문서**: `docs/tech-debt/active.md`, `docs/tech-debt/resolved.md`, `docs/tech-debt-tracker.md`

## 🔧 주요 변경점

- exec-plan tech-debt-pre-release를 completed로 이관(회고 포함)
- active.md에서 해소된 부채 9건을 resolved.md로 이동: supabase named export·focus-ring 통일·드로어 history 미정리·about silent fallback 로깅·about #eee·typography 0.8/0.9rem·$beige-300·Cloudinary q_85·Cloudinary OG·카카오 preset
- Hover Border 항목을 home 5건 기해소(2026-05-07) 반영해 admin 5건으로 축소
- tracker 개수 갱신: active 34 → 25, resolved 11 → 20. 점검일 2026-06-02

## 👀 확인 포인트

- 코드 변경 0, 동작 영향 없음 (문서만).
- G6(`app/→apis` 직접 호출 3건)은 사용자 결정으로 분리 — active.md "app/→apis 직접 호출" 부채가 계속 추적한다.

## ✅ 검증

- 문서만 변경이라 빌드·런타임 영향 없음. resolved.md 이동 항목의 실제 해소는 PR #108에서 verify-task·Gemini·Codex 리뷰로 확인됨.
