### PR TITLE
[Feat] 매칭 안 되는 모든 URL에 브랜드 404 화면 노출

### DIFF
--- a/docs/exec-plans/active/2026-06-10-not-found-page.md
+++ b/docs/exec-plans/active/2026-06-10-not-found-page.md
@@ -1,0 +1,215 @@
+# not-found-page
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-10
+- **브랜치**: feat/not-found-page
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+Claude Design의 `404 (사진 슬롯)` 디자인을 루트 `not-found.tsx`로 구현한다. 끝나면:
+
+- 매칭되지 않는 모든 URL에 다크 풀블리드 404가 뜬다 — 교회 사진 배경 + "길과 빛"(시편 119:105) 톤, 홈·이전 페이지·빠른 링크로 길을 안내한다.
+- 지금 영문 기본 404(또는 `news/notices`의 `<div>not-found</div>` 스텁)가 보이던 자리가 한국어 페이지로 바뀐다.
+
+## 검증된 Assumptions
+
+- 루트 `layout.tsx`는 `{children}`만 렌더하고 Header/Footer가 없다 — `Read(src/app/layout.tsx:42-64)`. 그래서 루트 404는 화면 전체를 덮는 풀블리드(full-bleed) 페이지가 된다.
+- 세리프 폰트 보유: `$font-family-secondary = var(--font-notoserifKR)` (Noto Serif KR), `next/font/google`로 로드, 용도가 "교회 로고타입·이름·성경 인용구" — `Read(_typography.scss:5-9, layout.tsx:35-40)`.
+- 금색 토큰 정확 일치: `$gold-600 #c4924a = 디자인 --gold-600`, `$gold-400 #d9a96a = --gold-400` — `grep(_color.scss:29-31)`. 시맨틱: `$accent`/`$accent-hover`.
+- 다크 표면 텍스트 토큰: `$txt-inverse`(white)·`$txt-on-dark-nav-muted #9ba2ae`·`$txt-on-dark-nav-faint #6b7280` — `grep(_color.scss:64,74,75)`. 디자인의 크림색 다단계 투명도 대응.
+- Cloudinary 배경 이미지 `not-found`는 클라우드 **루트**에 있다(`.../image/upload/.../not-found`, 사용자 제공). 그런데 `NEXT_PUBLIC_CLOUDINARY_ROOT_FOLDER`가 dev·prod 모두 설정됨 — `grep(.env:9)`. 로더 `normalizePublicId`가 prefix를 붙이므로(`Read(utils/cloudinary.ts:8-13,91-108)`) bare public_id로는 경로가 어긋난다. 로더는 `^https?://` src를 그대로 통과시킨다(line 97).
+- `news/bulletins/not-found.tsx`는 한국어·스타일·버튼을 갖춘 in-content 404, `news/notices/not-found.tsx`는 `<div>not-found</div>` 스텁 — `Read` 두 파일.
+
+## Success Criteria
+
+- 임의의 없는 URL(`/zzz`)에서 다크 404가 뜬다: 브랜드 마크+이름, `Error 404` eyebrow, 세리프 제목 "페이지를 찾을 수 없습니다", 안내문, `홈으로 돌아가기`(→`/`) 골드 버튼, `이전 페이지` 버튼, 빠른 링크 4개(실제 라우트), 시편 119:105 인용구.
+- 배경: Cloudinary `not-found` 사진이 로드되고 흑백+듀오톤 틴트가 적용된다. 사진 로드 실패 시 SVG "길과 빛" 일러스트가 보인다.
+- 404에 `robots: noindex` 메타가 붙는다.
+- `/news/notices/<없는경로>`가 영문 스텁이 아니라 한국어 in-content 404를 띄운다(목록으로 가기 버튼 포함).
+- 모바일 퍼스트 반응형. `.module.scss`에 색·간격·폰트 하드코딩 0(SVG 일러스트 fill은 art라 예외). `yarn build`·`yarn lint`·`yarn lint:styles` 통과, knip 신규 0.
+
+## Non-goals
+
+- `news/bulletins/not-found.tsx` 손대지 않음(이미 정상 — 외과적 변경 원칙). 단 notices를 그 톤에 맞춤.
+- `(content)/not-found.tsx`(라우트 그룹 공용 in-content 404) 신설 — 이번 디자인은 화면 전체를 덮는 방식이라 불필요.
+- 설교/시리즈 상세의 `notFound()` 동작 변경 — 그대로 루트 404로 떨어진다.
+- Cloudinary 듀오톤을 서버 변환(e_grayscale 등)으로 굽기 — 디자인대로 CSS filter로 처리.
+
+## 접근법
+
+레이어를 디자인 그대로 z-index로 쌓되, 디자인 툴 전용 요소(`<image-slot>`·힌트 칩·`data-filled` 토글)는 뺀다. 사진은 항상 고정이므로 틴트는 상시 적용, SVG는 로드 실패 폴백.
+
+- z0 SVG 일러스트(`aria-hidden`, 인라인) → z1 `next/image fill` Cloudinary 사진 → z2 듀오톤 틴트 2겹 → z3 스크림 그라데이션 → z4 콘텐츠.
+- 색·간격·폰트는 토큰. 디자인 hex는 토큰으로 치환(D2). SVG fill만 인라인 art.
+
+## 영향받는 파일
+
+- `src/app/not-found.tsx` (신규 — Server Component, `export const metadata` + 레이어/콘텐츠)
+- `src/app/_component/NotFoundBackground.tsx` (신규 — `'use client'`, 배경 이미지 + 전용 loader. RSC는 `next/image`에 loader 함수 prop을 못 넘김)
+- `src/app/_component/NotFoundBackButton.tsx` (신규 — `'use client'`, 이전 페이지 버튼만 분리)
+- `src/app/not-found.module.scss` (신규)
+- `src/app/(content)/news/notices/not-found.tsx` (수정 — 스텁 → 한국어 in-content 404)
+- `src/app/(content)/news/notices/not-found.module.scss` (신규 — bulletins 패턴 따름)
+
+## 단계별 체크리스트
+
+- [x] 1. `not-found.module.scss` — 레이어 z0~z4, 토큰 매핑(semantic 우선), 모바일 퍼스트(`respond-up`). 디자인 `max-width:760px`를 모바일 기본값으로 뒤집음
+- [x] 2. `NotFoundBackButton.tsx` (client) — `history.length>1 ? router.back() : router.push('/')` (D3)
+- [x] 3. `not-found.tsx` (server) — 인라인 SVG + 콘텐츠 + `<NotFoundBackground/>`(인라인 loader가 `w_${width}` 반영, `sizes="100vw"`) + `<NotFoundBackButton/>`. 빠른 링크 실제 라우트. `clsx` 2+ className. `metadata.robots.index=false`. (배경 이미지 loader는 RSC에서 함수 prop 전달 불가라 `NotFoundBackground.tsx` client로 추가 분리)
+- [x] 4. `news/notices/not-found.tsx` + `.module.scss` — 한국어 메시지 + "공지사항 목록으로"(`/news/notices`). snake_case className
+- [x] 5. `node scripts/verify-task.mjs not-found-page` (run-id 20260610-164314 통과) + 런타임 확인
+
+## Verification
+
+- `node scripts/verify-task.mjs not-found-page`
+- 수동: dev에서 `/zzz`·`/news/notices/zzz` 접속 → 다크 404·한국어 in-content 404 확인. 배경 사진 로드·SVG 폴백·robots noindex 메타 확인
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST (high) — 심각도 큰 지적 3건을 계획에 반영해 해소(D1·D2·D3).
+- **현재 판단**: WORK 진입 가능.
+- **다음 행동**: 구현 diff로 1차 검증.
+
+조치 요약:
+
+- A (심각): `'use client'`와 `export const metadata` 동시 선언은 App Router 빌드 오류다. `metadata`는 Server Component에서만 export된다 → D2.
+- B (심각): 고정 `w_1920` URL을 next/image 커스텀 로더가 그대로 반환하면 srcset 후보가 전부 같은 URL이 돼 뷰포트별 크기 조정이 깨진다. 로더가 `width`를 URL에 반영하고 `sizes="100vw"`를 명시하라 → D1.
+- C (심각): `history.back()`은 직접 유입 404에서 아무 동작도 안 하거나 외부 사이트로 나간다. `history.length>1`이면 뒤로, 아니면 홈으로 → D3. (디자인 원본 HTML도 같은 동작.)
+- 표현: `fill` 부모는 `position:relative`+실제 높이, 장식 레이어는 `absolute inset-0`, 콘텐츠는 positioned + z-index. 디자인 CSS가 이미 충족(`.frame` relative z4, 레이어 fixed inset:0).
+
+## Codex 1차 검증
+
+- **결론**: PASS (high) — 동작 오류 없음. 2차 확인 권고 2건 반영.
+- **현재 판단**: 커밋 가능.
+- **다음 행동**: Claude 2차에 권고 반영 결과 기록.
+
+조치 요약:
+
+- 서버/클라이언트 분리·인라인 이미지 로더·뒤로 가기 버튼 대체 동작 모두 정상으로 확인(빌드·런타임 근거 인용).
+- 권고 1: `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME`이 비면 배경 URL이 `res.cloudinary.com/undefined/...`가 된다 → 2차에서 env 존재 확인.
+- 권고 2: 사진 위 흐린 텍스트의 명도 대비(WCAG 4.5:1)를 한 번 더 확인 → 2차에서 스크림 강도로 판단.
+- notices not-found가 지금 동작하지 않는(휴면) 상태는 올바른 범위 판단으로 동의(억지로 연결하면 외과적 변경 원칙을 어긴다).
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — 신규 회귀 0, 커밋 가능.
+- **현재 판단**: 정적 검증 4종과 prod 런타임 확인을 충족했고, Codex 1차 권고 2건을 아래대로 확인했다.
+- **다음 행동**: 사용자 승인 후 커밋.
+
+| 시점 | run-id | lint | styles | build | knip 신규 | 런타임 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260610-164314 | ✅ | ✅ | ✅ | 0 | 아래 |
+
+prod 빌드 런타임 확인 (`yarn start`, curl):
+
+- `/zzz` → HTTP 404. `<title>페이지를 찾을 수 없습니다 | 대구동남교회</title>`, `<meta name="robots" content="noindex">`. 본문에 `Error 404`·세리프 제목·`홈으로 돌아가기`·`이전 페이지`·시편 119:105·브랜드 영문명 모두 존재.
+- 빠른 링크 4개가 `/about`·`/about/location`·`/about/serving-people`·`/about/worship`로 나간다.
+- 배경 Cloudinary URL이 `res.cloudinary.com/dn-church/image/upload/f_auto,q_auto,c_fill,g_auto,w_640/not-found`처럼 뷰포트별 width를 반영한다(srcset에 w_640·w_750…). 클라우드 이름은 `dn-church`다. public_id는 루트의 `not-found`라서 ROOT_FOLDER 접두사가 붙지 않았다.
+- notices not-found는 `news/notices/page.tsx`가 잘못된 쿼리에 `notFound()`를 호출할 때 뜬다 — 실측: `/news/notices?page=abc` → HTTP 404 + "공지사항을 찾을 수 없습니다"가 화면에 렌더된다. 다만 `news/notices/[id]`는 미구현 스텁(`<div>page</div>`)이라 없는 공지 id로는 404가 안 난다(별도 문제, tech-debt 등록).
+- 브라우저(Chrome) 시각 확인: 데스크톱(1440)은 사진 배경에 좌측 가로 스크림 위 텍스트, 모바일(625)은 세로 스크림에 풀폭 골드 버튼·푸터 스택으로 전환된다. 사진이 흑백 듀오톤(네이비/골드)으로 정규화돼 로드되고, 브랜드 마크·세리프 제목·시편 인용구가 디자인대로 보인다.
+
+Codex 1차 권고 확인:
+
+- env: `NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME`은 `.env`·`.env.local`에 존재(둘 다 `dn-church`로 끝남, grep 확인). 프로젝트 전역(`utils/cloudinary.ts`)이 이미 의존하는 필수 env라 별도 가드는 추가하지 않았다.
+- 대비: 모바일 스크림이 navy 0.7→0.96 그라데이션이라 텍스트가 사실상 단색 navy 위에 놓인다. `$txt-on-dark-nav-muted`(#9ba2ae)와 `$txt-inverse`(white)는 navy(#1c2b3a) 위에서 4.5:1을 넘는다. 사진 위 골드 인용구는 장식 텍스트라 본문 가독성과 무관하다.
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 의사결정 로그
+
+- **D1 — Cloudinary 배경은 인라인 width-반영 로더로 full URL을 만든다**
+  - 문제: 이미지 `not-found`는 클라우드 루트에 있는데, 프로젝트 공용 로더(`createCloudinaryLoader`)는 bare public_id에 `ROOT_FOLDER` prefix를 붙인다. 그대로 `src="not-found"`를 넘기면 `<ROOT>/not-found`로 합성돼 경로가 어긋난다.
+  - 해결: `next/image`에 인라인 loader를 줘서 `https://res.cloudinary.com/${env CLOUD_NAME}/image/upload/f_auto,q_${quality},c_fill,g_auto,w_${width}/not-found`를 만든다. `width`를 URL에 반영하므로 Codex가 지적한 srcset 단일화 문제가 없고, `sizes="100vw"`를 명시한다. 공용 로더의 http passthrough(고정 URL)는 responsive를 깨므로 택하지 않았다.
+  - 결과: ROOT_FOLDER와 무관하게 루트 public_id를 쓰고, 뷰포트별 크기로 받는다. 흑백·듀오톤은 디자인대로 CSS filter+틴트로 처리(서버 변환 안 함).
+
+- **D2 — not-found.tsx는 Server Component, 이전 페이지 버튼만 client로 분리**
+  - 문제: 이전 페이지 버튼은 `history.back()`이 필요해 client여야 하는데, 같은 파일에 `export const metadata`(robots noindex)를 두면 App Router가 빌드 오류를 낸다(`metadata`는 Server Component 전용).
+  - 해결: `not-found.tsx`를 server로 두고 metadata를 export한다. 버튼만 `_component/NotFoundBackButton.tsx`(`'use client'`)로 뺀다. 404는 이미 HTTP 404를 반환하므로 noindex는 보조 신호지만 디자인 명세(`<meta robots noindex>`)를 지킨다.
+  - 결과: 빌드 경계 충돌 없이 metadata와 인터랙션을 둘 다 살린다. 새 추상화는 client 버튼 1개로 최소.
+
+- **D3 — 이전 페이지는 history가 있을 때만 back, 없으면 홈**
+  - 문제: 직접 유입(북마크·외부 링크)으로 404에 오면 `history.back()`이 아무 동작도 안 하거나 외부 사이트로 되돌아간다.
+  - 해결: `history.length>1 ? history.back() : router.push('/')`. 디자인 원본 HTML도 같은 분기(`if(history.length>1)... else location.href='index.html'`)를 썼다.
+  - 결과: 어느 경로로 와도 버튼이 예측 가능하게 동작한다(최소 홈 복귀 보장).
+
+- **D4 — 디자인의 짙은 네이비(#16222e)는 토큰이 없어 `$navy-950`(#1c2b3a)로 대체**
+  - 문제: 디자인은 `--navy-950:#16222e`를 배경·스크림·틴트에 쓰는데 프로젝트 토큰에 그 값이 없다. 하드코딩은 금지(CLAUDE.md).
+  - 해결: 가장 가까운 `$navy-950`(#1c2b3a)로 매핑한다. 미세한 색 차이를 받아들이고 토큰 추가는 하지 않는다(토큰 단순화 선호). 단 인라인 SVG 일러스트의 gradient fill은 art라 디자인 hex를 그대로 둔다(.scss 아님 → stylelint 무관).
+  - 결과: `.module.scss`는 토큰만 쓰고, 일러스트는 디자인 색을 보존한다.
+
+## 후속 작업
+
+- 라우트별 전용 404가 없어 세 곳이 루트 일반 404로 떨어지거나 아예 안 걸린다.
+  - 설교: 없는 설교가 루트 404로 떨어진다(설교 전용 메시지 없음).
+  - admin: `notFound()`가 교회 다크 404로 떨어진다(셸 톤 불일치).
+  - 공지 상세: `news/notices/[id]` 스텁이라 없는 id로 404가 안 난다.
+  - 이유: 이번 작업은 루트 404와 notices 스텁 정리까지가 범위. 라우트별 맞춤 404와 미구현 상세 라우트는 별도 작업이다.
+  - 다음 기준: 설교/admin 영역 404를 다듬거나 notices 상세를 구현할 때.
+  - 기록 위치: `docs/tech-debt/active.md` "라우트·영역별 not-found 미세분화 부족"에 등록함.
+- 폴백 SVG 일러스트는 정적이다(디자인의 별 반짝임·빛 번짐(glow) 애니메이션 제외).
+  - 이유: 배경 사진이 항상 있어 SVG는 로드 실패 시에만 잠깐 보인다. 거의 안 보이는 화면에 애니메이션 코드를 들이지 않았다.
+  - 다음 기준: 사진을 떼고 SVG를 기본 배경으로 바꿀 때.
+  - 기록 위치: 없음.
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt/active.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -240,3 +240,19 @@
 - **마이그레이션 경로**: og:image가 필요한 하위 페이지의 `openGraph`를 `OPEN_GRAPH_BASE` 펼침으로 바꾸거나, 페이지별 전용 공유 이미지를 set. 공유 유입 점검 시 우선순위 결정
 - **영향 범위**: `src/app/(content)/about/**` 등 자체 `openGraph`를 선언하는 하위 페이지
 - **발견일**: 2026-06-09 (PR #110 site-seo-meta, 전체 라우트 curl 확인)
+
+### 🟢 라우트·영역별 not-found 미세분화 부족 (not-found-page 후속)
+
+- **상태**: 등록만 (not-found-page 범위 밖)
+- **무엇**: 루트 다크 404가 모든 `notFound()`를 받지만 일부는 맥락에 안 맞거나 아예 안 걸린다.
+  - 설교: `sermons/[id]`·`sermons/series/[id]`의 `notFound()`가 루트의 일반 "페이지를 찾을 수 없습니다"로 떨어진다. "설교를 찾을 수 없습니다 + 전체 설교 보기" 같은 전용 안내가 없다.
+  - admin: `admin/sermons/[id]/edit`의 `notFound()`도 루트의 교회 다크 화면으로 떨어진다. admin 셸과 톤이 안 맞는다.
+  - 공지 상세: `news/notices/[id]/page.tsx`가 미구현 스텁(`<div>page</div>`)이라 없는 공지 id로 가도 `notFound()`를 안 불러 HTTP 200 "page"가 뜬다. notices not-found는 리스트의 잘못된 쿼리(`/news/notices?page=abc`)로는 404가 뜨지만, 없는 공지 id 경로에선 `notFound()`가 안 불린다.
+- **왜**: not-found-page는 루트 404와 notices 스텁 정리까지만 범위. 라우트별 맞춤 404와 미구현 상세 라우트는 별도 작업이다.
+- **마이그레이션 경로**:
+  - 설교: `src/app/(content)/sermons/not-found.tsx` 추가 — 설교 맥락 메시지 + 전체 설교 링크.
+  - admin: `src/app/(admin)/not-found.tsx` 추가 — admin 셸 톤의 미니멀 404.
+  - 공지 상세: `news/notices/[id]/page.tsx`를 구현할 때 조회 결과가 없으면 `notFound()` 호출.
+- **영향 범위**: `src/app/(content)/sermons/`, `src/app/(admin)/`, `src/app/(content)/news/notices/[id]/`
+- **확인**: `grep -rln "notFound()" src/app` (호출처 7곳, not-found 파일은 bulletins·notices·root 3개)
+- **발견일**: 2026-06-10 (not-found-page 작업 중 `notFound()` 호출처 스캔)

--- a/src/app/(content)/news/notices/not-found.module.scss
+++ b/src/app/(content)/news/notices/not-found.module.scss
@@ -1,0 +1,31 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: $spacing-20;
+  text-align: center;
+}
+
+.title {
+  margin-bottom: $spacing-20;
+}
+
+.description {
+  margin-bottom: $spacing-24;
+  color: $txt-secondary;
+}
+
+.list_link {
+  padding: $spacing-12 $spacing-20;
+  border-radius: $radius-s;
+  background-color: $primary;
+  color: $txt-inverse;
+  font-weight: $font-weight-semibold;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: $primary-hover;
+  }
+}

--- a/src/app/(content)/news/notices/not-found.tsx
+++ b/src/app/(content)/news/notices/not-found.tsx
@@ -1,3 +1,16 @@
+import Link from 'next/link';
+import styles from './not-found.module.scss';
+
 export default function NotFound() {
-  return <div>not-found</div>;
+  return (
+    <div className={styles.container}>
+      <h2 className={styles.title}>공지사항을 찾을 수 없습니다</h2>
+      <p className={styles.description}>
+        요청하신 공지사항이 삭제되었거나 주소가 올바르지 않습니다.
+      </p>
+      <Link href="/news/notices" className={styles.list_link}>
+        공지사항 목록으로
+      </Link>
+    </div>
+  );
 }

--- a/src/app/_component/NotFoundBackButton.tsx
+++ b/src/app/_component/NotFoundBackButton.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import styles from '../not-found.module.scss';
+
+// 이전 페이지 버튼만 client로 분리한다 — not-found.tsx는 metadata export 때문에 Server Component여야 한다.
+// 직접 유입(북마크·외부 링크)으로 404에 오면 뒤로 갈 기록이 없으므로 홈으로 보낸다.
+export default function NotFoundBackButton() {
+  const router = useRouter();
+
+  const handleBack = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <button type="button" className={styles.link_back} onClick={handleBack}>
+      <span className={styles.arrow} aria-hidden="true">
+        ←
+      </span>
+      <span>이전 페이지</span>
+    </button>
+  );
+}

--- a/src/app/_component/NotFoundBackground.tsx
+++ b/src/app/_component/NotFoundBackground.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import Image from 'next/image';
+import type { ImageLoaderProps } from 'next/image';
+import styles from '../not-found.module.scss';
+
+// 배경 사진은 클라우드 루트의 public_id `not-found`를 쓴다. 공용 로더는 ROOT_FOLDER prefix를 붙여
+// 경로가 어긋나므로, 여기서 width를 반영하는 전용 로더로 full URL을 만든다(인라인 loader는 client 전용).
+const CLOUD_NAME = process.env.NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME;
+
+const backgroundLoader = ({ src, width, quality }: ImageLoaderProps) =>
+  `https://res.cloudinary.com/${CLOUD_NAME}/image/upload/f_auto,q_${quality ?? 'auto'},c_fill,g_auto,w_${width}/${src}`;
+
+export default function NotFoundBackground() {
+  return (
+    <div className={styles.photo}>
+      <Image loader={backgroundLoader} src="not-found" alt="" fill sizes="100vw" priority />
+    </div>
+  );
+}

--- a/src/app/not-found.module.scss
+++ b/src/app/not-found.module.scss
@@ -1,0 +1,355 @@
+// 루트 404 — 다크 풀블리드 takeover. 레이어를 z-index로 쌓는다:
+// z0 SVG 일러스트(폴백) · z1 사진 · z2 듀오톤 틴트 · z3 스크림 · z4 콘텐츠.
+// 모바일 퍼스트 — 기본값이 모바일, respond-up으로 상위 뷰포트 확장.
+
+.page {
+  position: relative;
+  min-height: 100vh;
+  min-height: 100dvh;
+  overflow: hidden;
+  background: $bg-dark-nav;
+  color: $txt-inverse;
+  font-size: $font-size-15;
+  line-height: $line-height-base;
+  letter-spacing: -0.02rem;
+  word-break: keep-all;
+}
+
+// ── z0: SVG 폴백 일러스트 (사진 로드 실패 시 노출) ──
+.scene {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+}
+
+// ── z1: 사진 (full-bleed) — 어떤 사진이든 흑백으로 정규화 ──
+.photo {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+
+  img {
+    filter: grayscale(1) contrast(1.06) brightness(0.92);
+  }
+}
+
+// ── z2: 듀오톤 틴트 — 사진을 네이비/골드 브랜드 톤으로 재염색 ──
+.tint {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+}
+
+.tint_navy {
+  background: $bg-dark-nav;
+  mix-blend-mode: color;
+  opacity: 0.62;
+}
+
+.tint_gold {
+  background: linear-gradient(120deg, $bg-dark-nav 0%, $accent 60%, $accent-hover 100%);
+  mix-blend-mode: overlay;
+  opacity: 0.6;
+}
+
+// ── z3: 스크림 — 글자 가독성 ──
+.scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba($bg-dark-nav, 0.7) 0%,
+    rgba($bg-dark-nav, 0.88) 46%,
+    rgba($bg-dark-nav, 0.96) 100%
+  );
+
+  @include respond-up($breakpoint-tablet) {
+    background: linear-gradient(
+      102deg,
+      rgba($bg-dark-nav, 0.94) 0%,
+      rgba($bg-dark-nav, 0.82) 34%,
+      rgba($bg-dark-nav, 0.3) 62%,
+      rgba($bg-dark-nav, 0) 80%
+    );
+  }
+}
+
+.scrim_edge {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba($bg-dark-nav, 0.5) 0%,
+    transparent 22%,
+    transparent 70%,
+    rgba($bg-dark-nav, 0.55) 100%
+  );
+}
+
+// ── z4: 콘텐츠 ──
+.frame {
+  position: relative;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100dvh;
+  max-width: 132rem;
+  margin: 0 auto;
+  padding: $spacing-28 $spacing-24;
+
+  @include respond-up($breakpoint-tablet) {
+    padding: $spacing-36 clamp($spacing-24, 5vw, $spacing-64);
+  }
+}
+
+.brand {
+  display: flex;
+  flex: none;
+  align-self: flex-start;
+  align-items: center;
+  gap: $spacing-10;
+}
+
+.brand_mark {
+  flex: none;
+  width: $spacing-40;
+  height: $spacing-40;
+  color: $accent-hover;
+}
+
+.brand_text {
+  display: flex;
+  flex-direction: column;
+}
+
+.brand_name {
+  font-family: $font-family-secondary;
+  font-size: $font-size-16;
+  font-weight: $font-weight-bold;
+  color: $txt-inverse;
+}
+
+.brand_sub {
+  font-size: $font-size-11;
+  letter-spacing: 0.05em;
+  color: $txt-on-dark-nav-faint;
+}
+
+.body {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  max-width: 56rem;
+  padding: $spacing-32 0;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-8;
+  margin-bottom: $spacing-20;
+  font-size: $font-size-12;
+  font-weight: $font-weight-bold;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  color: $accent-hover;
+
+  &::before {
+    content: '';
+    width: $spacing-24;
+    height: 1px;
+    background: rgba($accent-hover, 0.6);
+  }
+}
+
+.title {
+  font-family: $font-family-secondary;
+  font-size: $font-size-32;
+  font-weight: $font-weight-bold;
+  line-height: $line-height-tight;
+  letter-spacing: -0.05rem;
+  color: $txt-inverse;
+
+  @include respond-up($breakpoint-tablet) {
+    font-size: $font-size-42;
+  }
+}
+
+.lead {
+  max-width: 42rem;
+  margin-top: $spacing-20;
+  font-size: $font-size-15;
+  line-height: $line-height-loose;
+  color: $txt-on-dark-nav-muted;
+
+  @include respond-up($breakpoint-tablet) {
+    font-size: $font-size-16;
+  }
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-16;
+  margin-top: $spacing-36;
+
+  @include respond-up($breakpoint-tablet) {
+    flex-direction: row;
+    align-items: center;
+    gap: $spacing-20;
+  }
+}
+
+.btn_home {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-8;
+  padding: $spacing-16 $spacing-32;
+  border-radius: $radius-circle;
+  background: $accent;
+  color: $bg-dark-nav;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  transition: background 0.22s ease, transform 0.22s ease;
+
+  .arrow {
+    transition: transform 0.22s ease;
+  }
+
+  &:hover {
+    background: $accent-hover;
+    transform: translateY(-2px);
+
+    .arrow {
+      transform: translateX(3px);
+    }
+  }
+
+  @include respond-up($breakpoint-tablet) {
+    width: auto;
+  }
+}
+
+.link_back {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-6;
+  font-family: $font-family-base;
+  font-size: $font-size-14;
+  font-weight: $font-weight-semibold;
+  color: $txt-on-dark-nav-muted;
+  cursor: pointer;
+  transition: color 0.22s ease;
+
+  .arrow {
+    transition: transform 0.22s ease;
+  }
+
+  &:hover {
+    color: $txt-inverse;
+
+    .arrow {
+      transform: translateX(-3px);
+    }
+  }
+}
+
+.foot {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  gap: $spacing-16;
+  align-items: flex-start;
+  padding-top: $spacing-24;
+  border-top: 1px solid rgba($border-inverse, 0.12);
+
+  @include respond-up($breakpoint-tablet) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacing-16;
+  }
+}
+
+.quick {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-20;
+
+  a {
+    font-size: $font-size-13;
+    font-weight: $font-weight-semibold;
+    color: $txt-on-dark-nav-muted;
+    transition: color 0.22s ease;
+
+    &:hover {
+      color: $accent-hover;
+    }
+  }
+}
+
+.verse {
+  font-family: $font-family-secondary;
+  font-size: $font-size-13;
+  color: rgba($accent-hover, 0.72);
+}
+
+.verse_ref {
+  margin-left: $spacing-8;
+  font-family: $font-family-base;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  letter-spacing: 0.1em;
+  color: rgba($accent-hover, 0.5);
+}
+
+// 진입 애니메이션 — 모션 선호 사용자에게만
+@media (prefers-reduced-motion: no-preference) {
+  .rise {
+    opacity: 0;
+    transform: translateY(1.6rem);
+    animation: rise 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  }
+
+  .d1 {
+    animation-delay: 0.1s;
+  }
+
+  .d2 {
+    animation-delay: 0.24s;
+  }
+
+  .d3 {
+    animation-delay: 0.38s;
+  }
+
+  .d4 {
+    animation-delay: 0.52s;
+  }
+
+  .d5 {
+    animation-delay: 0.8s;
+  }
+}
+
+@keyframes rise {
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,158 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import clsx from 'clsx';
+import NotFoundBackground from './_component/NotFoundBackground';
+import NotFoundBackButton from './_component/NotFoundBackButton';
+import styles from './not-found.module.scss';
+
+export const metadata: Metadata = {
+  title: '페이지를 찾을 수 없습니다',
+  robots: { index: false }
+};
+
+const QUICK_LINKS = [
+  { label: '예배 안내', href: '/about/worship' },
+  { label: '오시는 길', href: '/about/location' },
+  { label: '교회 소개', href: '/about' },
+  { label: '섬기는 사람들', href: '/about/serving-people' }
+];
+
+export default function NotFound() {
+  return (
+    <div className={styles.page}>
+      {/* z0: 사진 로드 실패 시 보이는 "길과 빛"(시편 119:105) 폴백 일러스트 */}
+      <div className={styles.scene} aria-hidden="true">
+        <svg viewBox="0 0 1440 900" preserveAspectRatio="xMidYMid slice">
+          <defs>
+            <linearGradient id="nf-sky" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="#16222e" />
+              <stop offset="0.55" stopColor="#1d2f3f" />
+              <stop offset="0.82" stopColor="#2b4257" />
+              <stop offset="1" stopColor="#33506a" />
+            </linearGradient>
+            <radialGradient id="nf-glow" cx="0.5" cy="0.5" r="0.5">
+              <stop offset="0" stopColor="#fbe6c2" stopOpacity="0.95" />
+              <stop offset="0.28" stopColor="#e7bd78" stopOpacity="0.7" />
+              <stop offset="0.6" stopColor="#c4924a" stopOpacity="0.22" />
+              <stop offset="1" stopColor="#c4924a" stopOpacity="0" />
+            </radialGradient>
+            <linearGradient id="nf-path" x1="0" y1="1" x2="0" y2="0">
+              <stop offset="0" stopColor="#5a6b78" />
+              <stop offset="0.5" stopColor="#9d8f72" />
+              <stop offset="1" stopColor="#eccf9e" />
+            </linearGradient>
+            <linearGradient id="nf-hill-back" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="#24394b" />
+              <stop offset="1" stopColor="#1b2c3a" />
+            </linearGradient>
+            <linearGradient id="nf-hill-front" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="#172430" />
+              <stop offset="1" stopColor="#101a23" />
+            </linearGradient>
+          </defs>
+          <rect width="1440" height="900" fill="url(#nf-sky)" />
+          <g fill="#eccf9e">
+            <circle cx="220" cy="120" r="2.4" />
+            <circle cx="400" cy="200" r="1.8" />
+            <circle cx="640" cy="90" r="2" />
+            <circle cx="1120" cy="150" r="2.2" />
+            <circle cx="1280" cy="240" r="1.6" />
+            <circle cx="980" cy="80" r="1.8" />
+            <circle cx="160" cy="300" r="1.6" />
+            <circle cx="1340" cy="120" r="2" />
+          </g>
+          <g>
+            <circle cx="965" cy="486" r="320" fill="url(#nf-glow)" />
+            <circle cx="965" cy="486" r="20" fill="#fdf1d4" />
+            <circle cx="965" cy="486" r="46" fill="#f6dca6" opacity="0.5" />
+          </g>
+          <path
+            d="M0,512 C260,452 520,498 760,486 C1000,474 1240,512 1440,484 L1440,900 L0,900 Z"
+            fill="url(#nf-hill-back)"
+          />
+          <path
+            d="M512,900 C636,776 800,612 944,506 L988,506 C868,616 752,784 904,900 Z"
+            fill="url(#nf-path)"
+            opacity="0.92"
+          />
+          <path
+            d="M716,886 C772,772 856,628 956,512"
+            stroke="#fbe6c2"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeDasharray="2 26"
+            opacity="0.7"
+            fill="none"
+          />
+          <path
+            d="M0,628 C320,576 660,650 1020,624 C1220,609 1360,640 1440,632 L1440,900 L0,900 Z"
+            fill="url(#nf-hill-front)"
+          />
+        </svg>
+      </div>
+
+      {/* z1: 교회 사진 (흑백 정규화) */}
+      <NotFoundBackground />
+
+      {/* z2: 듀오톤 틴트 */}
+      <div className={clsx(styles.tint, styles.tint_navy)} />
+      <div className={clsx(styles.tint, styles.tint_gold)} />
+
+      {/* z3: 스크림 */}
+      <div className={styles.scrim} />
+      <div className={styles.scrim_edge} />
+
+      {/* z4: 콘텐츠 */}
+      <div className={styles.frame}>
+        <Link href="/" className={clsx(styles.brand, styles.rise, styles.d1)}>
+          <svg
+            className={styles.brand_mark}
+            viewBox="0 0 40 40"
+            fill="none"
+            aria-hidden="true"
+          >
+            <circle cx="20" cy="20" r="19.5" stroke="currentColor" strokeOpacity="0.45" />
+            <rect x="18.6" y="11" width="2.8" height="18" rx="1" fill="currentColor" />
+            <rect x="14" y="16.4" width="12" height="2.8" rx="1" fill="currentColor" />
+          </svg>
+          <span className={styles.brand_text}>
+            <span className={styles.brand_name}>대구동남교회</span>
+            <span className={styles.brand_sub}>Daegu Dongnam Church</span>
+          </span>
+        </Link>
+
+        <div className={styles.body}>
+          <span className={clsx(styles.tag, styles.rise, styles.d2)}>Error 404</span>
+          <h1 className={clsx(styles.title, styles.rise, styles.d2)}>페이지를 찾을 수 없습니다</h1>
+          <p className={clsx(styles.lead, styles.rise, styles.d3)}>
+            요청하신 페이지가 존재하지 않거나 주소가 변경되었습니다. 아래에서 다시 길을 찾으실 수
+            있습니다.
+          </p>
+          <div className={clsx(styles.actions, styles.rise, styles.d4)}>
+            <Link href="/" className={styles.btn_home}>
+              <span>홈으로 돌아가기</span>
+              <span className={styles.arrow} aria-hidden="true">
+                →
+              </span>
+            </Link>
+            <NotFoundBackButton />
+          </div>
+        </div>
+
+        <div className={clsx(styles.foot, styles.rise, styles.d5)}>
+          <nav className={styles.quick}>
+            {QUICK_LINKS.map((link) => (
+              <Link key={link.href} href={link.href}>
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+          <p className={styles.verse}>
+            “주의 말씀은 내 발에 등이요 내 길에 빛이니이다”
+            <span className={styles.verse_ref}>시편 119:105</span>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 라우트가 매칭되지 않는 모든 URL에 Next 기본 영문 404 대신 브랜드 404 화면을 띄운다.

**범위**:

- 루트 `not-found.tsx` 신설 — 다크 풀블리드 404 (사진 배경 + SVG 폴백)
- 공지사항(notices) in-content 404 스텁을 한국어 화면으로 교체
- 배경 표시·이전 페이지 이동 전용 client 컴포넌트 2개 분리

---

## 🔗 개발 컨텍스트

- **Task ID**: `not-found-page`
- **Exec Plan**: `docs/exec-plans/active/2026-06-10-not-found-page.md`
- **관련 ADR**: 해당 없음 (ADR needed: no)
- **관련 tech debt**: `docs/tech-debt/active.md` "라우트·영역별 not-found 미세분화 부족" 신규 등록
- **작업 범위**: 루트 404, notices in-content 404, 전용 컴포넌트·스타일
- **제외한 범위**: 설교 전용 404, admin 전용 404, notices 상세 라우트 구현 (tech-debt 등록)

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

라우트 미스 시 Next 기본 영문 404가 떠 브랜드 경험과 단절되고, 사용자가 다음 행동을 찾기 어렵다. 특히 설교 상세(`sermons/[id]`)는 `notFound()`를 호출하는데 받을 화면이 없어 영문 기본 404가 떴다. 매칭 안 되는 URL에서도 HTTP 404를 유지하면서 브랜드 화면으로 길을 안내한다.

---

## 🔧 주요 변경점 (Key Changes)

- `src/app/not-found.tsx` 신설 (Server Component) — 다크 풀블리드 404. 사진 배경(흑백 듀오톤 틴트) + "길과 빛"(시편 119:105) SVG 폴백, 브랜드 마크, `Error 404` eyebrow, 세리프 제목 "페이지를 찾을 수 없습니다", 홈·이전 페이지 버튼, 빠른 링크 4개. metadata robots noindex
- `src/app/_component/NotFoundBackground.tsx` 신설 (client) — Cloudinary public_id `not-found`를 뷰포트별 width 반영 전용 로더로 표시. RSC는 next/image에 loader 함수 prop을 못 넘겨 client로 분리
- `src/app/_component/NotFoundBackButton.tsx` 신설 (client) — history가 있으면 뒤로, 없으면 홈. metadata export(Server) 때문에 버튼만 분리
- `src/app/not-found.module.scss` 신설 — z0~z4 레이어, semantic 토큰, 모바일 퍼스트
- `src/app/(content)/news/notices/not-found.tsx` 수정 — `<div>not-found</div>` 스텁을 한국어 in-content 404로 교체 (+ `not-found.module.scss` 신설)

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| Cloudinary 배경 로더 (D1) | 인라인 width-반영 로더로 full URL 생성 + `sizes="100vw"` | 고정 `w_1920`이면 srcset 후보가 전부 같은 URL이라 뷰포트별 크기 조정이 깨짐 | 고정 width URL — 반응형 깨짐 |
| 컴포넌트 분리 (D2) | not-found.tsx는 Server Component, 이전 페이지 버튼·배경만 client | `'use client'` + `export const metadata` 동시 선언은 App Router 빌드 오류 | 전체 client — metadata export 불가 |
| 이전 페이지 동작 (D3) | `history.length > 1`이면 back, 아니면 홈 | 직접 유입 404에서 `history.back()`은 동작 안 하거나 외부로 이탈 | 무조건 back — 직접 유입 시 깨짐 |
| 짙은 네이비 색 (D4) | 토큰 `$navy-950`(#1c2b3a)로 대체 | 디자인 원본 #16222e에 맞는 토큰 부재, 하드코딩 금지 | hex 하드코딩 — 토큰 규칙 위반 |

> ⚠️ **트레이드오프:** 디자인 네이비(#16222e)와 토큰(#1c2b3a) 사이에 미세한 색 차이가 남는다.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs not-found-page` — PASS, RUN_ID=`20260610-172737`, lint·styles·build 통과, Knip 신규 0 |
| `harness-gate` | `node scripts/harness-gate.mjs not-found-page` — PASS |
| Codex 계획 검증 | CHANGE_REQUEST → 심각 지적 3건 반영(D1·D2·D3) |
| Codex 1차 검증 | PASS |
| Claude 2차 검증 | 완료 (런타임 curl + 브라우저 시각 확인) |
| ADR 판단 | 불필요 |
| 남은 warning | 없음 (Knip 신규 0) |

런타임·시각 확인:

- `/zzz` → HTTP 404, `<meta name="robots" content="noindex">`, 세리프 제목 렌더, 뷰포트별 Cloudinary URL(w_640·w_750…)
- `/news/notices?page=abc`(잘못된 쿼리) → HTTP 404 + 한국어 notices 404 렌더
- 브라우저(Chrome) 데스크톱 1440 / 모바일 625 — 사진 듀오톤 배경·스크림 전환·풀폭 버튼·푸터 스택 디자인대로 확인

---

## 🖼️ 화면 검증 (브라우저 실측)

|**데스크톱 (1440)** — 사진 배경(흑백 듀오톤) + 좌측 가로 스크림 위 텍스트| **모바일 (625)** — 세로 스크림 전환 + 풀폭 골드 버튼 + 푸터 스택| 
|--|--|
| <img width="1171" height="788" alt="image" src="https://github.com/user-attachments/assets/00e8e343-3cc9-4f0f-ad55-48da9466cf54" /> | <img width="578" height="785" alt="image" src="https://github.com/user-attachments/assets/a7513de7-4e13-4c06-ab44-d110886726e4" /> |


---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 잘못된 URL·없는 설교 접근 시 영문 404 대신 한국어 브랜드 404 화면이 뜬다
- **운영 리스크**: Cloudinary에 public_id `not-found` 이미지가 있어야 사진 배경이 표시됨 (없으면 SVG 폴백)
- **남은 빈틈(tech-debt)**: 설교 전용·admin 전용 404 미세분화, notices 상세 라우트 미구현 — `docs/tech-debt/active.md`에 등록
- **먼저 볼 화면 / 흐름**: 임의 경로 `/zzz` 접속 → 404 화면

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

다른 라우트 그룹에 맞춤 in-content 404를 추가할 때 이 화면(또는 bulletins 패턴)을 참고. 설교/admin 전용 404와 notices 상세 구현은 tech-debt 항목으로 추적 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
