### PR TITLE
[Chore] 홈 렌더 차단 최적화 — 세리프 CSS 절반·Pretendard self-host(LCP -575ms)

### DIFF
--- a/docs/exec-plans/active/2026-06-10-perf-optimize.md
+++ b/docs/exec-plans/active/2026-06-10-perf-optimize.md
@@ -126,6 +126,8 @@ before/after (전체 기록: `docs/research/perf-optimize/baseline-summary.md`):
 
 측정 방법: 같은 머신·prod 빌드. Lighthouse 모바일 5회 median+min/max(LCP variance 커 median 필요). 결정적 지표는 `.next` 청크·@font-face 카운트. Chrome은 `encodedBodySize`(캐시 무관). 시각 회귀: 브라우저로 홈 확인 — 브랜드 세리프·히어로 정상, 세리프 weight 변경(RecentSermons 500→400·QuickAccess 600→700)은 미세하고 의도된 매핑. 빌드: photoswipe.css를 client 컴포넌트에 둬도 App Router 빌드 통과(Codex 계획 검증 우려 미발생).
 
+PR #112 Codex 봇 리뷰(P2) 반영: 처음엔 홈만 스캔해 RecentSermons(500)·QuickAccess(600)만 매핑했는데, 홈 밖에도 세리프-500/600이 있었다. AboutWorship `.verse`·SchoolGrid `.time`(500→400), NoticeDrawer 제목(600→700)을 명시 매핑해 세리프 weight 축소를 전 페이지로 완성했다. 이 값들은 weight 제거 후 브라우저가 이미 같은 weight로 스냅하던 것이라 렌더 결과는 그대로고, 의도만 코드에 분명히 했다.
+
 ## 검증 이력
 
 <!--

--- a/docs/exec-plans/active/2026-06-10-perf-optimize.md
+++ b/docs/exec-plans/active/2026-06-10-perf-optimize.md
@@ -4,7 +4,7 @@
 - **시작일**: 2026-06-10
 - **브랜치**: perf/optimize-measure
 - **Open questions**: none
-- **ADR needed**: no
+- **ADR needed**: no — `pretendard` 의존성 추가는 이미 쓰던 CDN 폰트를 self-host로 옮긴 것뿐, 아키텍처·패턴 변경이 아님(D3)
 
 ## 목표
 
@@ -148,18 +148,21 @@ before/after (전체 기록: `docs/research/perf-optimize/baseline-summary.md`):
   - 문제: jsdelivr Pretendard `<link rel=stylesheet>`가 렌더를 1,146ms 막는다. 본문 폰트라 효과는 크지만 손대기 까다롭다.
   - 해결: Codex 계획 검증이 셋을 비교했다 — `media=print onload` async swap은 본문 한글 FOUT·CLS 위험, `preload+유지`는 렌더 차단 성격을 못 없애 1,146ms를 온전히 못 얻음, `next/font/local` self-host는 가장 안전하지만 폰트 자산 소유·preload·라이선스 운영 표면이 새로 생긴다. 그래서 이번엔 보류하고 별도 PR로 조사한다. 레버 1·2를 먼저 적용한다.
   - 결과: 본문 가독성 회귀 위험 없이 안전한 레버부터 처리한다. Pretendard는 후속 작업으로 남긴다.
+  - ⚠️ 정정(D3 참조): 보류 → 승격. 측정 결과 레버 1이 LCP를 못 움직였고 진짜 병목이 Pretendard라, 같은 작업에서 A2 방식으로 처리했다.
 
 - **D2 — 렌더 차단 CSS 101KiB는 세리프 @font-face라 레버 1에 흡수된다**
   - 문제: Codex가 폰트 다음 큰 레버로 렌더 차단 로컬 CSS 101KiB(전송)·306KB(원본)를 지목했다. 별도 CSS 축소 작업이 필요한지 의심했다.
   - 해결: 그 CSS를 분석하니 Noto Serif KR `@font-face`가 496블록(weight 4 × CJK unicode-range 슬라이스), unicode-range 선언만 247KB로 ~80%를 차지했다. 앱 SCSS 과다 유입이 아니라 세리프 폰트 CSS다. 그래서 별도 CSS 레버를 만들지 않고, 세리프 weight를 줄이는 레버 1이 @font-face 수와 이 CSS를 함께 절반으로 줄이게 둔다.
   - 결과: 레버 1이 폰트 바이트와 렌더 차단 CSS 둘 다 친다 — 주력 레버로 확정.
 
+- **D3 — 측정 결과로 레버 3(Pretendard self-host)을 승격한다 (D1 정정)**
+  - 문제: 레버 1·2 적용 후 Vercel preview를 브라우저로 실측하니, 세리프 CSS는 절반(306→153KB)인데 홈 LCP는 안 움직였다(BEFORE 3,220ms / AFTER 3,256ms, FCP=LCP). 레버 1은 페이로드만 줄였고 LCP 병목이 아니었다. (위 Claude 2차의 localhost median 표 LCP -563ms는 노이즈였고, Vercel 실측이 정확하다.)
+  - 해결: 홈 LCP는 히어로 이미지이고 FCP와 같은 시점에 그려진다. FCP를 가장 늦추는 것(long pole)은 외부 jsdelivr의 Pretendard 렌더 차단 스타일시트였다. 별도 도메인이라 DNS 조회와 TLS 핸드셰이크가 더 든다. 그래서 보류했던 레버 3을 승격한다(D1 정정). Codex 설계 검증으로 세 방식을 비교해 dynamic-subset을 같은 출처에서 self-host하는 방식(A2)을 택했다 — 단일 1.3MB 묶음(A1)은 히어로 이미지(LCP)와 대역폭을 다투고, 비차단 async swap(B)은 본문 폰트가 늦게 떠 글자가 한 번 바뀐다(FOUT). `pretendard` npm을 의존성으로 추가하고 dynamic-subset CSS를 import해 jsdelivr `<link>`·preconnect를 제거했다. woff2는 Turbopack이 같은 출처 자산으로 emit해 커밋되는 바이너리는 0이고, unicode-range로 필요한 한글 슬라이스만 받는 효율은 유지된다.
+  - 결과: jsdelivr 참조 0, Pretendard가 같은 출처에서 로드된다(외부 렌더 차단 스타일시트 제거, curl 확인). LCP가 실제로 줄었는지는 아직 미측정 — Vercel preview 재측정 결과를 아래 검증에 기록한다.
+
 ## 후속 작업
 
-- Pretendard(본문 폰트) jsdelivr 스타일시트가 렌더를 1,146ms 막는다. self-host(`next/font/local`)로 옮기면 렌더 차단을 없애고 fallback 메트릭까지 통제할 수 있다.
-  - 이유: 본문 폰트라 async 전환은 FOUT·CLS 위험, self-host는 폰트 자산 운영 표면이 새로 생겨 별도 PR감(D1).
-  - 다음 기준: 이번 레버 1·2 적용 후에도 홈 FCP가 목표 미달일 때, 또는 폰트 운영을 정비할 때.
-  - 기록 위치: `docs/tech-debt/active.md` 등록 후보.
+- A2도 여전히 렌더를 막는 스타일시트다(같은 출처로 바뀌었을 뿐). 완전히 안 막는 방식은 폰트 파일을 직접 호스팅(`next/font/local` 단일 subset woff2)해야 하는데, 폰트 자산을 직접 관리하는 부담이 크다. 홈 LCP를 더 줄여야 할 때 다시 본다.
 
 <!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
 - <후속 항목>

--- a/docs/exec-plans/active/2026-06-10-perf-optimize.md
+++ b/docs/exec-plans/active/2026-06-10-perf-optimize.md
@@ -158,7 +158,7 @@ before/after (전체 기록: `docs/research/perf-optimize/baseline-summary.md`):
 - **D3 — 측정 결과로 레버 3(Pretendard self-host)을 승격한다 (D1 정정)**
   - 문제: 레버 1·2 적용 후 Vercel preview를 브라우저로 실측하니, 세리프 CSS는 절반(306→153KB)인데 홈 LCP는 안 움직였다(BEFORE 3,220ms / AFTER 3,256ms, FCP=LCP). 레버 1은 페이로드만 줄였고 LCP 병목이 아니었다. (위 Claude 2차의 localhost median 표 LCP -563ms는 노이즈였고, Vercel 실측이 정확하다.)
   - 해결: 홈 LCP는 히어로 이미지이고 FCP와 같은 시점에 그려진다. FCP를 가장 늦추는 것(long pole)은 외부 jsdelivr의 Pretendard 렌더 차단 스타일시트였다. 별도 도메인이라 DNS 조회와 TLS 핸드셰이크가 더 든다. 그래서 보류했던 레버 3을 승격한다(D1 정정). Codex 설계 검증으로 세 방식을 비교해 dynamic-subset을 같은 출처에서 self-host하는 방식(A2)을 택했다 — 단일 1.3MB 묶음(A1)은 히어로 이미지(LCP)와 대역폭을 다투고, 비차단 async swap(B)은 본문 폰트가 늦게 떠 글자가 한 번 바뀐다(FOUT). `pretendard` npm을 의존성으로 추가하고 dynamic-subset CSS를 import해 jsdelivr `<link>`·preconnect를 제거했다. woff2는 Turbopack이 같은 출처 자산으로 emit해 커밋되는 바이너리는 0이고, unicode-range로 필요한 한글 슬라이스만 받는 효율은 유지된다.
-  - 결과: jsdelivr 참조 0, Pretendard가 같은 출처에서 로드된다(외부 렌더 차단 스타일시트 제거, curl 확인). LCP가 실제로 줄었는지는 아직 미측정 — Vercel preview 재측정 결과를 아래 검증에 기록한다.
+  - 결과: jsdelivr 참조가 사라지고, Pretendard를 같은 출처에서 받는다(외부 렌더 차단 스타일시트 제거). Vercel preview를 Lighthouse로 6회씩 측정하니, jsdelivr 렌더 차단이 BEFORE 6/6회 → AFTER 0/6회로 사라졌고 홈 LCP 중앙값이 8,040ms → 7,465ms로 약 575ms 줄었다(두 분포가 거의 겹치지 않음: AFTER 7251–7862 vs BEFORE 7783–8115). LCP가 안 움직인 레버 1과 달리 레버 3은 움직여, 진짜 병목이 Pretendard였다는 가설이 측정으로 뒷받침됐다. FCP·Perf·TBT는 편차가 커(FCP 분포 2.3초, TBT는 JS 무변경인데 이동) 읽지 않는다.
 
 ## 후속 작업
 

--- a/docs/exec-plans/active/2026-06-10-perf-optimize.md
+++ b/docs/exec-plans/active/2026-06-10-perf-optimize.md
@@ -1,0 +1,205 @@
+# perf-optimize
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-10
+- **브랜치**: perf/optimize-measure
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+홈의 느린 첫 화면(FCP 6.5s·LCP 9.7s)을 측정으로 진단해 가장 큰 병목을 줄인다. 끝나면 같은 조건(prod 빌드·Lighthouse 모바일)에서 before/after 표로 개선 폭을 수치로 보인다.
+
+베이스라인 진단(유효): 병목은 JS 번들이 아니라 **폰트 크기(647KiB)와 렌더 차단 CSS**다. TBT는 210ms로 낮고, react-icons는 Next 16 기본 optimizePackageImports에 이미 포함돼 손댈 게 없다. 상세 수치는 `docs/research/perf-optimize/baseline-summary.md`.
+
+## 검증된 Assumptions
+
+- react-icons는 Next 16 기본 `optimizePackageImports`에 팩 단위로 전부 포함됨 — `node_modules/next/dist/server/config.js:982-1012` 확인. 코드도 58/60 파일이 sub-path import. → 번들 최적화 여지 없음(no-op).
+- 홈 LCP 요소 = Banner 히어로 IMG, elementRenderDelay 2,082ms가 지배 — Lighthouse `lcp-breakdown-insight`. 이미지는 fetchpriority=high로 101ms에 도착, 렌더가 막혀 못 그림.
+- render-blocking 절감 추정 4,070ms — 로컬 CSS 101KiB(2,273ms) + jsdelivr Pretendard CSS(1,146ms) + 기타 CSS. Lighthouse `render-blocking-insight`.
+- 폰트 647KiB/21파일이 전체 전송 1,295KiB의 절반 — Lighthouse network-requests 집계.
+- 세리프 weight 사용: 700·400 다수, 500(RecentSermons), 600(QuickAccess, layout 미요청→스냅), 800 미사용 — `grep $font-family-secondary`.
+- photoswipe.css(7.4KiB)가 `layout.tsx:8`에서 전역 import — 모든 라우트에 렌더 차단 CSS로 실림. 실제 사용처는 게시판·주보 2곳.
+
+## Success Criteria
+
+측정 방법론(before/after, 같은 머신·prod 빌드·Lighthouse 모바일):
+
+- 비교 라우트: 홈(`/`), 게시판 상세(`/news/bulletins/1`). 각 **Lighthouse 모바일 5회**, median + min/max 기록(LCP·FCP·Perf·전체 전송·폰트 KiB).
+- 결정적 지표: 최대 CSS 청크 바이트(베이스라인 306,630 B), Noto Serif KR @font-face 블록 수(베이스라인 496), 홈 폰트 파일 수(베이스라인 21).
+- 수치 판정(베이스라인 1회 기준 → after median):
+  - 홈 폰트 전송: 647 KiB → **≤ 500 KiB**.
+  - 세리프 @font-face 블록: 496 → **약 절반(~248)**, 최대 CSS 청크 306KB → **유의하게 감소**.
+  - 홈 LCP median: 9.7s → **개선(델타 표)**, FCP median: 6.5s → **개선**.
+  - 홈 라우트 network에 photoswipe CSS·JS 요청 **0개**.
+  - 시각 회귀 없음 — 브라우저로 홈·게시판 데스크톱+모바일 확인(세리프 텍스트·갤러리 정상).
+  - `yarn build`·`yarn lint`·`yarn lint:styles` 통과, knip 신규 0.
+
+## Non-goals
+
+- react-icons / `optimizePackageImports` 추가 — 이미 프레임워크 기본값 적용(no-op).
+- 전체 라우트 성능 튜닝 — 홈·게시판 두 라우트의 첫 화면 병목만.
+- 이미지 파이프라인·Cloudinary 변환 변경 — LCP 이미지는 이미 최적(fetchpriority·101ms).
+- globals.scss 대수술 — 렌더 차단 CSS 중 앱 자체 번들 축소는 별도 작업.
+- Pretendard 렌더 차단 완화(async swap·self-host) — 본문 폰트라 위험이 커서 별도 PR로 다룬다(레버 3 보류, D1).
+
+## 접근법 — 레버 2개 (3은 보류)
+
+- **레버 1 (세리프 weight, 주력)**: Noto Serif KR weight를 `['400','500','700','800']` → `['400','700']`로. RecentSermons(500)·QuickAccess(600) 세리프를 400/700 중 하나로 명시 매핑해 스냅 의존 제거. 이 레버는 두 병목을 동시에 줄인다.
+  - 폰트 바이트: 페이지가 weight별 unicode-range 슬라이스를 받으므로 weight 수가 줄면 전송량이 준다.
+  - 렌더 차단 CSS: 306KB(전송 101KiB)의 약 80%가 Noto Serif KR @font-face 496블록(weight 4 × CJK 슬라이스)이라, weight를 절반으로 줄이면 @font-face와 CSS도 절반이 된다(D2).
+- **레버 2 (photoswipe)**: `PhotoSwipe.tsx`를 `next/dynamic`(ssr:false)으로 감싸고, `photoswipe.css`(7.4KB) 전역 import를 그 컴포넌트/갤러리 segment로 옮긴다. 비갤러리 라우트(홈 포함)에서 photoswipe CSS·JS 제거. 컴포넌트 내 CSS import가 빌드 실패하면 갤러리 route segment import로 대체(D1 Codex 조건).
+- **레버 3 (Pretendard) 보류** → 후속 작업. 본문 폰트 async 전환은 FOUT·CLS 위험이 있고, self-host는 폰트 자산 소유·preload·라이선스를 직접 운영해야 한다. Codex 권고로 이번 범위에서 뺀다(D1).
+
+## 영향받는 파일
+
+- `src/app/layout.tsx` (세리프 weight 축소, photoswipe.css 전역 import 제거, 레버 3 결과 반영)
+- `src/app/_component/home/RecentSermons.module.scss`·`QuickAccess.module.scss` (세리프 weight 명시 매핑)
+- `src/components/common/PhotoSwipe.tsx` + 사용처(`BoardBody`, `LatestBulletinImages`) (동적 import·CSS 동봉)
+- 레버 3에 따라 `layout.tsx` `<head>` 또는 폰트 로딩 방식
+
+## 단계별 체크리스트
+
+- [x] 1. 베이스라인 확정 — 홈 Lighthouse 5회 median + .next client JS·CSS·@font-face·폰트 바이트 기록(`baseline-summary.md`)
+- [x] 2. 레버 1 — 세리프 weight 4→2(400·700) + RecentSermons(500→400)·QuickAccess(600→700) 매핑
+- [x] 3. 레버 2 — photoswipe.css 전역 import 제거 → PhotoSwipe.tsx로 이동(빌드 통과)
+- [x] 4. 레버 3 보류 확정(D1) — 후속 작업으로 기록
+- [x] 5. after 측정 — 동일 조건 5회 median, before/after 델타 표(@font-face -50%, LCP -563ms, CSS -43%)
+- [x] 6. 브라우저 시각 확인(홈 브랜드 세리프·히어로 정상) + `verify-task`(run 20260610-192006 통과)
+
+## Verification
+
+- `node scripts/verify-task.mjs perf-optimize`
+- 수동: before/after Lighthouse 중앙값 표(LCP·FCP·폰트 KiB·전송), 브라우저 시각 회귀 확인
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST (high) — 요구 4건을 반영(D1·D2·SC 수치화·측정 5회).
+- **현재 판단**: 레버 1(주)+2로 WORK 진입, 레버 3 보류.
+- **다음 행동**: 구현 diff로 1차 검증.
+
+조치 요약:
+
+- 레버 3 보류(D1): Pretendard는 본문 폰트라 `media=print onload` async swap이 FOUT·CLS 위험. self-host(next/font/local)는 폰트 자산 소유·preload·라이선스 운영 표면이 새로 생겨 별도 PR감. 이번 범위에서 뺀다.
+- 레버 2 빌드 안전성: client 컴포넌트 안 CSS import가 App Router 전역 CSS 제약으로 빌드 실패할 수 있음. 실패하면 갤러리 route segment에서 import로 대체(첫 open FOUC 주의).
+- 성공 기준 수치화 + Lighthouse 3→5회 median+min/max로 보강(아래 SC 반영).
+- Codex가 "놓친 더 큰 레버"로 지목한 렌더 차단 로컬 CSS 101KiB는 분석 결과 Noto Serif KR @font-face 496블록이라 레버 1에 흡수됨(D2).
+
+## Codex 1차 검증
+
+- **결론**: PASS (high) — 4개 변경에 동작 오류·레이어 위반 없음. 2차 확인 권고 3건을 아래대로 해소.
+- **현재 판단**: 커밋 가능.
+- **다음 행동**: Claude 2차에 2차 확인 결과 기록.
+
+조치 요약:
+
+- 권고 1(photoswipe `.pswp` override 깨짐): repo에 `.pswp` override가 0건이라 CSS 순서 변경 위험이 없다 — `grep "pswp" src --include=*.scss/*.css` 무매칭.
+- 권고 2(photoswipe.css가 홈에서 빠지고 갤러리에만): 빌드 청크 `433167e9…css`에 `.pswp`가 있고 홈은 photoswipe 요청 0(Chrome 확인). 갤러리 라우트로 스코프됨.
+- 권고 3(RecentSermons 제목 굵기 변화): 의도된 매핑(500→400). 브랜드 세리프·히어로는 브라우저로 정상 확인.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — 신규 회귀 0, 측정으로 개선 확인, 커밋 가능.
+- **현재 판단**: 정적 검증 4종 + 결정적 빌드 지표 + Lighthouse 5회 median + Chrome 실측으로 before/after를 확보했다.
+- **다음 행동**: 사용자 승인 후 커밋.
+
+| 시점 | run-id | lint | styles | build | knip 신규 |
+| --- | --- | --- | --- | --- | --- |
+| 1차 | 20260610-192006 | ✅ | ✅ | ✅ | 0 |
+
+before/after (전체 기록: `docs/research/perf-optimize/baseline-summary.md`):
+
+| 지표 | before | after | 델타 |
+| --- | --- | --- | --- |
+| 세리프 @font-face 블록 | 496 | 250 | -50% |
+| 최대 CSS 청크(원본) | 306,630 B | 153,510 B | -50% |
+| 홈 Lighthouse Perf median | 61 | 67 | +6 |
+| 홈 LCP median | 6,653 ms | 6,090 ms | -563 ms |
+| 홈 FCP median | 4,405 ms | 4,245 ms | -160 ms |
+| 홈 TBT median | 220 ms | 118 ms | -102 ms |
+| 홈 CSS 전송(Chrome encoded) | 143 KiB | 82 KiB | -43% |
+| 홈 photoswipe 요청 | (전역 로드) | 0 | 제거 |
+
+측정 방법: 같은 머신·prod 빌드. Lighthouse 모바일 5회 median+min/max(LCP variance 커 median 필요). 결정적 지표는 `.next` 청크·@font-face 카운트. Chrome은 `encodedBodySize`(캐시 무관). 시각 회귀: 브라우저로 홈 확인 — 브랜드 세리프·히어로 정상, 세리프 weight 변경(RecentSermons 500→400·QuickAccess 600→700)은 미세하고 의도된 매핑. 빌드: photoswipe.css를 client 컴포넌트에 둬도 App Router 빌드 통과(Codex 계획 검증 우려 미발생).
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 의사결정 로그
+
+- **D1 — Pretendard 렌더 차단 완화(레버 3)는 이번 범위에서 뺀다**
+  - 문제: jsdelivr Pretendard `<link rel=stylesheet>`가 렌더를 1,146ms 막는다. 본문 폰트라 효과는 크지만 손대기 까다롭다.
+  - 해결: Codex 계획 검증이 셋을 비교했다 — `media=print onload` async swap은 본문 한글 FOUT·CLS 위험, `preload+유지`는 렌더 차단 성격을 못 없애 1,146ms를 온전히 못 얻음, `next/font/local` self-host는 가장 안전하지만 폰트 자산 소유·preload·라이선스 운영 표면이 새로 생긴다. 그래서 이번엔 보류하고 별도 PR로 조사한다. 레버 1·2를 먼저 적용한다.
+  - 결과: 본문 가독성 회귀 위험 없이 안전한 레버부터 처리한다. Pretendard는 후속 작업으로 남긴다.
+
+- **D2 — 렌더 차단 CSS 101KiB는 세리프 @font-face라 레버 1에 흡수된다**
+  - 문제: Codex가 폰트 다음 큰 레버로 렌더 차단 로컬 CSS 101KiB(전송)·306KB(원본)를 지목했다. 별도 CSS 축소 작업이 필요한지 의심했다.
+  - 해결: 그 CSS를 분석하니 Noto Serif KR `@font-face`가 496블록(weight 4 × CJK unicode-range 슬라이스), unicode-range 선언만 247KB로 ~80%를 차지했다. 앱 SCSS 과다 유입이 아니라 세리프 폰트 CSS다. 그래서 별도 CSS 레버를 만들지 않고, 세리프 weight를 줄이는 레버 1이 @font-face 수와 이 CSS를 함께 절반으로 줄이게 둔다.
+  - 결과: 레버 1이 폰트 바이트와 렌더 차단 CSS 둘 다 친다 — 주력 레버로 확정.
+
+## 후속 작업
+
+- Pretendard(본문 폰트) jsdelivr 스타일시트가 렌더를 1,146ms 막는다. self-host(`next/font/local`)로 옮기면 렌더 차단을 없애고 fallback 메트릭까지 통제할 수 있다.
+  - 이유: 본문 폰트라 async 전환은 FOUT·CLS 위험, self-host는 폰트 자산 운영 표면이 새로 생겨 별도 PR감(D1).
+  - 다음 기준: 이번 레버 1·2 적용 후에도 홈 FCP가 목표 미달일 때, 또는 폰트 운영을 정비할 때.
+  - 기록 위치: `docs/tech-debt/active.md` 등록 후보.
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt/active.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/docs/research/perf-optimize/baseline-summary.md
+++ b/docs/research/perf-optimize/baseline-summary.md
@@ -1,0 +1,79 @@
+# perf-optimize 베이스라인 (before) — 2026-06-10
+
+측정: develop 74524c8 깨끗 상태, prod 빌드(`yarn build`), Lighthouse 모바일, 홈 1회(병목 식별용).
+
+## 홈 런타임 (Lighthouse mobile, 1회)
+- Perf score: 55
+- FCP: 6,467 ms
+- LCP: 9,752 ms (LCP 요소 = Banner 히어로 IMG)
+- TBT: 210 ms (낮음 — JS 실행 병목 아님)
+- CLS: 0
+- 전체 전송: 1,295 KiB
+
+## 자원 분해 (홈, transfer)
+- Font: 647 KiB / 21 파일  ← 최대
+- Script: 291 KiB
+- Stylesheet: 144 KiB
+- Image: 110 KiB
+- 폰트 내역: Noto Serif KR(next/font, 4 weight) self-host + Pretendard(jsdelivr dynamic-subset) 12+ 파일
+
+## LCP 분해 (홈)
+- TTFB 37ms / resourceLoadDelay 21ms / resourceLoadDuration 101ms / **elementRenderDelay 2,082ms**
+- 즉 이미지는 빨리 도착(fetchpriority=high 적용), 렌더가 막혀 못 그림.
+
+## render-blocking (홈, est savings 4,070ms)
+- 로컬 CSS 103,792 B (2,273ms)
+- jsdelivr Pretendard CSS 12,959 B (1,146ms)
+- 로컬 CSS 15,458 B (773ms) + 소형 2개(323ms×2)
+
+## 결정적 번들 지표
+- .next/static/chunks 전체 client JS: 1,529.9 KiB (50 파일)
+
+## 세리프 weight 사용 현황
+- 700: brand·title·verse·Footer / 400: Banner h1·NewHere / 500: RecentSermons / 600: QuickAccess(요청 안 됨→스냅) / 800: 미사용
+
+## 홈 — Lighthouse 모바일 5회 median (정확한 before)
+| 지표 | median | min–max |
+| --- | --- | --- |
+| Perf | 61 | 60–66 |
+| LCP | 6,653 ms | 5,748–7,672 |
+| FCP | 4,405 ms | 3,948–5,859 |
+| TBT | 220 ms | 0–254 |
+
+## 홈 — Claude in Chrome 실측 (localhost 무throttle, 412px, encodedBodySize)
+- LCP 2,336 ms / FCP 2,336 ms
+- 폰트 10파일 / 360.9 KiB · CSS 143 KiB · JS 237.9 KiB
+
+---
+
+# AFTER (레버 1+2 적용) — 2026-06-10
+
+레버 1(Noto Serif KR weight 4→2: 400·700, RecentSermons 500→400·QuickAccess 600→700 매핑) + 레버 2(photoswipe.css 전역 import → PhotoSwipe.tsx). 레버 3(Pretendard) 보류.
+
+## 결정적 빌드 지표 (캐시·노이즈 무관)
+| 지표 | before | after | 델타 |
+| --- | --- | --- | --- |
+| 세리프 @font-face 블록 (최대 CSS 청크) | 496 | 250 | -50% |
+| 최대 CSS 청크(원본 바이트) | 306,630 | 153,510 | -153,120 B (-50%) |
+| unicode-range 선언 바이트 | 247,217 | 123,613 | -50% |
+| 전체 client JS | 1,529.9 KiB | 1,529.9 KiB | 0 (예상 — JS 아님) |
+
+## 홈 Lighthouse 모바일 5회 median (throttled)
+| 지표 | before median | after median | 델타 |
+| --- | --- | --- | --- |
+| Perf | 61 (60–66) | 67 (63–70) | +6 |
+| LCP | 6,653 ms (5,748–7,672) | 6,090 ms (5,489–6,253) | -563 ms |
+| FCP | 4,405 ms (3,948–5,859) | 4,245 ms (3,859–4,700) | -160 ms |
+| TBT | 220 ms | 118 ms | -102 ms |
+
+## 홈 Claude in Chrome 실측 (localhost, encodedBodySize)
+| 지표 | before | after | 델타 |
+| --- | --- | --- | --- |
+| CSS encoded | 143 KiB | 82 KiB | -61 KiB (-43%) |
+| 폰트 woff2 | 360.9 KiB / 10 | 360.9 KiB / 10 | 0 (같은 글리프 렌더 — 줄어든 건 @font-face CSS) |
+| photoswipe 요청(홈) | — | 0 | 홈에서 제거 |
+
+## 해석
+- 병목이던 렌더 차단 세리프 @font-face CSS가 절반(306→153KB, 전송 ~101→~50KiB). Lighthouse median LCP -563ms·Perf +6·TBT -102ms로 일관 개선(after max LCP 6,253 < before max 7,672).
+- woff2 폰트 바이트는 동일 — 같은 한글 글리프를 렌더하므로 weight만 줄어든 효과는 woff2가 아니라 @font-face CSS에서 나타남.
+- 빌드: photoswipe.css를 client 컴포넌트에 둬도 App Router 빌드 통과(Codex 우려 미발생).

--- a/docs/research/perf-optimize/troubleshooting.md
+++ b/docs/research/perf-optimize/troubleshooting.md
@@ -1,0 +1,98 @@
+# 트러블슈팅 — 홈 첫 화면이 느리다 (LCP/FCP)
+
+> 2026-06-10 · 작업 `perf-optimize` (PR #112) · 관련: [exec-plan](../../exec-plans/active/2026-06-10-perf-optimize.md), [baseline-summary](./baseline-summary.md)
+
+홈 LCP/FCP가 느려 최적화한 과정을 남긴다. **추정 원인을 잘못 짚었다가 측정으로 바로잡은 기록**이라, 다음 성능 작업에서 같은 함정을 피하려고 정리했다.
+
+## 증상
+
+- 홈 Lighthouse(모바일): FCP 약 6.5s, LCP 약 9.7s(콜드 1회). Perf 55.
+- 백로그에 적힌 추정 원인: "react-icons 번들 / `optimizePackageImports` / unused JS 68KiB".
+
+## 결론부터
+
+- 진짜 병목은 **JS 번들이 아니라 폰트 관련 렌더 차단**이었다.
+- 효과가 있던 건 **레버 3(Pretendard self-host)** 하나뿐 — 홈 LCP 중앙값을 약 575ms 줄였다.
+- 처음 손댄 **레버 1(세리프 weight 축소)은 CSS 페이로드를 절반으로 줄였지만 LCP는 못 움직였다**. 페이로드 절감과 LCP 개선은 다른 문제다.
+
+### 한눈에 — BEFORE → AFTER
+
+| 레버 | 지표 | BEFORE | AFTER | 변화 |
+| --- | --- | --- | --- | --- |
+| **3. Pretendard self-host** | **홈 LCP 중앙값** (Vercel·6회) | **8,040 ms** | **7,465 ms** | **-575 ms (실제 개선)** |
+| 3. Pretendard self-host | jsdelivr 렌더 차단 등장 | 6/6회 | 0/6회 | 외부 렌더 차단 제거 |
+| 1. 세리프 weight 4→2 | 세리프 `@font-face` 블록 | 496 | 250 | -50% (페이로드만) |
+| 1. 세리프 weight 4→2 | 최대 CSS 청크(원본) | 306,630 B | 153,510 B | -50% |
+| 1. 세리프 weight 4→2 | 홈 LCP 중앙값 | 3,220 ms | 3,256 ms | **무변화** (LCP 병목 아님) |
+| 2. photoswipe 격리 | 홈 photoswipe 요청 | 전역 로드 | 0 | 비갤러리에서 제거 |
+
+> 핵심 대비: **같은 "CSS/폰트 줄이기"라도, 레버 3(외부 렌더 차단 제거)은 LCP를 -575ms 줄였고 레버 1(세리프 CSS 절반)은 LCP를 못 줄였다.** 무엇을 줄이느냐가 아니라 **임계 경로의 long pole을 줄였느냐**가 갈랐다.
+
+## 진단 순서와 막힌 곳
+
+### 1. 백로그 추정(react-icons)은 이미 해결돼 있었다
+
+- 코드: react-icons import 58/60 파일이 이미 `react-icons/io5` 같은 sub-path named import — barrel bloat 없음.
+- 프레임워크: **Next 16 기본 `optimizePackageImports` 목록에 react-icons 팩이 전부 들어 있다** — `node_modules/next/dist/server/config.js`의 `react-icons/ai·bs·fa·hi·io5·pi …`.
+- → `optimizePackageImports`에 react-icons를 넣어도 아무 효과가 없다(no-op). 백로그 추정을 그대로 믿지 말고 먼저 확인할 것.
+
+### 2. TBT가 낮다 = JS 실행이 병목이 아니다
+
+- 베이스라인 TBT 210ms(낮음). LCP 분해에서 **elementRenderDelay 2,082ms**가 지배.
+- LCP 요소 = 홈 히어로 이미지. `fetchpriority=high`로 이미지는 101ms에 도착하는데 **렌더가 막혀** 못 그린다.
+- → 병목은 "JS 실행"이 아니라 "첫 렌더를 막는 것(render-blocking)". 자원을 종류별로 나눠 보니 폰트가 647KiB, 21개 파일로 전송량의 절반을 차지했다.
+
+### 3. 첫 시도(레버 1)는 엉뚱한 곳을 고쳤다
+
+- 렌더 차단 CSS 청크가 306KB(전송 101KiB)였는데, 까보니 **Noto Serif KR `@font-face`가 496블록**(weight 4 × CJK unicode-range 슬라이스), unicode-range 선언만 247KB로 ~80%.
+- 그래서 세리프 weight를 4→2(400·700)로 줄였다 → @font-face 496→250, CSS 청크 306→153KB(-50%).
+- **그런데 Vercel preview로 재니 홈 LCP가 안 움직였다**(BEFORE 3,220ms / AFTER 3,256ms). 이유:
+  - LCP = 히어로 이미지 = FCP 시점. FCP는 **렌더 차단 임계 경로의 가장 느린 것(long pole)**에 묶인다.
+  - 줄인 세리프 CSS는 같은 출처에서 병렬로 빨리 받는 쪽이라 long pole이 아니었다.
+
+### 4. 측정 노이즈에 속을 뻔했다
+
+- localhost Lighthouse는 LCP 편차가 ±2~3초로 컸다. 운 좋은 한 세션 median(LCP -563ms)을 개선으로 착각했다.
+- 두 서버를 동시에 띄우고 Lighthouse를 돌리니 CPU 경합으로 값이 뒤집혔다. **JS를 안 건드렸는데 TBT가 움직이면 = 측정값이 머신 상태에 따라 달라진다는 신호.**
+- 교훈: 시간 지표는 한 머신·한 세션으로 단정하지 말 것. 표본을 늘려 median+분포로 보거나, 결정적 지표(바이트·@font-face 수)로 판단할 것.
+
+### 5. 진짜 병목 = 외부 Pretendard 렌더 차단 스타일시트
+
+- 본문 폰트 Pretendard를 jsdelivr `<link rel=stylesheet>`(dynamic-subset)로 받고 있었다. Lighthouse render-blocking 약 1,146ms — 별도 도메인이라 DNS 조회·TLS 핸드셰이크까지 든다.
+- 이게 FCP의 long pole이었다. 세리프(레버 1)는 곁가지였다.
+
+### 6. 고친 방법(레버 3, A2)
+
+- Codex 설계 검증으로 셋을 비교:
+  - **A1**: `next/font/local` 단일 variable woff2 — 비차단이지만 ~1.3MB 폰트가 히어로 이미지(LCP)와 대역폭을 다툰다.
+  - **A2(채택)**: 같은 dynamic-subset CSS·woff2를 우리 출처에서 self-host — 외부 도메인 비용 제거, unicode-range subset 효율 유지, FOUT(폰트가 늦게 떠 글자가 한 번 바뀌는 현상) 위험 최소.
+  - **B**: jsdelivr를 `media=print onload`로 비차단 — 본문 폰트라 FOUT(글자가 한 번 바뀜).
+- 구현: `pretendard` npm 의존성 추가 + dynamic-subset CSS import, jsdelivr `<link>`·preconnect 제거. **woff2는 Turbopack이 같은 출처 자산으로 emit**해 커밋되는 바이너리는 0.
+- 결과(Vercel preview Lighthouse 6회): jsdelivr 렌더 차단 6/6회 → 0/6회 제거, **홈 LCP 중앙값 8,040 → 7,465ms(약 -575ms, 두 분포 거의 분리)**. 폭은 작지만 실제로 개선됐다.
+
+## 다음에 쓸 체크리스트
+
+1. **백로그 추정을 먼저 검증한다.** 프레임워크 기본값(Next `optimizePackageImports` 등)이 이미 처리했는지 `node_modules` 설정을 확인.
+2. **TBT부터 본다.** 낮으면 JS가 아니라 렌더 차단·자원 로딩이 병목.
+3. **LCP 요소가 무엇인지 확인한다.** 이미지면 폰트/CSS 축소로는 잘 안 움직인다. 텍스트면 폰트가 직접 영향.
+4. **render-blocking long pole을 찾는다.** 특히 외부 도메인 스타일시트(폰트 CDN)는 DNS·TLS까지 더해 가장 느린 경우가 많다.
+5. **페이로드 절감 ≠ LCP 개선**을 구분한다. CSS/바이트를 줄여도 LCP가 안 변할 수 있다(느린 망·대역폭엔 여전히 도움).
+6. **측정은 결정적 지표 + 표본 다수.** 시간 지표(LCP)는 노이즈가 크다 — Vercel preview에 올려 PageSpeed Insights(구글 서버, 머신 독립)나 Lighthouse 다회 median으로 본다. localhost 단발은 신뢰 불가.
+
+## 측정 도구 모음 (이 작업에서 쓴 것)
+
+| 목적 | 방법 |
+| --- | --- |
+| 라우트별 번들(Next 16) | `next build`는 크기 컬럼이 없음 → `.next/static/chunks` 파일 크기 합산, 또는 `next build --experimental-analyze`(Turbopack 전용) |
+| @font-face·CSS 분해 | 최대 CSS 청크에서 `grep -c "@font-face"`, `unicode-range` 바이트 |
+| 실제 전송 바이트(캐시 무관) | 브라우저에서 `performance.getEntriesByType('resource')`의 `encodedBodySize` |
+| LCP(실측) | `PerformanceObserver({type:'largest-contentful-paint', buffered:true})` + `takeRecords()` (동기). 단 같은 URL 반복은 bfcache로 안 잡힐 수 있어 쿼리로 캐시버스팅 |
+| 시간 지표(머신 독립) | Vercel preview URL + PageSpeed Insights(pagespeed.web.dev). API는 무키 quota 주의 |
+| 편차 대응 | 한 번에 한 서버만 켜고 Lighthouse 다회 → median + min/max. 두 서버 동시 측정은 경합으로 무효 |
+
+## 함정 기록
+
+- **localhost LCP는 못 믿는다.** 네트워크가 즉시라 렌더 차단 CSS 크기 차이가 안 드러나고, 머신 부하로 세션마다 뒤집힌다.
+- **Vercel preview는 기본적으로 인증 보호(401)**라 외부 도구(PSI)가 못 들어간다. 보호를 끄거나 운영 URL(공개)로 비교.
+- **운영 `dnchurch.vercel.app`은 main**이라 develop과 콘텐츠가 다를 수 있다(이 시점엔 #110·#111 미반영). before는 `dnchurch-git-develop-...vercel.app`(develop preview)로 잡는 게 정확.
+- **세리프 weight를 줄일 땐 전 페이지를 스캔**한다. 홈만 보면 다른 페이지(예배 안내·공지)의 같은 폰트 사용처를 놓친다(Codex 봇 P2가 잡음).

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dayjs": "^1.11.13",
     "next": "^16.0.10",
     "photoswipe": "^5.4.4",
+    "pretendard": "1.3.9",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.66.0",

--- a/src/app/(content)/about/worship/_component/AboutWorship.module.scss
+++ b/src/app/(content)/about/worship/_component/AboutWorship.module.scss
@@ -53,7 +53,8 @@
 .verse {
   font-family: $font-family-secondary;
   font-size: $font-size-16;
-  font-weight: $font-weight-medium;
+  // 세리프 weight 400·700만 유지하므로 medium(500)→regular(400) 명시 매핑 (브라우저 자동 매칭과 동일)
+  font-weight: $font-weight-regular;
   line-height: $line-height-relaxed;
   letter-spacing: $letter-spacing-body;
   color: $txt-inverse;

--- a/src/app/(content)/about/worship/_component/SchoolGrid.module.scss
+++ b/src/app/(content)/about/worship/_component/SchoolGrid.module.scss
@@ -35,7 +35,8 @@
 .time {
   font-family: $font-family-secondary;
   font-size: $font-size-15;
-  font-weight: $font-weight-medium;
+  // 세리프 weight 400·700만 유지하므로 medium(500)→regular(400) 명시 매핑 (브라우저 자동 매칭과 동일)
+  font-weight: $font-weight-regular;
   letter-spacing: $letter-spacing-body;
   font-variant-numeric: tabular-nums;
   color: $txt-primary;

--- a/src/app/(content)/news/notices/_component/NoticeDrawer.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeDrawer.module.scss
@@ -130,7 +130,8 @@
   margin-bottom: $spacing-8;
   font-family: $font-family-secondary;
   font-size: $font-size-18;
-  font-weight: $font-weight-semibold;
+  // 세리프 weight 400·700만 유지하므로 semibold(600)→bold(700) 명시 매핑 (브라우저 자동 매칭과 동일)
+  font-weight: $font-weight-bold;
   color: $txt-primary;
   word-break: keep-all;
   line-height: map-get($heading-line-heights, 'h5');

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -99,7 +99,8 @@ $icon_box_size: 4.2rem;
 .label {
   font-family: $font-family-secondary;
   font-size: $font-size-15;
-  font-weight: $font-weight-semibold;
+  // 세리프 weight를 400·700로 줄이며 semibold(600)→bold(700)로 명시 매핑 (기존에도 600 미요청이라 700로 스냅됨)
+  font-weight: $font-weight-bold;
   color: $txt-primary;
 }
 

--- a/src/app/_component/home/RecentSermons.module.scss
+++ b/src/app/_component/home/RecentSermons.module.scss
@@ -35,7 +35,8 @@
 
 .header h2 {
   font-family: $font-family-secondary;
-  font-weight: $font-weight-medium;
+  // 세리프 weight를 400·700로 줄이며 medium(500)→regular(400)로 명시 매핑 (브라우저 자동 매칭과 동일)
+  font-weight: $font-weight-regular;
   color: $white;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import ToastContainer from '@/components/common/Toast/ToastContainer';
 import SessionContextProvider from '@/context/SessionContextProvider';
 import { OPEN_GRAPH_BASE } from '@/config/seo';
 import '@/styles/globals.scss';
-import 'photoswipe/dist/photoswipe.css';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
 
@@ -32,8 +31,10 @@ export const viewport: Viewport = {
   viewportFit: 'cover'
 };
 
+// 세리프는 로고타입·헤딩·인용구 강조용. CJK 폰트는 weight마다 unicode-range @font-face가 생성돼
+// 렌더 차단 CSS와 폰트 바이트가 weight 수에 비례한다. 실제 쓰는 400·700만 남긴다(500→400, 600→700로 매핑).
 const notoserifKR = Noto_Serif_KR({
-  weight: ['400', '500', '700', '800'],
+  weight: ['400', '700'],
   subsets: ['latin'],
   variable: '--font-notoserifKR',
   display: 'swap'

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,9 @@ import ScrollToTop from '@/components/common/ScrollToTop';
 import ToastContainer from '@/components/common/Toast/ToastContainer';
 import SessionContextProvider from '@/context/SessionContextProvider';
 import { OPEN_GRAPH_BASE } from '@/config/seo';
+// Pretendard(본문 폰트)를 jsdelivr 외부 스타일시트 대신 self-host. 외부 도메인 렌더 차단(DNS·TLS) 비용 제거.
+// dynamic-subset CSS라 unicode-range로 필요한 한글 슬라이스만 받는 효율은 그대로. woff2는 Turbopack이 같은 출처 자산으로 emit한다.
+import 'pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css';
 import '@/styles/globals.scss';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL;
@@ -44,12 +47,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
   return (
     <html lang="ko" className={`${notoserifKR.variable}`}>
       <head>
-        <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
         <link rel="preconnect" href="https://res.cloudinary.com" />
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
-        />
       </head>
       <body>
         <div id="root">

--- a/src/components/common/PhotoSwipe.tsx
+++ b/src/components/common/PhotoSwipe.tsx
@@ -14,6 +14,8 @@ import {
 import PhotoSwipeType, { type PhotoSwipeOptions } from 'photoswipe';
 import { type ImageState, type PhotoSwipeProps } from '@/types/photoswipe';
 import styles from './PhotoSwipe.module.scss';
+// 갤러리에서만 쓰는 CSS — 전역(layout) 대신 이 컴포넌트가 실리는 라우트에만 로드한다.
+import 'photoswipe/dist/photoswipe.css';
 
 export default function PhotoSwipe({
   images,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3449,6 +3449,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+pretendard@1.3.9:
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/pretendard/-/pretendard-1.3.9.tgz#b1f86d5a7a729f518974098fcf85f34fff3526b7"
+  integrity sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==
+
 prettier@^3.3.3:
   version "3.3.3"
   resolved "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz"


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 홈의 렌더 차단 CSS를 줄여 첫 화면 그리기를 앞당긴다.

**범위**:

- 세리프(Noto Serif KR) weight를 실제 쓰는 400·700 2개로 줄임 (500→400, 600→700 매핑)
- 갤러리 전용 photoswipe.css를 layout 전역 import에서 PhotoSwipe 컴포넌트로 옮겨, 비갤러리 라우트에서 제거
- 진단·측정·결정 기록(exec-plan, baseline 측정)

---

## 🔗 개발 컨텍스트

- **Task ID**: `perf-optimize`
- **Exec Plan**: `docs/exec-plans/active/2026-06-10-perf-optimize.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: Pretendard 렌더 차단 완화 (후속 PR 후보)
- **작업 범위**: 세리프 weight 감축(레버 1) + photoswipe.css 컴포넌트 격리(레버 2)
- **제외한 범위**: Pretendard 렌더 차단 완화(레버 3) — 본문 폰트 FOUT 위험으로 별도 PR

---

## 💡 변경 배경 (Motivation)

홈 FCP 6.5s·LCP 9.7s로 느린데 TBT는 210ms로 낮았다. JS 실행이 아니라 렌더 차단 CSS가 병목이라는 신호다. react-icons는 Next 16 기본 `optimizePackageImports`에 이미 포함돼 손댈 게 없었다(no-op). 진짜 원인은 weight마다 unicode-range @font-face가 생성되는 세리프 CSS(최대 청크 306KB·496블록)와 폰트 부하 647KiB였다.

---

## 🔧 주요 변경점 (Key Changes)

- 세리프 weight를 `['400','500','700','800']`에서 `['400','700']`로 줄임 — `src/app/layout.tsx`
- 사용처 weight를 남은 2개로 매핑: RecentSermons 500→400, QuickAccess 600→700 — `RecentSermons.module.scss`, `QuickAccess.module.scss`
- photoswipe.css를 layout 전역 import에서 갤러리 컴포넌트로 옮김 — `src/components/common/PhotoSwipe.tsx` (layout에서 제거)

---

## 📊 before → after (성능)

빌드 지표는 캐시·네트워크 노이즈와 무관한 결정적 값이다. **런타임 시간 지표(LCP/FCP)는 localhost·단일 머신에서 노이즈가 크므로(세션마다 ±2~3초, TBT도 흔들림), 신뢰할 측정은 Vercel preview를 PageSpeed Insights(구글 서버)로 재는 것이다. 아래 표 참고.**

### 결정적 빌드 지표 (재현 가능)

| 지표 | before | after | 델타 |
| --- | --- | --- | --- |
| 세리프 @font-face 블록(최대 CSS 청크) | 496 | 250 | -50% |
| 최대 CSS 청크 원본 바이트 | 306,630 B | 153,510 B | -153,120 B (-50%) |
| 홈 CSS 전송(Chrome encoded) | 100.9 KiB(최대 파일) | 50.6 KiB | -50% |
| 전체 client JS | 1,529.9 KiB | 1,529.9 KiB | 0 (예상대로 — JS 병목 아님) |

### 시간 지표 — Vercel preview 실측 결과: **LCP 개선 없음 (정직 기록)**

두 preview를 실제 브라우저(워밍 후 각 3회, PerformanceObserver)로 측정:

| 지표 | 🔴 BEFORE (develop preview) | 🟢 AFTER (이 PR preview) |
| --- | --- | --- |
| LCP median | 3,220 ms | 3,256 ms |
| FCP | = LCP | = LCP |

→ **LCP·FCP는 사실상 동일(노이즈 ±내).** CSS를 절반으로 줄였지만 홈 LCP/FCP는 안 움직였다. PageSpeed Insights 단발 측정에서도 BEFORE가 더 낮게 나왔다.

**원인(측정으로 드러남):**
- 홈 LCP 요소 = 히어로 이미지이고 FCP와 같은 시점에 그려진다. 즉 FCP가 한계이고, FCP는 렌더 차단 리소스 임계 경로의 long pole에 묶인다.
- 줄인 세리프 CSS는 같은 출처에서 병렬로 빨리 받는 쪽이라 long pole이 아니었다.
- **진짜 long pole은 외부 jsdelivr Pretendard 렌더 차단 스타일시트**(별도 도메인 연결 비용 포함) — 이번에 보류한 레버 3.

**그래서 이 PR(레버 1·2)의 실제 가치는 "렌더 차단/폰트 CSS 페이로드 -50%"이지 LCP 개선이 아니다.** 페이로드 절감은 대역폭·파싱·저사양에 도움이지만, 빠른 망의 홈 LCP는 못 잡는다.

### 레버 3 추가 — Pretendard self-host (LCP 실제 개선)

위 분석대로 진짜 병목이 외부 jsdelivr Pretendard 렌더 차단 스타일시트라, 보류했던 레버 3을 같은 PR에서 처리했다. Codex 설계 검증으로 A2(같은 출처 dynamic-subset self-host) 채택 — `pretendard` npm 의존성 추가 + dynamic-subset CSS import, jsdelivr `<link>`·preconnect 제거. woff2는 Turbopack이 같은 출처로 emit(커밋 바이너리 0), unicode-range subset 효율 유지. A1(단일 1.3MB)은 히어로 LCP와 대역폭 경쟁, B(async)는 본문 FOUT라 배제.

Vercel preview Lighthouse 6회 측정:

| 지표 | 🔴 BEFORE (develop) | 🟢 AFTER (레버 3) | 판단 |
| --- | --- | --- | --- |
| LCP median | 8,040 ms (7783–8115) | 7,465 ms (7251–7862) | **-575ms, 분포 거의 분리 → 실제 개선** |
| jsdelivr 렌더 차단 | 6/6회 등장 | 0/6회 | 결정적 제거 |
| FCP·Perf·TBT | — | — | 편차 과대(FCP 분포 2.3초, TBT는 JS 무변경인데 이동) → 못 읽음 |

→ **레버 1은 LCP 무변화였지만 레버 3은 LCP median을 약 575ms 줄였다.** 진짜 병목이 Pretendard였음이 측정으로 확인됐다. 단 극적 개선은 아니고, 빠른 망에선 modest하다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 진짜 병목 | 렌더 차단 세리프 @font-face CSS | TBT 210ms로 낮아 JS 아님, LCP elementRenderDelay 2,082ms로 렌더가 막힘 | react-icons 최적화 — Next 16 기본에 이미 포함(no-op) |
| 세리프 weight 매핑 | 500→400, 600→700 | QuickAccess 600은 요청 없이 스냅된 값, RecentSermons 500은 400과 자동 매칭과 동일 | weight 4개 유지 — @font-face·CSS가 weight 수에 비례 |
| photoswipe.css 위치 | PhotoSwipe 컴포넌트 | 갤러리 라우트에만 로드, 홈 등 비갤러리에서 제거 | 전역 layout import 유지 — 모든 라우트에 불필요 부하 |
| Pretendard(레버 3) | 보류 | 본문 폰트라 FOUT 위험, 별도 PR에서 다룰 후속 | 이번에 포함 — 위험 대비 검증 부담 큼 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs perf-optimize` — PASS, RUN_ID=`20260610-193310`, failed=0, warned=Knip(기존 부채) |
| `harness-gate` | PASS |
| Codex 계획 검증 | CHANGE_REQUEST → 반영(레버 3 보류) |
| Codex 1차 검증 | PASS |
| Claude 2차 검증 | 완료 |
| ADR 판단 | 불필요 |

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 없음 — 같은 글리프를 렌더하므로 화면 모양은 동일, 첫 그리기만 빨라짐(렌더 차단 CSS -50%)
- **운영 리스크**: 없음 — 배포 순서·환경변수·스크립트 실행 불필요
- **QA 후속**: 주보 갤러리(PhotoSwipe)에서 이미지 뷰어 스타일이 정상인지 — photoswipe.css를 전역에서 컴포넌트로 옮겼으므로 (`.pswp` override는 repo에 0건이라 순서 위험 없음)
- **롤백 시 영향**: 없음

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- weight 매핑은 시각 의도 변경이 아니라 사용 중인 두 weight로 스냅한 것이다. medium/semibold가 다시 필요하면 weight 추가 시 @font-face·CSS 부하가 비례해 늘어남을 기억할 것.
- 시간 지표(LCP)는 localhost에서 신뢰 불가 — Vercel preview + PageSpeed Insights로 재야 머신 독립적 수치가 나온다.
- 다음 성능 작업은 Pretendard 렌더 차단 완화(레버 3). 본문 폰트라 FOUT 검증 필요 — tech-debt 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
