### PR TITLE
[Chore] Figma를 디자인 SoT로 전환 결정 + 토큰 동기화 파이프라인 구축 (변수 174개 비파괴 추출)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,9 @@ next-env.d.ts
 docs/references/**/*.html
 docs/references/**/*.jsx
 
+# Figma 디자인 시스템 빌드 작업 메모 (일회성 — 커밋 금지)
+# docs/research/ 다른 파일(README·perf-optimize 등)은 계속 추적, figma-ds-* 만 차단
+docs/research/figma-ds-*
+
 # Windows bash crash dump
 *.stackdump

--- a/docs/decisions/0017-figma-sot-design-to-code.md
+++ b/docs/decisions/0017-figma-sot-design-to-code.md
@@ -1,0 +1,62 @@
+# 0017 — 디자인 SoT를 Figma로 옮기고 디자인투코드 채택, 무료 경로부터 검증
+
+- **Status**: Accepted
+- **Date**: 2026-06-13
+- **Deciders**: scseong, Claude Code
+- **Tags**: frontend, design-system, tooling
+
+## Context
+
+지난주 코드 기반 SCSS 디자인 시스템(토큰 174개 + `src/components/ui/` 12 컴포넌트)을 Figma로 옮겼다. 그 뒤 "Figma와 코드를 어떻게 일치시키나"를 정해야 했고, 논의가 다음 순서로 흘렀다.
+
+- 처음엔 코드를 SoT(source of truth)로 두자고 권했다. 근거: 무료 Figma는 컬렉션당 모드 1개라 반응형·다크 값을 못 담는다(실제 `addMode`가 "Limited to 1 modes only"로 막힘).
+- 사용자가 반론했다. 코드가 더 자주 바뀌고, 색·간격 결정은 Figma에서 보며 하니 Figma가 기준이어야 한다.
+- 두 입장을 레이어별 SoT로 갈랐다. 디자인 레이어(토큰값·컴포넌트 시각 스펙)는 Figma, 행위·반응형·믹스인은 코드.
+- 사용자가 목표를 분명히 했다. Figma Dev MCP로 코드를 생성하고 GitHub를 거쳐 컴포넌트 기반으로 개발하는 디자인투코드(Figma 디자인을 코드로 생성), 그 전체를 하네스로 굴린다.
+- Fast Campus 강의(`Claude Code + Figma MCP 디자인 시스템 자동화`)로 방법론을 대조했다. Figma→코드 + Code Connect가 주류임이 확인됐다. 단 공식 Figma Dev MCP는 Starter에서 월 6회 호출 한도, Code Connect는 Organization 유료 플랜이 필요하다.
+
+결정을 미루면 비용이 쌓인다. 44개 라우트 중 절반이 빈 스텁(community·gallery·next-gen·notifications·search)인데, 규칙 없이 채워지면 페이지마다 제각각 구현돼 일관성이 다시 무너진다. 지금도 폼이 3가지 방식으로 갈리고 `ui/TextField`는 실사용이 0건이라, ui/ 카탈로그가 강제되지 않는 상태가 그대로 굳는다.
+
+## Decision
+
+**디자인 시스템의 SoT를 디자인 레이어 한정으로 Figma에 두고, Figma→코드 디자인투코드를 채택한다. 비용 0인 무료 경로로 PoC를 먼저 돌리고, 효과를 확인한 뒤 유료(Code Connect) 전환을 판단한다.**
+
+| 항목 | 결정 |
+|---|---|
+| SoT 경계 | 디자인 레이어(토큰값 174개·컴포넌트 시각 스펙) = Figma / 행위·반응형·믹스인·맵·복합 rgba = 코드 |
+| 이식 전략 | 기존 ui/ + 구현된 페이지 = 매핑 재사용(브리지로 추출, 하네스가 ui/ 규칙에 맞게 다듬음) / 스텁 페이지·신규 컴포넌트 = 디자인투코드 생성 |
+| 경로 | Path Free 먼저 — figma-console/Talk-to-Figma 브리지 + 하네스가 Code Connect 역할 대행. Path Pro(유료 Figma + Code Connect)는 PoC 후 결정 |
+| 첫 작업 | 토큰 동기화 파이프라인(exec-plan `ds-token-sync-pipeline`) — "토큰 먼저, 디자인 나중" 순서 |
+
+## Consequences
+
+### 긍정적
+- 스텁 페이지를 디자인투코드로 생성하면 일관성이 구현 시점에 강제된다. 빈 페이지라 기존 코드와 충돌하지 않는다.
+- 비용 0으로 시작한다. 유료 판단을 추측이 아니라 PoC 결과로 미룬다.
+- 하네스(skills·Codex·verify-task)가 생성 코드를 ui/ 규칙·토큰에 맞게 거르는 검증 엔진이 된다.
+
+### 부정적 / 트레이드오프
+- Path Free는 Code Connect가 없어, Figma 컴포넌트를 ui/ 컴포넌트로 잇는 매핑을 하네스가 수기로 떠안는다. 생성 코드 품질이 Path Pro보다 낮고 사람 검토가 더 든다.
+- 무료 브리지는 Figma 데스크톱 + 플러그인이 켜져 있어야 동작한다(WebSocket). CI에서 자동으로 못 돌리고 로컬에서 손으로 실행한다.
+- Figma는 디자인 레이어만 SoT라, 믹스인·반응형·복합 rgba는 코드에만 남는다. "왜 이건 Figma에 없나"는 경계로 둔다.
+
+### 영향 범위
+- 코드: `scripts/`(토큰 싱크 보조), `src/components/ui/`(매핑 타겟 정비 — 후속), `tokens.config.json`(신규).
+- 문서: 본 ADR, exec-plan `ds-token-sync-pipeline` 외 후속 plan.
+- 운영: 토큰 동기화가 로컬 수기 명령이다(Figma 데스크톱 필요).
+
+## Alternatives Considered
+
+### A안: 코드를 SoT로 유지 (코드→Figma 단방향 싱크)
+- 기각: 사용자가 디자인 결정을 Figma에서 하고 디자인투코드를 목표로 명시했다. 코드 SoT는 "Figma에서 탐색 → 코드로 구현" 흐름과 어긋난다. 무료 플랜이 전체를 못 담는 한계는 레이어별 SoT로 흡수했다(디자인 레이어만 Figma).
+
+### B안: Path Pro로 바로 시작 (유료 Figma + Code Connect)
+- 기각: 효과를 검증하기 전에 Figma Organization 비용을 선지출한다. 디자인투코드가 이 브라운필드(44 라우트·기존 ui/ 12 컴포넌트)에서 실제로 동작하는지 PoC로 확인한 뒤 결정해도 늦지 않다.
+
+### C안: 강의대로 그린필드로 새 디자인 시스템 구축
+- 기각: 강의 결과물(미니 디자인 시스템 + Supabase CRUD + 배포)을 이미 더 높은 수준으로 보유한다(44 라우트·ADR 16건·게이트·Codex 오케스트레이션). 빈 조각은 강의 STEP 2~4(Code Connect·디자인투코드·QA)뿐이라, 맨땅이 아니라 기존 시스템에 이식한다.
+
+## References
+- 관련 exec-plan: `docs/exec-plans/active/2026-06-13-ds-token-sync-pipeline.md`
+- 관련 ADR: 0001(Codex 오케스트레이션 전략), 0004(ui 컴포넌트 토대), 0012(admin 토큰 분리), 0014(카드 전략)
+- 관련 연구: `docs/research/figma-ds-build-state.json` (Figma 빌드 원장 — 커밋 제외)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -46,5 +46,6 @@
 | [0014](0014-card-component-strategy.md) | 카드 컴포넌트: 전면 통합 대신 공유 부품·스타일 추출 | Accepted | 2026-06-02 |
 | [0015](0015-page-state-seo-policy.md) | 페이지 상태·SEO 정책: 유형별 상태 파일 최소 요구 + news 디테일 JSON-LD 확대 | Accepted | 2026-06-02 |
 | [0016](0016-server-action-conventions.md) | Server Action 공통 패턴 (위치·검증·반환·revalidate) | Accepted | 2026-06-12 |
+| [0017](0017-figma-sot-design-to-code.md) | 디자인 SoT를 Figma로 옮기고 디자인투코드 채택, 무료 경로부터 검증 | Accepted | 2026-06-13 |
 
 <!-- last-audit: 2026-05-01 -->

--- a/docs/design-system/tokens.tokens.json
+++ b/docs/design-system/tokens.tokens.json
@@ -1,0 +1,2878 @@
+{
+  "$extensions": {
+    "figma-console-mcp": {
+      "exportedAt": "2026-06-13T12:01:37.001Z",
+      "mcpVersion": "1.31.0"
+    }
+  },
+  "color": {
+    "$extensions": {
+      "figma-console-mcp": {
+        "figmaCollectionId": "VariableCollectionId:2:3",
+        "originalName": "Color"
+      }
+    },
+    "accent": {
+      "default": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gold.600}"
+              }
+            },
+            "variableId": "VariableID:6:8"
+          }
+        },
+        "$type": "color",
+        "$value": "{gold.600}"
+      },
+      "hover": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gold.400}"
+              }
+            },
+            "variableId": "VariableID:6:9"
+          }
+        },
+        "$type": "color",
+        "$value": "{gold.400}"
+      },
+      "subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gold.100}"
+              }
+            },
+            "variableId": "VariableID:6:10"
+          }
+        },
+        "$type": "color",
+        "$value": "{gold.100}"
+      }
+    },
+    "bg": {
+      "accent-subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#C4924A1F"
+              }
+            },
+            "variableId": "VariableID:5:21"
+          }
+        },
+        "$type": "color",
+        "$value": "#C4924A1F"
+      },
+      "admin": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F7F8FA"
+              }
+            },
+            "variableId": "VariableID:5:25"
+          }
+        },
+        "$type": "color",
+        "$value": "#F7F8FA"
+      },
+      "admin-hover": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#EEF0F4"
+              }
+            },
+            "variableId": "VariableID:5:27"
+          }
+        },
+        "$type": "color",
+        "$value": "#EEF0F4"
+      },
+      "admin-subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F1F3F6"
+              }
+            },
+            "variableId": "VariableID:5:26"
+          }
+        },
+        "$type": "color",
+        "$value": "#F1F3F6"
+      },
+      "beige-subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{beige.100}"
+              }
+            },
+            "variableId": "VariableID:5:19"
+          }
+        },
+        "$type": "color",
+        "$value": "{beige.100}"
+      },
+      "card": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{white}"
+              }
+            },
+            "variableId": "VariableID:5:16"
+          }
+        },
+        "$type": "color",
+        "$value": "{white}"
+      },
+      "dark": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#0F1820"
+              }
+            },
+            "variableId": "VariableID:5:22"
+          }
+        },
+        "$type": "color",
+        "$value": "#0F1820"
+      },
+      "dark-card": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#1A2535"
+              }
+            },
+            "variableId": "VariableID:5:23"
+          }
+        },
+        "$type": "color",
+        "$value": "#1A2535"
+      },
+      "dark-nav": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.950}"
+              }
+            },
+            "variableId": "VariableID:5:24"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.950}"
+      },
+      "dark-nav-active": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#3B434D"
+              }
+            },
+            "variableId": "VariableID:5:29"
+          }
+        },
+        "$type": "color",
+        "$value": "#3B434D"
+      },
+      "dark-nav-hover": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2A2F36"
+              }
+            },
+            "variableId": "VariableID:5:28"
+          }
+        },
+        "$type": "color",
+        "$value": "#2A2F36"
+      },
+      "hover": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2C3E500F"
+              }
+            },
+            "variableId": "VariableID:5:20"
+          }
+        },
+        "$type": "color",
+        "$value": "#2C3E500F"
+      },
+      "primary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{beige.50}"
+              }
+            },
+            "variableId": "VariableID:5:15"
+          }
+        },
+        "$type": "color",
+        "$value": "{beige.50}"
+      },
+      "secondary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{beige.150}"
+              }
+            },
+            "variableId": "VariableID:5:17"
+          }
+        },
+        "$type": "color",
+        "$value": "{beige.150}"
+      },
+      "secondary-deep": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{beige.300}"
+              }
+            },
+            "variableId": "VariableID:5:18"
+          }
+        },
+        "$type": "color",
+        "$value": "{beige.300}"
+      }
+    },
+    "border": {
+      "admin": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#E5E8ED"
+              }
+            },
+            "variableId": "VariableID:5:39"
+          }
+        },
+        "$type": "color",
+        "$value": "#E5E8ED"
+      },
+      "card": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{beige.200}"
+              }
+            },
+            "variableId": "VariableID:5:35"
+          }
+        },
+        "$type": "color",
+        "$value": "{beige.200}"
+      },
+      "dark-faint": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FFFFFF1A"
+              }
+            },
+            "variableId": "VariableID:5:38"
+          }
+        },
+        "$type": "color",
+        "$value": "#FFFFFF1A"
+      },
+      "dark-nav": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2A2F36"
+              }
+            },
+            "variableId": "VariableID:5:40"
+          }
+        },
+        "$type": "color",
+        "$value": "#2A2F36"
+      },
+      "dark-subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FFFFFF33"
+              }
+            },
+            "variableId": "VariableID:5:37"
+          }
+        },
+        "$type": "color",
+        "$value": "#FFFFFF33"
+      },
+      "focus": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.800}"
+              }
+            },
+            "variableId": "VariableID:5:33"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.800}"
+      },
+      "inverse": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{white}"
+              }
+            },
+            "variableId": "VariableID:5:36"
+          }
+        },
+        "$type": "color",
+        "$value": "{white}"
+      },
+      "primary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.300}"
+              }
+            },
+            "variableId": "VariableID:5:30"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.300}"
+      },
+      "strong": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#6B728070"
+              }
+            },
+            "variableId": "VariableID:5:32"
+          }
+        },
+        "$type": "color",
+        "$value": "#6B728070"
+      },
+      "subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#6B728038"
+              }
+            },
+            "variableId": "VariableID:5:31"
+          }
+        },
+        "$type": "color",
+        "$value": "#6B728038"
+      },
+      "warm": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#64503226"
+              }
+            },
+            "variableId": "VariableID:5:34"
+          }
+        },
+        "$type": "color",
+        "$value": "#64503226"
+      }
+    },
+    "label": {
+      "neutral-bg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.200}"
+              }
+            },
+            "variableId": "VariableID:6:23"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.200}"
+      },
+      "neutral-fg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.700}"
+              }
+            },
+            "variableId": "VariableID:6:22"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.700}"
+      }
+    },
+    "primary": {
+      "active": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.950}"
+              }
+            },
+            "variableId": "VariableID:6:4"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.950}"
+      },
+      "default": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.800}"
+              }
+            },
+            "variableId": "VariableID:6:2"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.800}"
+      },
+      "hover": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.600}"
+              }
+            },
+            "variableId": "VariableID:6:3"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.600}"
+      },
+      "soft": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#5B6BA5"
+              }
+            },
+            "variableId": "VariableID:6:6"
+          }
+        },
+        "$type": "color",
+        "$value": "#5B6BA5"
+      },
+      "soft-subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#5B6BA514"
+              }
+            },
+            "variableId": "VariableID:6:7"
+          }
+        },
+        "$type": "color",
+        "$value": "#5B6BA514"
+      },
+      "subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2C3E5014"
+              }
+            },
+            "variableId": "VariableID:6:5"
+          }
+        },
+        "$type": "color",
+        "$value": "#2C3E5014"
+      }
+    },
+    "status": {
+      "negative": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{red.500}"
+              }
+            },
+            "variableId": "VariableID:6:13"
+          }
+        },
+        "$type": "color",
+        "$value": "{red.500}"
+      },
+      "negative-bg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{red.100}"
+              }
+            },
+            "variableId": "VariableID:6:14"
+          }
+        },
+        "$type": "color",
+        "$value": "{red.100}"
+      },
+      "negative-soft": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#C0392B"
+              }
+            },
+            "variableId": "VariableID:6:21"
+          }
+        },
+        "$type": "color",
+        "$value": "#C0392B"
+      },
+      "positive": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{green.500}"
+              }
+            },
+            "variableId": "VariableID:6:11"
+          }
+        },
+        "$type": "color",
+        "$value": "{green.500}"
+      },
+      "positive-bg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{green.100}"
+              }
+            },
+            "variableId": "VariableID:6:12"
+          }
+        },
+        "$type": "color",
+        "$value": "{green.100}"
+      },
+      "positive-soft": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2E7D5B"
+              }
+            },
+            "variableId": "VariableID:6:19"
+          }
+        },
+        "$type": "color",
+        "$value": "#2E7D5B"
+      },
+      "positive-soft-bg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2E7D5B14"
+              }
+            },
+            "variableId": "VariableID:6:20"
+          }
+        },
+        "$type": "color",
+        "$value": "#2E7D5B14"
+      },
+      "warning": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{orange.600}"
+              }
+            },
+            "variableId": "VariableID:6:15"
+          }
+        },
+        "$type": "color",
+        "$value": "{orange.600}"
+      },
+      "warning-bg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{orange.100}"
+              }
+            },
+            "variableId": "VariableID:6:16"
+          }
+        },
+        "$type": "color",
+        "$value": "{orange.100}"
+      },
+      "warning-soft": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#D97706"
+              }
+            },
+            "variableId": "VariableID:6:17"
+          }
+        },
+        "$type": "color",
+        "$value": "#D97706"
+      },
+      "warning-soft-bg": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#D9770614"
+              }
+            },
+            "variableId": "VariableID:6:18"
+          }
+        },
+        "$type": "color",
+        "$value": "#D9770614"
+      }
+    },
+    "text": {
+      "admin-tertiary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#8A94A3"
+              }
+            },
+            "variableId": "VariableID:5:12"
+          }
+        },
+        "$type": "color",
+        "$value": "#8A94A3"
+      },
+      "dark-faint": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FFFFFF66"
+              }
+            },
+            "variableId": "VariableID:5:11"
+          }
+        },
+        "$type": "color",
+        "$value": "#FFFFFF66"
+      },
+      "dark-muted": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FFFFFF99"
+              }
+            },
+            "variableId": "VariableID:5:10"
+          }
+        },
+        "$type": "color",
+        "$value": "#FFFFFF99"
+      },
+      "disabled": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.400}"
+              }
+            },
+            "variableId": "VariableID:5:7"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.400}"
+      },
+      "image-subtle": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FFFFFFB2"
+              }
+            },
+            "variableId": "VariableID:5:9"
+          }
+        },
+        "$type": "color",
+        "$value": "#FFFFFFB2"
+      },
+      "inverse": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{white}"
+              }
+            },
+            "variableId": "VariableID:5:8"
+          }
+        },
+        "$type": "color",
+        "$value": "{white}"
+      },
+      "link": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.800}"
+              }
+            },
+            "variableId": "VariableID:5:5"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.800}"
+      },
+      "link-active": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{navy.950}"
+              }
+            },
+            "variableId": "VariableID:5:6"
+          }
+        },
+        "$type": "color",
+        "$value": "{navy.950}"
+      },
+      "on-dark-nav-faint": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.500}"
+              }
+            },
+            "variableId": "VariableID:5:14"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.500}"
+      },
+      "on-dark-nav-muted": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#9BA2AE"
+              }
+            },
+            "variableId": "VariableID:5:13"
+          }
+        },
+        "$type": "color",
+        "$value": "#9BA2AE"
+      },
+      "primary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.900}"
+              }
+            },
+            "variableId": "VariableID:5:2"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.900}"
+      },
+      "secondary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.700}"
+              }
+            },
+            "variableId": "VariableID:5:3"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.700}"
+      },
+      "tertiary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:3",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{gray.500}"
+              }
+            },
+            "variableId": "VariableID:5:4"
+          }
+        },
+        "$type": "color",
+        "$value": "{gray.500}"
+      }
+    }
+  },
+  "primitives": {
+    "$extensions": {
+      "figma-console-mcp": {
+        "figmaCollectionId": "VariableCollectionId:2:2",
+        "originalName": "Primitives"
+      }
+    },
+    "beige": {
+      "50": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FAFAF8"
+              }
+            },
+            "variableId": "VariableID:3:19"
+          }
+        },
+        "$type": "color",
+        "$value": "#FAFAF8"
+      },
+      "100": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F5F4F2"
+              }
+            },
+            "variableId": "VariableID:3:20"
+          }
+        },
+        "$type": "color",
+        "$value": "#F5F4F2"
+      },
+      "150": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F2F0EB"
+              }
+            },
+            "variableId": "VariableID:3:21"
+          }
+        },
+        "$type": "color",
+        "$value": "#F2F0EB"
+      },
+      "200": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F0EEE9"
+              }
+            },
+            "variableId": "VariableID:3:22"
+          }
+        },
+        "$type": "color",
+        "$value": "#F0EEE9"
+      },
+      "300": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#E8E6E1"
+              }
+            },
+            "variableId": "VariableID:3:23"
+          }
+        },
+        "$type": "color",
+        "$value": "#E8E6E1"
+      }
+    },
+    "black": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:2",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "literal": "#000000"
+            }
+          },
+          "variableId": "VariableID:3:2"
+        }
+      },
+      "$type": "color",
+      "$value": "#000000"
+    },
+    "gold": {
+      "100": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F5EAD6"
+              }
+            },
+            "variableId": "VariableID:3:18"
+          }
+        },
+        "$type": "color",
+        "$value": "#F5EAD6"
+      },
+      "400": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#D9A96A"
+              }
+            },
+            "variableId": "VariableID:3:17"
+          }
+        },
+        "$type": "color",
+        "$value": "#D9A96A"
+      },
+      "600": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#C4924A"
+              }
+            },
+            "variableId": "VariableID:3:16"
+          }
+        },
+        "$type": "color",
+        "$value": "#C4924A"
+      }
+    },
+    "gray": {
+      "50": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F9FAFB"
+              }
+            },
+            "variableId": "VariableID:3:11"
+          }
+        },
+        "$type": "color",
+        "$value": "#F9FAFB"
+      },
+      "100": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F3F4F6"
+              }
+            },
+            "variableId": "VariableID:3:10"
+          }
+        },
+        "$type": "color",
+        "$value": "#F3F4F6"
+      },
+      "200": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#E5E7EB"
+              }
+            },
+            "variableId": "VariableID:3:9"
+          }
+        },
+        "$type": "color",
+        "$value": "#E5E7EB"
+      },
+      "300": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#D1D5DB"
+              }
+            },
+            "variableId": "VariableID:3:8"
+          }
+        },
+        "$type": "color",
+        "$value": "#D1D5DB"
+      },
+      "400": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#9CA3AF"
+              }
+            },
+            "variableId": "VariableID:3:7"
+          }
+        },
+        "$type": "color",
+        "$value": "#9CA3AF"
+      },
+      "500": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#6B7280"
+              }
+            },
+            "variableId": "VariableID:3:6"
+          }
+        },
+        "$type": "color",
+        "$value": "#6B7280"
+      },
+      "700": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#374151"
+              }
+            },
+            "variableId": "VariableID:3:5"
+          }
+        },
+        "$type": "color",
+        "$value": "#374151"
+      },
+      "900": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#111827"
+              }
+            },
+            "variableId": "VariableID:3:4"
+          }
+        },
+        "$type": "color",
+        "$value": "#111827"
+      }
+    },
+    "green": {
+      "100": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#D1FAE5"
+              }
+            },
+            "variableId": "VariableID:3:25"
+          }
+        },
+        "$type": "color",
+        "$value": "#D1FAE5"
+      },
+      "500": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#10B981"
+              }
+            },
+            "variableId": "VariableID:3:24"
+          }
+        },
+        "$type": "color",
+        "$value": "#10B981"
+      }
+    },
+    "navy": {
+      "600": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#3D5166"
+              }
+            },
+            "variableId": "VariableID:3:15"
+          }
+        },
+        "$type": "color",
+        "$value": "#3D5166"
+      },
+      "800": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#2C3E50"
+              }
+            },
+            "variableId": "VariableID:3:14"
+          }
+        },
+        "$type": "color",
+        "$value": "#2C3E50"
+      },
+      "900": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#0A1218"
+              }
+            },
+            "variableId": "VariableID:3:12"
+          }
+        },
+        "$type": "color",
+        "$value": "#0A1218"
+      },
+      "950": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#1C2B3A"
+              }
+            },
+            "variableId": "VariableID:3:13"
+          }
+        },
+        "$type": "color",
+        "$value": "#1C2B3A"
+      }
+    },
+    "orange": {
+      "100": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FFEDD5"
+              }
+            },
+            "variableId": "VariableID:3:29"
+          }
+        },
+        "$type": "color",
+        "$value": "#FFEDD5"
+      },
+      "600": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#F68B28"
+              }
+            },
+            "variableId": "VariableID:3:28"
+          }
+        },
+        "$type": "color",
+        "$value": "#F68B28"
+      }
+    },
+    "red": {
+      "100": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#FEE2E2"
+              }
+            },
+            "variableId": "VariableID:3:27"
+          }
+        },
+        "$type": "color",
+        "$value": "#FEE2E2"
+      },
+      "500": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:2",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "#EF4444"
+              }
+            },
+            "variableId": "VariableID:3:26"
+          }
+        },
+        "$type": "color",
+        "$value": "#EF4444"
+      }
+    },
+    "white": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:2",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "literal": "#FFFFFF"
+            }
+          },
+          "variableId": "VariableID:3:3"
+        }
+      },
+      "$type": "color",
+      "$value": "#FFFFFF"
+    }
+  },
+  "radius": {
+    "$extensions": {
+      "figma-console-mcp": {
+        "figmaCollectionId": "VariableCollectionId:2:5",
+        "originalName": "Radius"
+      }
+    },
+    "circle": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.999}"
+            }
+          },
+          "variableId": "VariableID:24:22"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.999}"
+    },
+    "l": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.20}"
+            }
+          },
+          "variableId": "VariableID:24:17"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.20}"
+    },
+    "m": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.16}"
+            }
+          },
+          "variableId": "VariableID:24:18"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.16}"
+    },
+    "s": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.12}"
+            }
+          },
+          "variableId": "VariableID:24:19"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.12}"
+    },
+    "scale": {
+      "2": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 2
+              }
+            },
+            "variableId": "VariableID:24:2"
+          }
+        },
+        "$type": "dimension",
+        "$value": 2
+      },
+      "4": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 4
+              }
+            },
+            "variableId": "VariableID:24:3"
+          }
+        },
+        "$type": "dimension",
+        "$value": 4
+      },
+      "6": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 6
+              }
+            },
+            "variableId": "VariableID:24:4"
+          }
+        },
+        "$type": "dimension",
+        "$value": 6
+      },
+      "8": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 6
+              }
+            },
+            "variableId": "VariableID:24:5"
+          }
+        },
+        "$type": "dimension",
+        "$value": 6
+      },
+      "10": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 8
+              }
+            },
+            "variableId": "VariableID:24:6"
+          }
+        },
+        "$type": "dimension",
+        "$value": 8
+      },
+      "12": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 10
+              }
+            },
+            "variableId": "VariableID:24:7"
+          }
+        },
+        "$type": "dimension",
+        "$value": 10
+      },
+      "16": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 12
+              }
+            },
+            "variableId": "VariableID:24:8"
+          }
+        },
+        "$type": "dimension",
+        "$value": 12
+      },
+      "20": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 16
+              }
+            },
+            "variableId": "VariableID:24:9"
+          }
+        },
+        "$type": "dimension",
+        "$value": 16
+      },
+      "24": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 20
+              }
+            },
+            "variableId": "VariableID:24:10"
+          }
+        },
+        "$type": "dimension",
+        "$value": 20
+      },
+      "28": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 22
+              }
+            },
+            "variableId": "VariableID:24:11"
+          }
+        },
+        "$type": "dimension",
+        "$value": 22
+      },
+      "32": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 24
+              }
+            },
+            "variableId": "VariableID:24:12"
+          }
+        },
+        "$type": "dimension",
+        "$value": 24
+      },
+      "40": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 32
+              }
+            },
+            "variableId": "VariableID:24:13"
+          }
+        },
+        "$type": "dimension",
+        "$value": 32
+      },
+      "48": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 40
+              }
+            },
+            "variableId": "VariableID:24:14"
+          }
+        },
+        "$type": "dimension",
+        "$value": 40
+      },
+      "999": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:5",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 9999
+              }
+            },
+            "variableId": "VariableID:24:15"
+          }
+        },
+        "$type": "dimension",
+        "$value": 9999
+      }
+    },
+    "xl": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.28}"
+            }
+          },
+          "variableId": "VariableID:24:16"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.28}"
+    },
+    "xs": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.8}"
+            }
+          },
+          "variableId": "VariableID:24:20"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.8}"
+    },
+    "xxs": {
+      "$extensions": {
+        "figma-console-mcp": {
+          "collectionId": "VariableCollectionId:2:5",
+          "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+          "lastSyncedValue": {
+            "Value": {
+              "reference": "{scale.4}"
+            }
+          },
+          "variableId": "VariableID:24:21"
+        }
+      },
+      "$type": "dimension",
+      "$value": "{scale.4}"
+    }
+  },
+  "spacing": {
+    "$extensions": {
+      "figma-console-mcp": {
+        "figmaCollectionId": "VariableCollectionId:2:4",
+        "originalName": "Spacing"
+      }
+    },
+    "content-gap": {
+      "l": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.24}"
+              }
+            },
+            "variableId": "VariableID:7:25"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.24}"
+      },
+      "m": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.16}"
+              }
+            },
+            "variableId": "VariableID:7:26"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.16}"
+      },
+      "s": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.12}"
+              }
+            },
+            "variableId": "VariableID:7:27"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.12}"
+      },
+      "xl": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.32}"
+              }
+            },
+            "variableId": "VariableID:7:24"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.32}"
+      },
+      "xs": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.8}"
+              }
+            },
+            "variableId": "VariableID:7:28"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.8}"
+      }
+    },
+    "scale": {
+      "0": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 0
+              }
+            },
+            "variableId": "VariableID:7:2"
+          }
+        },
+        "$type": "dimension",
+        "$value": 0
+      },
+      "1": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 1
+              }
+            },
+            "variableId": "VariableID:7:3"
+          }
+        },
+        "$type": "dimension",
+        "$value": 1
+      },
+      "2": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 2
+              }
+            },
+            "variableId": "VariableID:7:4"
+          }
+        },
+        "$type": "dimension",
+        "$value": 2
+      },
+      "4": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 4
+              }
+            },
+            "variableId": "VariableID:7:5"
+          }
+        },
+        "$type": "dimension",
+        "$value": 4
+      },
+      "6": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 6
+              }
+            },
+            "variableId": "VariableID:7:6"
+          }
+        },
+        "$type": "dimension",
+        "$value": 6
+      },
+      "8": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 6
+              }
+            },
+            "variableId": "VariableID:7:7"
+          }
+        },
+        "$type": "dimension",
+        "$value": 6
+      },
+      "10": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 8
+              }
+            },
+            "variableId": "VariableID:7:8"
+          }
+        },
+        "$type": "dimension",
+        "$value": 8
+      },
+      "12": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 10
+              }
+            },
+            "variableId": "VariableID:7:9"
+          }
+        },
+        "$type": "dimension",
+        "$value": 10
+      },
+      "16": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 12
+              }
+            },
+            "variableId": "VariableID:7:10"
+          }
+        },
+        "$type": "dimension",
+        "$value": 12
+      },
+      "20": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 16
+              }
+            },
+            "variableId": "VariableID:7:11"
+          }
+        },
+        "$type": "dimension",
+        "$value": 16
+      },
+      "24": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 20
+              }
+            },
+            "variableId": "VariableID:7:12"
+          }
+        },
+        "$type": "dimension",
+        "$value": 20
+      },
+      "28": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 28
+              }
+            },
+            "variableId": "VariableID:7:13"
+          }
+        },
+        "$type": "dimension",
+        "$value": 28
+      },
+      "32": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 24
+              }
+            },
+            "variableId": "VariableID:7:14"
+          }
+        },
+        "$type": "dimension",
+        "$value": 24
+      },
+      "36": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 36
+              }
+            },
+            "variableId": "VariableID:7:15"
+          }
+        },
+        "$type": "dimension",
+        "$value": 36
+      },
+      "40": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 32
+              }
+            },
+            "variableId": "VariableID:7:16"
+          }
+        },
+        "$type": "dimension",
+        "$value": 32
+      },
+      "48": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 40
+              }
+            },
+            "variableId": "VariableID:7:17"
+          }
+        },
+        "$type": "dimension",
+        "$value": 40
+      },
+      "56": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 56
+              }
+            },
+            "variableId": "VariableID:7:18"
+          }
+        },
+        "$type": "dimension",
+        "$value": 56
+      },
+      "64": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 52
+              }
+            },
+            "variableId": "VariableID:7:19"
+          }
+        },
+        "$type": "dimension",
+        "$value": 52
+      },
+      "80": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 64
+              }
+            },
+            "variableId": "VariableID:7:20"
+          }
+        },
+        "$type": "dimension",
+        "$value": 64
+      },
+      "120": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 80
+              }
+            },
+            "variableId": "VariableID:7:21"
+          }
+        },
+        "$type": "dimension",
+        "$value": 80
+      },
+      "160": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 120
+              }
+            },
+            "variableId": "VariableID:7:22"
+          }
+        },
+        "$type": "dimension",
+        "$value": 120
+      },
+      "200": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 160
+              }
+            },
+            "variableId": "VariableID:7:23"
+          }
+        },
+        "$type": "dimension",
+        "$value": 160
+      }
+    },
+    "section-gap": {
+      "40": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.40}"
+              }
+            },
+            "variableId": "VariableID:7:31"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.40}"
+      },
+      "64": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.64}"
+              }
+            },
+            "variableId": "VariableID:7:30"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.64}"
+      },
+      "80": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:4",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "reference": "{scale.80}"
+              }
+            },
+            "variableId": "VariableID:7:29"
+          }
+        },
+        "$type": "dimension",
+        "$value": "{scale.80}"
+      }
+    }
+  },
+  "typography": {
+    "$extensions": {
+      "figma-console-mcp": {
+        "figmaCollectionId": "VariableCollectionId:2:6",
+        "originalName": "Typography"
+      }
+    },
+    "family": {
+      "base": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "Pretendard Variable"
+              }
+            },
+            "variableId": "VariableID:24:23"
+          }
+        },
+        "$type": "string",
+        "$value": "Pretendard Variable"
+      },
+      "secondary": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": "Noto Serif KR"
+              }
+            },
+            "variableId": "VariableID:24:24"
+          }
+        },
+        "$type": "string",
+        "$value": "Noto Serif KR"
+      }
+    },
+    "letter-spacing": {
+      "body": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": -0.30000001192092896
+              }
+            },
+            "variableId": "VariableID:24:52"
+          }
+        },
+        "$type": "dimension",
+        "$value": -0.30000001192092896
+      },
+      "heading": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": -1.5
+              }
+            },
+            "variableId": "VariableID:24:53"
+          }
+        },
+        "$type": "dimension",
+        "$value": -1.5
+      },
+      "tight": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": -1
+              }
+            },
+            "variableId": "VariableID:24:54"
+          }
+        },
+        "$type": "dimension",
+        "$value": -1
+      },
+      "wide": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 1
+              }
+            },
+            "variableId": "VariableID:24:55"
+          }
+        },
+        "$type": "dimension",
+        "$value": 1
+      },
+      "wider": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 2
+              }
+            },
+            "variableId": "VariableID:24:56"
+          }
+        },
+        "$type": "dimension",
+        "$value": 2
+      }
+    },
+    "line-height": {
+      "base": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 150
+              }
+            },
+            "variableId": "VariableID:24:49"
+          }
+        },
+        "$type": "dimension",
+        "$value": 150
+      },
+      "loose": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 180
+              }
+            },
+            "variableId": "VariableID:24:51"
+          }
+        },
+        "$type": "dimension",
+        "$value": 180
+      },
+      "normal": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 145
+              }
+            },
+            "variableId": "VariableID:24:48"
+          }
+        },
+        "$type": "dimension",
+        "$value": 145
+      },
+      "relaxed": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 160
+              }
+            },
+            "variableId": "VariableID:24:50"
+          }
+        },
+        "$type": "dimension",
+        "$value": 160
+      },
+      "reset": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 100
+              }
+            },
+            "variableId": "VariableID:24:45"
+          }
+        },
+        "$type": "dimension",
+        "$value": 100
+      },
+      "snug": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 135
+              }
+            },
+            "variableId": "VariableID:24:47"
+          }
+        },
+        "$type": "dimension",
+        "$value": 135
+      },
+      "tight": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 130
+              }
+            },
+            "variableId": "VariableID:24:46"
+          }
+        },
+        "$type": "dimension",
+        "$value": 130
+      }
+    },
+    "size": {
+      "11": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 11
+              }
+            },
+            "variableId": "VariableID:24:29"
+          }
+        },
+        "$type": "dimension",
+        "$value": 11
+      },
+      "12": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 12
+              }
+            },
+            "variableId": "VariableID:24:30"
+          }
+        },
+        "$type": "dimension",
+        "$value": 12
+      },
+      "13": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 13
+              }
+            },
+            "variableId": "VariableID:24:31"
+          }
+        },
+        "$type": "dimension",
+        "$value": 13
+      },
+      "14": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 14
+              }
+            },
+            "variableId": "VariableID:24:32"
+          }
+        },
+        "$type": "dimension",
+        "$value": 14
+      },
+      "15": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 15
+              }
+            },
+            "variableId": "VariableID:24:33"
+          }
+        },
+        "$type": "dimension",
+        "$value": 15
+      },
+      "16": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 16
+              }
+            },
+            "variableId": "VariableID:24:34"
+          }
+        },
+        "$type": "dimension",
+        "$value": 16
+      },
+      "18": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 18
+              }
+            },
+            "variableId": "VariableID:24:35"
+          }
+        },
+        "$type": "dimension",
+        "$value": 18
+      },
+      "20": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 20
+              }
+            },
+            "variableId": "VariableID:24:36"
+          }
+        },
+        "$type": "dimension",
+        "$value": 20
+      },
+      "22": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 22
+              }
+            },
+            "variableId": "VariableID:24:37"
+          }
+        },
+        "$type": "dimension",
+        "$value": 22
+      },
+      "24": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 24
+              }
+            },
+            "variableId": "VariableID:24:38"
+          }
+        },
+        "$type": "dimension",
+        "$value": 24
+      },
+      "26": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 26
+              }
+            },
+            "variableId": "VariableID:24:39"
+          }
+        },
+        "$type": "dimension",
+        "$value": 26
+      },
+      "28": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 28
+              }
+            },
+            "variableId": "VariableID:24:40"
+          }
+        },
+        "$type": "dimension",
+        "$value": 28
+      },
+      "32": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 32
+              }
+            },
+            "variableId": "VariableID:24:41"
+          }
+        },
+        "$type": "dimension",
+        "$value": 32
+      },
+      "34": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 34
+              }
+            },
+            "variableId": "VariableID:24:42"
+          }
+        },
+        "$type": "dimension",
+        "$value": 34
+      },
+      "36": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 36
+              }
+            },
+            "variableId": "VariableID:24:43"
+          }
+        },
+        "$type": "dimension",
+        "$value": 36
+      },
+      "42": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 42
+              }
+            },
+            "variableId": "VariableID:24:44"
+          }
+        },
+        "$type": "dimension",
+        "$value": 42
+      }
+    },
+    "weight": {
+      "bold": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.001Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 700
+              }
+            },
+            "variableId": "VariableID:24:28"
+          }
+        },
+        "$type": "fontWeight",
+        "$value": 700
+      },
+      "medium": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 500
+              }
+            },
+            "variableId": "VariableID:24:26"
+          }
+        },
+        "$type": "fontWeight",
+        "$value": 500
+      },
+      "regular": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 400
+              }
+            },
+            "variableId": "VariableID:24:25"
+          }
+        },
+        "$type": "fontWeight",
+        "$value": 400
+      },
+      "semibold": {
+        "$extensions": {
+          "figma-console-mcp": {
+            "collectionId": "VariableCollectionId:2:6",
+            "lastSyncedAt": "2026-06-13T12:01:37.000Z",
+            "lastSyncedValue": {
+              "Value": {
+                "literal": 600
+              }
+            },
+            "variableId": "VariableID:24:27"
+          }
+        },
+        "$type": "fontWeight",
+        "$value": 600
+      }
+    }
+  }
+}

--- a/docs/exec-plans/active/2026-06-13-ds-token-sync-pipeline.md
+++ b/docs/exec-plans/active/2026-06-13-ds-token-sync-pipeline.md
@@ -1,0 +1,135 @@
+# ds-token-sync-pipeline
+
+- **상태**: 🟢 검증 통과 (커밋 승인 대기)
+- **시작일**: 2026-06-13
+- **브랜치**: feat/ds-figma-sync
+- **Open questions**: 유료 Code Connect 전환은 PoC 후 판단 (ADR 0017)
+- **ADR needed**: no — 방향 결정은 ADR 0017, 본 task는 그 첫 실행(토큰 싱크)만
+
+## 목표
+
+Figma와 코드 토큰을 명령 한 번으로 맞추는 파이프라인을 만든다. figma-console MCP의 `figma_export_tokens`로 Figma 변수를 DTCG(Design Tokens Community Group 표준 JSON) 피벗으로 뽑고, 같은 도구의 dry-run으로 두 곳 차이를 건수로 본다. 손으로 쓴 `src/styles/tokens/*`는 건드리지 않는다.
+
+## 검증된 Assumptions
+
+- figma-console MCP가 `figma_export_tokens`(출력 `dtcg`·`scss`·`css-vars`)와 `figma_import_tokens`(입력 `dtcg` 완전 지원, `scss` 입력은 NotImplementedError)를 제공한다 — ToolSearch로 두 도구 스키마 확인.
+- Figma 파일에 변수 174개가 5개 컬렉션(Primitives 28·Color 61·Spacing 30·Radius 21·Typography 34)에 있고 컬렉션마다 모드 1개다 — `figma_get_variables(format=summary)` 호출 결과.
+- `src/styles/tokens/*`는 손으로 쓴 파일이고 믹스인·heading 맵·반응형 vw 맵·`rgba()` 합성을 담는다. 이들은 Figma 변수로 표현되지 않는다 — `.claude/skills/styles/SKILL.md` 읽음.
+- figma-console 브리지는 Figma 데스크톱 + 플러그인이 켜져 있어야 동작한다(WebSocket port 9224) — `figma_get_status(probe=true)` 응답 `success:true`.
+
+> probe 결과(2026-06-13 step 1·4): `figma_export_tokens` 무인자·dry-run 호출은 `src/styles/tokens/`를 안 쓴다 — `git diff` 0줄, 루트 `tokens.tokens.json` 미생성으로 확인. `strategy:dry-run`+`format:scss` 조합도 작동(Codex CR #2 해소). 토큰 174개는 응답 collections 합으로 확정.
+
+## Success Criteria
+
+- `figma_export_tokens` 무인자 호출이 `src/styles/tokens/*`를 안 쓴다 — `git status` 깨끗. ✅
+- `tokens.config.json`이 레포 루트에 있고, 무인자 export가 `docs/design-system/tokens.tokens.json`(도구 기본 파일명)을 실제 생성한다. ✅
+- DTCG 산출물에 토큰 174개가 전부 들어간다 — `grep -c '"$value"'` = 174. ✅
+- 드리프트 건수를 얻어 `docs/references/figma-token-sync.md`에 적는다 — 비교 41개 중 값 드리프트 0건(40 일치 + `$white` `#fff`=`#FFFFFF` 1 값-동일). ✅
+- 동기화 절차 + SoT 경계 문서가 "Figma 소유 174 vs SCSS 전용(믹스인·맵·반응형·rgba)"을 목록으로 적는다. ✅
+- 모든 단계 뒤 `git diff --stat src/styles/tokens/`가 빈 결과. ✅
+
+## 영향받는 파일
+
+- `tokens.config.json` (신규 — export/import config)
+- `docs/design-system/tokens.tokens.json` (신규 — Figma에서 뽑은 DTCG 피벗, 생성물 78KB)
+- `docs/references/figma-token-sync.md` (신규 — 동기화 절차 + SoT 경계 + 드리프트 베이스라인 + 텍스트·이펙트 스타일 스펙)
+- `.gitignore` (수정 — Codex 1차 검증 후 `docs/research/figma-ds-*` 커밋 차단 1줄)
+
+## Non-goals
+
+- `src/styles/tokens/*` 재생성·덮어쓰기 — 손으로 쓴 SCSS를 보존한다.
+- ui/ 컴포넌트 변경, Button `loading` prop·MetaList·SectionHeader·Toast 승격 — 후속 task.
+- 디자인투코드(Figma 디자인을 코드로 생성) 생성 PoC — 후속(스텁 페이지 1곳).
+- 유료 Code Connect 설정 — ADR 0017 open question.
+
+## 단계별 체크리스트
+
+- [x] 1. **쓰기 안전성 probe** — `figma_export_tokens` 무인자 호출. `suggestedScaffold` 반환 + 파일 미작성 확인. ✅ 2026-06-13
+- [x] 2. `tokens.config.json` 작성 — `source`/`generated.dir` 둘 다 `docs/design-system`(비파괴), `formats:[dtcg]`, mode `Value`. ✅
+- [x] 3. `figma_export_tokens`(무인자, config 읽음) → `docs/design-system/tokens.tokens.json` 생성. `$value` 174개 확인. `git diff src/styles/tokens/` 0줄. ✅
+- [x] 4. **드리프트 점검** — `figma_export_tokens(strategy:dry-run, format:scss)` 작동 확인. scss를 임시 파일로 뽑아 소스와 같은 이름 raw-hex 41개 비교 → 값 드리프트 0건. 임시 파일 제거. ✅
+- [x] 5. `docs/references/figma-token-sync.md`에 드리프트 베이스라인 + 동기화 절차 + SoT 경계 작성. ✅
+- [x] 6. `node scripts/verify-task.mjs` + `git diff --stat src/styles/tokens/` 빈 결과. ✅
+
+## Verification
+
+- `node scripts/verify-task.mjs ds-token-sync-pipeline` — run-id `20260613-210708`. ESLint·stylelint·Build 통과. Knip 경고는 기존 부채(15 unused files 등)이고 신규 파일은 미포함.
+- 드리프트 건수는 `docs/references/figma-token-sync.md`에 수기 기록. verify-task는 그 숫자를 검사하지 않는다.
+
+## ADR 판단
+
+- ADR needed: no — Figma-SoT 디자인투코드 방향 결정은 ADR 0017에 기록함. 본 task는 `tokens.config.json`·`docs/` 신규 파일만 추가하는 그 실행 단계다.
+
+## 의사결정 로그
+
+- **D1 — DTCG 피벗을 `docs/design-system/`에 두고 도구 기본 파일명을 받아들임**
+  - 문제: figma-console가 제안한 scaffold는 `source.dir`을 `src/styles/tokens`(손으로 쓴 SCSS 자리)로, 출력 파일명을 `tokens.tokens.json`으로 잡는다. 그대로 쓰면 SCSS를 덮어쓸 위험이 있고, 계획서엔 `tokens.dtcg.json`으로 적었다.
+  - 해결: `source.dir`·`generated.dir`을 둘 다 `docs/design-system`으로 돌려 비파괴를 보장했다. 파일명은 도구 기본값 `tokens.tokens.json`을 받아들였다 — 이유: 무인자 export가 같은 이름으로 재생성하므로 도구와 싸우지 않는 편이 재동기화가 단순하다. 계획서 표기를 실제 파일명으로 맞췄다.
+  - 결과: `docs/design-system/tokens.tokens.json` 1개가 정본. `git diff src/styles/tokens/` 0줄로 비파괴 확인.
+- **D2 — `docs/research/figma-ds-*`를 `.gitignore`에 추가 (Codex 1차 검증 지적)**
+  - 문제: Figma 빌드 메모 2개가 `.gitignore`에 없어 `git add -A` 한 번에 커밋될 위험. 커밋 금지 규칙이 메모리에만 있고 기계로 안 막혔다.
+  - 해결: `docs/research/` 전체 차단은 이미 추적 중인 9개(README·perf-optimize 등)와 충돌이라 불가 → `docs/research/figma-ds-*`만 차단. 이유: 추적 파일은 그대로 두고 figma 빌드 메모 2개만 막아야 한다.
+  - 결과: `git check-ignore`로 2개 차단 확인, 추적 파일 9개 영향 0. git status가 task 파일만 남음.
+- **D3 — 텍스트·이펙트 스타일 스펙을 로컬 메모에서 버전 관리 문서로 옮김 (사용자 요청)**
+  - 문제: 텍스트 스타일 12·이펙트 스타일 4 스펙이 `docs/research/figma-ds-token-mapping.md`(커밋 제외)에만 있었다. DTCG export는 변수만 담아 이 스타일들을 안 잡는다.
+  - 해결: 스펙 표를 `docs/references/figma-token-sync.md`로 옮겨 버전 관리에 넣었다. 이유: 변수가 아닌 Figma 자산이라 토큰 피벗으로는 다시 뽑을 수 없다 — repo에 남겨야 한다. `docs/research` 메모는 gitignore 유지.
+  - 결과: 스타일 스펙이 버전 관리 문서에 남음. `docs/research` 메모는 로컬 스크래치로만 둔다.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST → 4건 반영 후 WORK 진입. dry-run 쓰기 안전성을 step 1 probe로 확인, `dry-run`+`scss` 폴백 명시(step 4), 드리프트 기록을 `docs/references/figma-token-sync.md`로 지정, `tokens.config.json` 출력 경로 명시.
+- **현재 판단**: 4건 모두 실측으로 해소됨 — probe·드리프트 점검이 가정 아닌 실제 호출로 통과.
+- **다음 행동**: 없음 (WORK·VERIFY 완료).
+
+## Codex 1차 검증
+
+- **결론**: CHANGE_REQUEST → 1건 해소. `docs/research/figma-ds-*` 2개가 `.gitignore`에 없어 `git add -A`로 커밋될 위험 → 특정 패턴으로 차단(`git check-ignore` 확인). config·생성물 커밋·외과적 변경은 통과.
+- **현재 판단**: 앱 코드 변경 0건이라 버그·타입·레이어 지적은 없음. 유일한 material은 커밋 위생(research 파일)이었고 해소함.
+- **다음 행동**: 없음 (커밋 승인 대기).
+
+## Claude 2차 검증
+
+- **최종 판단**: 통과 — 신규 파일만 추가, `src/styles/tokens/` 0줄, 필수 검증 회귀 0.
+- **현재 판단**: 아래 표. Knip 경고는 기존 부채이고 본 task 파일은 미포함(`grep tokens.config|design-system` 0 hit).
+- **다음 행동**: 커밋 승인 요청.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260613-210708 | ✅ | ✅ | ✅ | 0 | — |
+
+## 검증 이력
+
+<details>
+<summary>2026-06-13 Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST (confidence high)
+- 이유: `figma_export_tokens` 동작(dry-run 무쓰기·`dry-run`+`scss` 조합·드리프트 산출물 위치·config 출력 경로)이 가정만 있고 미확인.
+- 조치: 체크리스트 1·4 재구성(probe+폴백), SC·Verification에 기록 위치·검증 범위 명시. WORK에서 4건 모두 실측 해소.
+
+</details>
+
+<details>
+<summary>2026-06-13 Codex 1차 검증 (구현)</summary>
+
+- 판정: CHANGE_REQUEST (confidence high)
+- 이유: `docs/research/figma-ds-*` 2개가 `.gitignore` 미등록 — `git add -A` 시 커밋 위험.
+- 조치: `.gitignore`에 `docs/research/figma-ds-*` 추가. config·생성물 커밋·외과적 변경은 통과 판정.
+
+</details>
+
+## 후속 작업
+
+- ui/ 카탈로그 정비 (C-1 폼 단일화 · C-2 SearchField/Select 신설 · C-3 ADR 0014 부품 추출)
+  - 이유: 토큰 파이프라인을 먼저 깔아야 토큰 변경이 Figma에 흘러간다.
+  - 다음 기준: 본 task 머지 후 `start-task.mjs`로 `ds-ui-catalog-refit` slug 생성.
+  - 기록 위치: ADR 0017 ## Decision 이식 전략 행
+- 디자인투코드 PoC (스텁 페이지 1곳, 예: community 게시판)
+  - 이유: ui/ 카탈로그가 매핑 타겟으로 정비된 뒤에 의미가 있다.
+  - 다음 기준: C-1~C-3 일부 완료 후.
+  - 기록 위치: ADR 0017 ## Decision 이식 전략 행
+- semantic 토큰 이름 매핑 자동 드리프트 비교 (Figma resolved-hex ↔ 소스 alias)
+  - 이유: 이번엔 raw-hex 41개만 자동 비교. semantic 16개는 소스가 alias라 빠짐.
+  - 다음 기준: 드리프트가 실제로 생기기 시작할 때(Phase C 토큰 추가 후).
+  - 기록 위치: 없음

--- a/docs/references/figma-token-sync.md
+++ b/docs/references/figma-token-sync.md
@@ -1,0 +1,81 @@
+# Figma ↔ 코드 토큰 동기화
+
+ADR 0017(Figma-SoT 디자인투코드, Path Free)의 토큰 동기화 절차다. Style Dictionary·Tokens Studio가 하던 export를 figma-console MCP로 처리한다. 설정은 레포 루트 `tokens.config.json`, 피벗은 `docs/design-system/tokens.tokens.json`(DTCG).
+
+## SoT(source of truth, 기준 원본) 경계 — Figma가 가진 것 vs 코드가 가진 것
+
+디자인 레이어만 Figma가 기준이다. 행위·반응형·함수는 코드에만 정의한다.
+
+| 구분 | 항목 | 위치 |
+| --- | --- | --- |
+| **Figma 소유 (174)** | 색 primitive 28(hex), 색 semantic 61(alias 32 + raw 29), spacing 30, radius 21, typography 34 | Figma 변수 → `docs/design-system/tokens.tokens.json` |
+| **Figma 소유 (스타일 16)** | 텍스트 스타일 12 + 이펙트(그림자) 4 — 변수가 아닌 별도 스타일 | DTCG 미포함 → 아래 "텍스트·이펙트 스타일" 절 |
+| **코드 전용** | 믹스인(`hover-bg-shift`·`text-card-title` 등), heading size 맵, `$responsive-font-vw-map`, `rgba()` 합성, breakpoint·z-index·container·고정 높이, semantic alias의 warm/cool 역할 | `src/styles/tokens/*`, `src/styles/_mixins.scss` |
+
+Figma 변수로 표현되지 않는 것 (코드에서만 정의):
+
+- 가로·세로 쌍을 한 토큰에 담는 `$padding-*`
+- 투명도 합성 `rgba($navy-800, 0.06)`
+- 미디어쿼리 분기
+
+## 명령 (Claude + figma-console MCP, Figma 데스크톱 켜둔 상태)
+
+```
+# Figma → 코드 : DTCG 피벗 생성 (Path Free 기본)
+figma_export_tokens                         # 무인자, tokens.config.json 읽어 docs/design-system/tokens.tokens.json 씀
+
+# 드리프트 점검 : 값 비교만, 파일 안 씀
+figma_export_tokens(strategy=dry-run, format=scss)   # 컬렉션별 토큰 수 + scss 미리보기
+
+# 코드 → Figma : 값 변경만 자동 (후속)
+figma_import_tokens(format=dtcg, dryRun=true)        # diff 미리보기 → dryRun=false로 적용
+# 신규 토큰 추가는 figma_setup_design_tokens / figma_batch_create_variables (반자동)
+```
+
+## 제약
+
+- figma-console 브리지는 Figma 데스크톱 + 플러그인이 켜져 있어야 동작한다(WebSocket port 9224). CI에서 자동으로 못 돌리고 로컬에서 손으로 실행한다.
+- `figma_import_tokens`는 기존 토큰 **값 변경**만 적용한다. **신규 토큰 추가**(예: Phase C의 `red-700`)는 `figma_setup_design_tokens`로 따로 만든다.
+- DTCG 입력만 완전 지원한다. scss 입력은 `NotImplementedError`다.
+
+## 드리프트 베이스라인 (2026-06-13)
+
+- 방법: `figma_export_tokens(format=scss)`로 Figma 값을 뽑아 `src/styles/tokens/*`와 같은 이름 raw-hex 토큰을 값 비교.
+- 결과: 비교 대상 41개 중 40개 정확 일치, 1개 값-동일(`$white`: Figma `#FFFFFF` = 소스 `#fff`). **값 드리프트 0건.**
+- semantic 16개는 Figma가 hex로 해석하고 소스는 alias(`$txt-primary: $gray-900`)라 자동 비교에서 빠진다. 이름 매핑 자동 비교는 후속 과제.
+
+## 텍스트·이펙트 스타일 — DTCG 미포함
+
+`figma_export_tokens`는 변수 174개만 뽑는다. Figma의 텍스트 스타일 12종과 이펙트 스타일 4종은 변수가 아니라 별도 스타일이다. 그래서 DTCG에 안 들어간다. 코드 기준 원본은 `_typography.scss`·`_effect.scss`이고, 아래는 Figma에 만든 스타일 스펙이다(모바일 값, 2026-06-13 `figma_get_text_styles`로 확인).
+
+### 텍스트 스타일 12종
+
+family는 Pretendard(정적 설치), 인용만 Noto Serif KR. lineHeight 단위 PERCENT, letterSpacing PIXELS.
+
+| 스타일 | family / style | size | lineHeight | letterSpacing |
+| --- | --- | --- | --- | --- |
+| Heading/H1 | Pretendard / Bold | 32 | 130% | -1 |
+| Heading/H2 | Pretendard / Bold | 26 | 130% | -0.5 |
+| Heading/H3 | Pretendard / Bold | 22 | 135% | -0.3 |
+| Heading/H4 | Pretendard / SemiBold | 20 | 145% | -0.3 |
+| Heading/H5 | Pretendard / SemiBold | 18 | 150% | -0.3 |
+| Body/Default | Pretendard / Regular | 15 | 150% | -0.3 |
+| Body/Reading | Pretendard / Regular | 15 | 160% | -0.3 |
+| Body/Prose | Pretendard / Regular | 15 | 180% | -0.3 |
+| Body/UI | Pretendard / Medium | 14 | 145% | -0.3 |
+| Label/Caption | Pretendard / Regular | 13 | 145% | -0.3 |
+| Label/Small | Pretendard / Medium | 12 | 145% | 1 |
+| Quote/Serif | Noto Serif KR / Regular | 18 | 160% | -0.3 |
+
+> 데스크톱 heading은 코드에서 더 크다(h1 42 / h2 34 / h3 28 / h4 24 / h5 20). Figma는 모드 1개라 모바일 값만 담는다.
+
+### 이펙트(그림자) 스타일 4종
+
+전부 DROP_SHADOW, 색은 `rgba($gray-900, a)`(gray-900 = #111827). offset x는 0.
+
+| 스타일 | 레이어 (offset y · blur · spread · alpha) | 코드 |
+| --- | --- | --- |
+| Shadow/sm | (y1) blur3 spread0 a0.06 | `$shadow-sm` |
+| Shadow/md | (y3) blur8 spread-1 a0.08 + (y1) blur3 spread-1 a0.06 | `$shadow-md` |
+| Shadow/lg | (y6) blur16 spread-2 a0.10 + (y2) blur6 spread-2 a0.06 | `$shadow-lg` |
+| Shadow/xl | (y8) blur32 spread0 a0.12 + (y4) blur16 spread0 a0.08 | `$shadow-xl` |

--- a/docs/references/figma-token-sync.md
+++ b/docs/references/figma-token-sync.md
@@ -44,6 +44,15 @@ figma_import_tokens(format=dtcg, dryRun=true)        # diff 미리보기 → dry
 - 결과: 비교 대상 41개 중 40개 정확 일치, 1개 값-동일(`$white`: Figma `#FFFFFF` = 소스 `#fff`). **값 드리프트 0건.**
 - semantic 16개는 Figma가 hex로 해석하고 소스는 alias(`$txt-primary: $gray-900`)라 자동 비교에서 빠진다. 이름 매핑 자동 비교는 후속 과제.
 
+## 알려진 한계 (export 데이터 품질, 2026-06-14)
+
+PR #118 자동 리뷰(Gemini·Codex)가 짚은 점이다. 이 DTCG 피벗은 아직 정본(canonical)이나 재import 원본으로 쓰지 못한다. 지금 쓰임은 색 드리프트 점검과 참조까지다.
+
+- **숫자 scale 토큰 이름↔값 불일치 (spacing·radius)**: 생성된 `tokens.tokens.json`에서 `spacing.scale.32`의 값이 24, `radius.scale.40`의 값이 32처럼 키 이름과 값이 어긋난다. radius·spacing 두 컬렉션에서 같이 나타난다. 원인은 아직 못 정했다. 후보 둘 — (a) figma-console export의 직렬화 문제 (b) Figma 변수 자체의 값. figma-console 재연결 뒤 `figma_get_variables`로 Figma 원본 값을 직접 대조해 가린다. 색 토큰은 영향이 없다(위 드리프트 베이스라인 0건). 손으로 쓴 `src/styles/tokens/*`도 무관하다.
+- **DTCG alias 경로 미해결 (47건)**: `$value`가 `{gold.600}`인데 실제 primitive는 `primitives.gold.600`에 있다. figma-console 자체 왕복(export↔import)이 이를 푸는지는 확인하지 않았다. 표준 DTCG/Style Dictionary resolver에 그대로 넣으면 미해결로 남는다. 외부 resolver나 재import 원본으로 쓰기 전에 해석 동작을 확인한다.
+
+> `tokens.config.json`의 `"canonical": "dtcg"`는 디자인 레이어 기준 원본을 DTCG로 옮기겠다는 목표를 적은 것이지, 지금 이 파일이 정본으로 검증됐다는 뜻이 아니다. 위 두 한계를 풀기 전까지는 색 드리프트 점검·참조로만 쓴다.
+
 ## 텍스트·이펙트 스타일 — DTCG 미포함
 
 `figma_export_tokens`는 변수 174개만 뽑는다. Figma의 텍스트 스타일 12종과 이펙트 스타일 4종은 변수가 아니라 별도 스타일이다. 그래서 DTCG에 안 들어간다. 코드 기준 원본은 `_typography.scss`·`_effect.scss`이고, 아래는 Figma에 만든 스타일 스펙이다(모바일 값, 2026-06-13 `figma_get_text_styles`로 확인).

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -329,3 +329,15 @@
 - **마이그레이션 경로**: `sermons/all/page.tsx`에 `isUnknownPreacher`(원문 `preacher`가 있는데 `allPreachers`에 없음) 가드를 추가해 `isUnknownSeries`와 같은 EmptyState로 떨어뜨린다.
 - **영향 범위**: `src/app/(content)/sermons/all/page.tsx`, `src/utils/sermon.ts`
 - **발견일**: 2026-06-11 (PR #113 Codex 1차 검증)
+
+### 🟢 figma-console DTCG export — 숫자 scale 이름↔값 불일치 + alias 미해결 (figma-sync PR #118)
+
+- **상태**: 등록만 (figma-console 재연결 후 규명 — Figma 근본 디자인 시스템 개선 → 코드 이식 작업 때)
+- **무엇**: `docs/design-system/tokens.tokens.json`(Figma→DTCG 피벗)에 두 가지가 있다. ① 숫자 scale 토큰의 이름과 값이 어긋난다 — `spacing.scale.32`=24, `radius.scale.40`=32 등, spacing·radius 두 컬렉션에서 같이 나타난다. ② `$value`가 `{gold.600}` 형태인데 실제 primitive는 `primitives.gold.600`에 있어 alias 47개가 표준 DTCG resolver에서 미해결로 남는다. PR #118 자동 리뷰(Gemini·Codex)가 지적, Claude 교차 검증으로 확인.
+- **왜 지금 안 하나**: 손으로 쓴 `src/styles/tokens/*`는 그대로라 앱이 무관하고, 색 드리프트 점검(raw-hex 41개 0건)도 유효하다. 이 피벗을 정본·재import 원본으로 쓰기 전까지는 막지 않는다. 원인(export 직렬화 문제 vs Figma 변수 값)을 가리려면 figma-console 재연결이 필요한데 지금 끊겨 있다.
+- **마이그레이션 경로**:
+  - ① figma-console 재연결 후 `figma_get_variables`로 Figma 원본 spacing·radius 값을 직접 읽어 export 결과와 대조한다. export 버그면 도구 쪽을 우회·설정하고, Figma 값 문제면 Figma를 고친다.
+  - ② alias는 `figma_import_tokens` 왕복이 `{gold.600}`을 푸는지 확인한다. 외부 resolver를 붙일 거면 `primitives.` 접두 경로로 정규화한다.
+- **영향 범위** (2건): `docs/design-system/tokens.tokens.json`(생성물 — 손으로 고치지 말 것) / figma-console export 설정. 앱(`src/`) 무관
+- **확인**: `git show feat/ds-figma-sync:docs/design-system/tokens.tokens.json` → spacing.scale(약 1911행)·radius.scale(약 1547행)에서 키↔`$value` 대조
+- **발견일**: 2026-06-14 (PR #118 Gemini·Codex 자동 리뷰 + Claude 교차 검증)

--- a/tokens.config.json
+++ b/tokens.config.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://figma-console-mcp.southleft.com/schemas/tokens.config.v1.json",
+  "source": {
+    "dir": "docs/design-system",
+    "canonical": "dtcg"
+  },
+  "generated": {
+    "dir": "docs/design-system",
+    "formats": [
+      { "format": "dtcg" }
+    ]
+  },
+  "conflictResolution": "ask"
+}


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 디자인 시스템의 값 출처(SoT, Source of Truth)를 Figma로 옮기는 방향을 ADR로 확정하고, Figma 변수를 코드 토큰으로 내려받는 동기화 파이프라인을 비파괴로 깔았습니다.

**범위**:

- 디자인 SoT 전환 결정 기록 — ADR 0017 등록 + 인덱스 1줄
- Figma 변수 174개를 DTCG 표준 형식(Design Tokens Community Group)으로 추출하는 export/import 설정과 추출물
- 동기화 절차·SoT 경계·드리프트 기준값을 적은 참조 문서

---

## 🔗 개발 컨텍스트

- **Task ID**: `ds-token-sync-pipeline`
- **Exec Plan**: N/A (ADR 중심 작업)
- **관련 ADR**: `docs/decisions/0017-figma-sot-design-to-code.md` (이 PR에서 등록)
- **관련 tech debt**: 해당 없음
- **작업 범위**: 방향 결정(ADR) + Figma→코드 토큰 추출·비교 파이프라인 구축. 무료 경로(Path Free) PoC만.
- **제외한 범위**: `src/styles/tokens/*` SCSS는 한 줄도 고치지 않음. 유료 경로(Code Connect) 도입은 PoC 효과 확인 후 별도 판단.

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제 / 목적:**

색상·간격 같은 디자인 값을 Figma에서 정하는데, 코드 토큰과 Figma가 따로 놀았습니다. 두 곳이 어긋나도 잡아낼 방법이 없었고, 어느 쪽이 정답인지도 합의되지 않았습니다. 이 PR은 (1) "디자인 값은 Figma가 정답"이라는 경계를 ADR로 못 박고, (2) Figma 변수를 코드로 내려받아 두 곳의 차이를 자동으로 비교하는 첫 파이프라인을 만듭니다.

**관련 이슈:**

- Issue: #

---

## 🔧 주요 변경점 (Key Changes)

- `docs/decisions/0017-figma-sot-design-to-code.md` 신규 — 디자인 SoT를 디자인 레이어 한정으로 Figma에 두는 결정. `docs/decisions/README.md`에 인덱스 1줄 추가.
- `tokens.config.json` 신규 (루트) — figma-console의 토큰 export/import 설정. 추출 대상·출력 경로만 정의하고 코드 토큰은 덮어쓰지 않는 비파괴 설정.
- `docs/design-system/tokens.tokens.json` 신규 — Figma 변수 174개를 DTCG 피벗 형식으로 추출한 생성물 (78KB / 2878줄).
- `docs/references/figma-token-sync.md` 신규 — 동기화 절차, SoT 경계 정의, 드리프트 기준값, 텍스트 스타일 12종·이펙트 스타일 4종 스펙.
- `.gitignore` +4줄 — `docs/research/figma-ds-*` 일회성 산출물을 커밋에서 차단.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

이 PR의 핵심은 "어떻게 만들었나"보다 "왜 이 방향인가"입니다. 결정에 이르기까지 의견이 두 번 뒤집혔습니다.

**의사결정 흐름:**

1. 처음엔 코드를 SoT로 권했습니다. 무료 Figma는 컬렉션당 모드가 1개뿐이라 반응형·다크 모드를 변수로 담지 못하기 때문입니다.
2. 사용자가 반론했습니다 — 코드가 더 자주 바뀌고, 색·간격 결정은 실제로 Figma에서 한다.
3. 레이어별로 SoT를 나눠 절충했습니다. 디자인 값·시각 스펙은 Figma, 행위·반응형·믹스인은 코드.
4. Fast Campus 강의로 방법론을 대조했습니다. Figma→코드 + Code Connect가 주류였으나, 공식 Dev MCP는 Starter 플랜 월 6회 제한, Code Connect는 조직(Org) 유료였습니다.
5. 그래서 비용 0인 무료 경로(Path Free)부터 검증하기로 했습니다.

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 디자인 시스템 SoT 위치 | 디자인 레이어 한정으로 Figma | - 색·간격 결정을 실제로 Figma에서 함<br/>- Figma→코드(디자인투코드) 방향이 사용자 목표 | A안 코드 SoT 유지 — 사용자가 디자인투코드를 목표로 명시해 방향이 어긋남 |
| 도입 경로 | 무료 경로(Path Free) PoC 먼저 | - 비용 0으로 효과 먼저 확인<br/>- 유료 전환은 효과 확인 뒤 판단 | B안 Path Pro 바로 — 검증 전에 유료를 선지출하게 됨 |
| 적용 방식 | 기존 코드베이스에 이식 | - 이미 44개 라우트·ADR 16건·검증 게이트 보유<br/>- 버릴 자산이 큼 | C안 강의대로 그린필드 — 기존 자산을 버리게 됨 |
| SoT 경계 | Figma=값 174개+컴포넌트 시각 스펙 / 코드=행위·반응형·믹스인·맵·복합 rgba | - 자주 바뀌는 행위·반응형은 코드가 더 적합<br/>- 정적인 디자인 값은 Figma가 적합 | 경계 없는 전면 Figma SoT — 반응형·믹스인을 변수로 못 담음 |

**이 task(파이프라인)가 실제로 한 일:**

`figma_export_tokens`로 Figma 변수 174개를 DTCG로 추출하고, dry-run으로 코드 토큰과 비교했습니다. raw-hex 41개 중 값이 어긋난 건은 0건이었습니다 (40개 일치 + `$white`의 `#fff`와 `#FFFFFF`가 표기만 다르고 값은 같은 1건). 손으로 쓴 `src/styles/tokens/*` SCSS는 0줄 건드리지 않았습니다.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 있음: Exec Plan은 ADR 중심 작업이라 N/A |
| `verify-task` | `node scripts/verify-task.mjs ds-token-sync-pipeline` — PASS, RUN_ID=`20260613-210708`, HEAD=`adce612`, ESLint·stylelint·Build 통과, 신규 회귀 0 |
| `harness-gate` | N/A |
| Codex 계획 검증 | CHANGE_REQUEST — 4건 반영 (probe, dry-run 폴백, 드리프트 기록 위치, config 출력 경로) |
| Codex 1차 검증 | FIX_APPLIED — `docs/research/figma-ds-*` gitignore 추가 |
| Claude 2차 검증 | 완료 |
| ADR 판단 | `docs/decisions/0017-figma-sot-design-to-code.md` |
| 남은 warning | 기존 부채 (Knip — 신규 파일 미포함) |

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 없음. 비파괴 변경이라 앱 동작이 바뀌지 않습니다 (`src/styles/tokens/` 0줄 수정).
- **운영 리스크**: 없음. 추출물·설정·문서만 추가하고 빌드·런타임 경로는 건드리지 않습니다.
- **QA 후속**: 없음.
- **롤백 시 영향**: 없음. 신규 파일만 추가해 되돌려도 기존 동작에 영향이 없습니다.
- **먼저 볼 화면 / 흐름**: 없음 (비파괴, 앱 동작 변화 0).

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

이 PR은 방향 결정과 파이프라인 토대까지입니다. 다음에 건드릴 때 주의할 점:

- 토큰 드리프트 기준값(베이스라인)은 `docs/references/figma-token-sync.md`에 적혀 있습니다. 이후 Figma 값이 바뀌면 이 기준과 비교합니다.
- 유료 경로(Code Connect) 도입 여부는 무료 경로 PoC 효과를 본 뒤 판단합니다 (ADR 0017 결정).
- SoT 경계(Figma 소유 vs 코드 소유)를 헷갈리면 ADR 0017과 참조 문서를 먼저 봅니다. 행위·반응형·믹스인은 코드가 정답입니다.
