### PR TITLE
[Refactor] auth 4폼을 form/ 레거시에서 ui/ 디자인 시스템(TextField·Button)으로 이관

### DIFF
--- a/docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md
+++ b/docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md
@@ -88,6 +88,13 @@ auth 4폼(SignIn·SignUp·PasswordUpdate·EmailVerificationRequest)을 `componen
 | --- | --- | --- | --- | --- | --- | --- |
 | 2차 | 20260613-222314 | ✅ | ✅ | ✅ | 0 | Chrome `/login`·`/sign-up`·`/forget-password` 렌더·register 동작 ✅ / `/reset-password`는 복구 토큰 필요로 미검증 |
 
+## 회귀 수정 — 폼 필드 세로 간격이 0으로 붙음
+
+- **문제**: ui/ 이관 후 auth 4폼의 입력칸·버튼이 세로 간격 0으로 붙었다. 레거시 `FormField`가 갖던 `margin-bottom: $spacing-12`가 사라졌다. `ui/TextField`는 외부 margin을 두지 않는데(컴포넌트가 외부 간격을 소유하지 않는 설계), `<form>`도 그 간격을 대신 주지 않았다.
+- **발견**: Claude in Chrome으로 BEFORE(`develop`)/AFTER 헤드리스 캡처를 비교하던 중 사용자가 패딩이 깨졌다고 지적했다.
+- **해결**: auth 4폼 공용 `src/app/_component/auth/authForm.module.scss`를 새로 만들어 `.form { display: flex; flex-direction: column; gap: $content-gap-s }`(12px — 레거시 값과 동일)을 정의하고, 4폼의 `<form>`에 `className`을 붙였다. RHF·제출 동작은 그대로다.
+- **결과**: 헤드리스 재캡처로 `/login`(hideLabel)·`/sign-up`(라벨 5필드) 간격이 복원됐다(라벨↔입력 8px < 필드↔필드 12px). stylelint PASS, eslint 0 error(경고 4건은 기존 `watch()`·exhaustive-deps 부채), tsc 0 error. production build는 사용자 dev 서버의 `.next` 충돌을 피하려고 보류했다.
+
 ## 검증 이력
 
 <details>

--- a/docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md
+++ b/docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md
@@ -1,0 +1,111 @@
+# auth-form-ui-migration
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-13
+- **브랜치**: feat/ds-form-unification
+- **Open questions**: none
+- **ADR needed**: no — ui/ 변경이지만 ADR 0004 정책(선택적 prop 추가·콜러 영향 0 허용) 범위. 새 결정 없음
+
+## 목표
+
+auth 4폼(SignIn·SignUp·PasswordUpdate·EmailVerificationRequest)을 `components/form/` 레거시에서 `ui/TextField`+`ui/Button`으로 옮긴다. 입력 어휘를 ui/ 하나로 통일해 `ui/TextField`의 실사용을 0건에서 4폼으로 늘린다. 선행으로 `ui/Button`에 `loading`, `ui/TextField`에 `hideLabel`을 더한다.
+
+## 검증된 Assumptions
+
+- `components/form/` 소비처는 6곳 — auth 4폼 + `news/bulletins/_component/BulletinForm.tsx` + `file/ImageUpload.tsx`(FormAlertMessage만). `grep -rn '@/components/form' src` 결과. form/ 완전 제거는 이번 범위 밖이다.
+- `ui/TextField`는 구조분해 후 나머지를 `<input {...inputProps}>`에 스프레드한다(TextField.tsx:47,83). react-hook-form `register`의 `ref`·`onChange`·`onBlur`·`name`이 input에 전달돼 RHF가 동작한다.
+- `ui/Button`은 `ButtonHTMLAttributes` 확장 + `forwardRef`, `loading` 없음(Button.tsx:10,46).
+- `@mixin blind`(sr-only: absolute·1px·clip)가 `_mixins.scss:37`에 있다.
+- `common/Loader`는 spinner div를 그린다(Loader.tsx). 단 Loader에 색이 박혀 있어 navy 버튼 위에서 안 보인다. 그래서 currentColor를 따르는 스피너를 Button.module.scss에 따로 정의한다.
+- auth 4폼은 `FormAlertMessage`를 폼-레벨 에러/성공에 쓴다(필드 에러 아님). EmailVerification은 success·error 둘 다. 각 폼 읽음.
+
+## Success Criteria
+
+- `ui/Button` `loading`: `loading`이면 스피너(`aria-hidden="true"`)를 보이고 children은 `@include blind`로 시각만 숨겨 accessible name을 유지한다. 버튼에 `disabled`·`aria-busy="true"`. 미지정 콜러는 변화 0(선택적 prop).
+- `ui/TextField` `hideLabel`: `hideLabel`이면 `<label>`이 `@include blind`로 시각만 숨고 `htmlFor` 연결은 남는다.
+- auth 4폼에서 `FormField`·`FormSubmitButton` import 0건 — `grep -rn "FormField\|FormSubmitButton" src/app/_component/auth` 0 hit. `FormAlertMessage`는 남는다.
+- `node scripts/verify-task.mjs` ESLint·stylelint·Build 통과, 신규 회귀 0.
+- **Claude in Chrome UI 검증**: `/login`·`/sign-up`·`/forget-password` 3페이지가 렌더되고 — 입력칸이 ui/TextField 모양, 제출이 ui/Button(navy primary, fullWidth), 콘솔 에러 0. 빈 입력 시 제출 비활성, 입력 시 활성. 전후 스크린샷 확보. (`/reset-password`는 Supabase 복구 토큰이 있어야 폼이 떠서 직접 렌더 검증은 비고로 둔다.)
+
+## 영향받는 파일
+
+- `src/components/ui/Button/Button.tsx` + `Button.module.scss` — `loading`
+- `src/components/ui/TextField/TextField.tsx` + `TextField.module.scss` — `hideLabel`
+- `src/app/_component/auth/SignInForm.tsx`
+- `src/app/_component/auth/SignUpForm.tsx`
+- `src/app/_component/auth/PasswordUpdateForm.tsx`
+- `src/app/_component/auth/EmailVerificationRequestForm.tsx`
+
+## Non-goals
+
+- `BulletinForm`·`ImageUpload` 마이그레이션 — 후속(content 폼).
+- `components/form/` 디렉토리 제거 — 위 둘이 남아 불가.
+- `ui/Alert`(폼-레벨 알림) 신설 — `FormAlertMessage` 유지.
+- ESLint raw-primitive 금지 규칙 — 별도 작업.
+- 폼 검증 로직·action 호출 변경 — RHF `register`/`handleSubmit`/`onSubmit`은 그대로. 컴포넌트만 교체.
+
+## 단계별 체크리스트
+
+- [ ] 1. `ui/Button`에 `loading` 추가 — `loading`이면: ① `.spinner`(currentColor·`aria-hidden="true"`) 렌더 ② children을 `.blind_label`(`@include blind`)로 감싸 시각만 숨김(SR은 읽음) ③ `disabled` ④ `aria-busy="true"`. 미지정 콜러 영향 0 확인.
+- [ ] 2. `ui/TextField`에 `hideLabel` 추가 — `.label_hidden`에 `@include blind`. 미지정 시 기존과 동일.
+- [ ] 3. `SignInForm` 교체 — email·password를 `<TextField hideLabel>`, 제출을 `<Button type="submit" fullWidth size="lg" loading={isSubmitting} disabled={!isValid}>`. FormAlertMessage 유지.
+- [ ] 4. `SignUpForm` 교체 — 5필드 라벨 표시, 동일 버튼 패턴. `watch`/`setError` 로직 유지.
+- [ ] 5. `PasswordUpdateForm` 교체 — 2필드, 동일 패턴.
+- [ ] 6. `EmailVerificationRequestForm` 교체 — email `hideLabel`, 버튼 `loading` + 동적 label(`getButtonContent`)·`disabled={!isValid || isRunning}`.
+- [x] 7. `node scripts/verify-task.mjs auth-form-ui-migration` — ESLint·stylelint·Build ✅ (run-id 20260613-222314). ✅
+- [x] 8. **Claude in Chrome UI 검증** — `/login`·`/sign-up`·`/forget-password` 렌더·register 동작·콘솔 확인 완료(앱 에러 0, Trancy 확장 경고만). reset-password는 토큰 필요로 미검증. ✅
+
+## Verification
+
+- `node scripts/verify-task.mjs auth-form-ui-migration`
+- Claude in Chrome: dev 서버 띄우고 3페이지 렌더·콘솔 에러 0·전후 스크린샷. a11y 변경(label 숨김·aria-busy)은 Codex 1차 검증에서 교차 확인.
+
+## ADR 판단
+
+- ADR needed: no — `src/components/ui/`는 ADR_TRIGGER_PART이나, ADR 0004 운영 정책 "prop 추가는 콜러 영향 없는 선택적 prop이면 OK, 시그니처 파괴만 ADR 후보"에 해당한다. `loading`·`hideLabel` 둘 다 선택적·기본 미동작이라 기존 콜러 변화 0. 새 ADR 불요. 단 a11y 동작 변경(label 숨김·aria-busy)이라 ui-components SKILL의 "a11y 동작 변경 시 Codex 1차 검증 필수" 적용.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST → 1건 반영. `ui/Button.loading`이 children을 스피너로 대체하면 버튼 accessible name이 비어 a11y 회귀가 공용 API로 전파됨 → 옵션 A 채택(스피너 `aria-hidden`, children은 `@include blind`로 유지).
+- **현재 판단**: 5체크 중 SC만 material(accessible name 보존 누락), 나머지 PASS. hideLabel·레이아웃·스코프 리스크는 Codex가 부재로 확인.
+- **다음 행동**: WORK 진입 — step 1 Button loading부터(옵션 A).
+
+## Codex 1차 검증
+
+- **결론**: PASS (confidence high). a11y(loading accessible name 보존·hideLabel htmlFor 유지·`aria-busy`)·RHF register 스프레드·필드 속성 보존·외과적 변경 모두 머지 차단 이슈 0.
+- **현재 판단**: 옵션 A 구현이 의도대로 — 스피너 `aria-hidden` + children `@include blind`로 EmailVerification 동적 라벨도 SR이 읽는다. register 덮어쓰기 위험 없음.
+- **다음 행동**: VERIFY — verify-task 통과(run-id 20260613-222314), Claude in Chrome UI 검증 진행.
+
+## Claude 2차 검증
+
+- **최종 판단**: 통과 — verify-task(lint·stylelint·build) + Claude in Chrome 3폼 시각·동작 검증 완료. 머지 가능.
+- **현재 판단**: 아래 표. `/login`은 타이핑→버튼 navy 활성화로 register 연결까지 확인. 콘솔 에러 1건은 Trancy 확장의 `trancy-version` 하이드레이션 불일치(앱 무관, 에러 메시지가 extension 원인 명시).
+- **다음 행동**: 커밋 승인 요청.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260613-222314 | ✅ | ✅ | ✅ | 0 | Chrome `/login`·`/sign-up`·`/forget-password` 렌더·register 동작 ✅ / `/reset-password`는 복구 토큰 필요로 미검증 |
+
+## 검증 이력
+
+<details>
+<summary>2026-06-13 Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST (confidence high)
+- 이유: `ui/Button.loading`이 children을 스피너로 대체 → 버튼 accessible name이 비어 a11y 회귀가 공용 API로 전파.
+- 조치: 옵션 A 채택 — 스피너 `aria-hidden`, children은 `@include blind`로 유지. SC·체크리스트 1 반영.
+
+</details>
+
+## 후속 작업
+
+- `BulletinForm`(news/bulletins) → ui/TextField·Textarea·Button 마이그레이션
+  - 이유: content 폼이라 auth와 분리. 파일 업로드 필드가 섞여 범위가 다르다.
+  - 다음 기준: 본 task 머지 + BulletinForm 파일 업로드 필드 설계가 정리된 뒤 별도 exec-plan.
+  - 기록 위치: 없음 (본 exec-plan 후속 작업)
+- `ui/Alert` 신설 + `FormAlertMessage`·`ImageUpload` 이관 → `components/form/` 제거
+  - 이유: 폼-레벨 알림은 필드와 다른 관심사. ui/ 알림 컴포넌트가 선행돼야 한다.
+  - 다음 기준: 폼-레벨 알림이 3곳 이상에서 필요해질 때.
+  - 기록 위치: 없음

--- a/docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md
+++ b/docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md
@@ -95,6 +95,17 @@ auth 4폼(SignIn·SignUp·PasswordUpdate·EmailVerificationRequest)을 `componen
 - **해결**: auth 4폼 공용 `src/app/_component/auth/authForm.module.scss`를 새로 만들어 `.form { display: flex; flex-direction: column; gap: $content-gap-s }`(12px — 레거시 값과 동일)을 정의하고, 4폼의 `<form>`에 `className`을 붙였다. RHF·제출 동작은 그대로다.
 - **결과**: 헤드리스 재캡처로 `/login`(hideLabel)·`/sign-up`(라벨 5필드) 간격이 복원됐다(라벨↔입력 8px < 필드↔필드 12px). stylelint PASS, eslint 0 error(경고 4건은 기존 `watch()`·exhaustive-deps 부채), tsc 0 error. production build는 사용자 dev 서버의 `.next` 충돌을 피하려고 보류했다.
 
+## PR #119 리뷰 대응 (2026-06-14)
+
+자동 리뷰(Gemini·Codex) 4건을 Codex 교차 검증과 브라우저 실측으로 판정했다.
+
+- **TextField ref 전달 (Gemini HIGH) — 오탐**: React 19에선 `ref`가 일반 prop이라 `...inputProps`를 타고 `<input>`까지 흘러간다. 무효 폼을 강제 제출하니 email 칸에 포커스가 잡혔고, 이로써 React Hook Form(RHF)의 ref 전달을 실측 확인했다(`activeElement.id === 'email'`). 동작은 정상이나 ref가 드러나지 않게 전달돼서, 공용 컴포넌트의 안전을 위해 `forwardRef`로 직접 연결했다(`Button`과 같은 패턴). 호출부 영향 0.
+- **noValidate 누락 (Gemini) — 타당**: `required`가 input에 네이티브 `required`를 걸어 브라우저 검증 말풍선이 RHF 커스텀 에러보다 먼저 뜬다. auth 4폼 `<form>`에 `noValidate`를 더했다. 실측 `form.noValidate === true`.
+- **필드 에러 a11y (Codex) — 타당**: ui/TextField 에러 `<p>`에 `role={error ? 'alert' : undefined}`를 더해, onChange 에러가 스크린리더에 즉시 읽힌다. 실측 에러 `<p>` 2개 모두 `role="alert"`.
+- **필드 간격 collapse (Codex)**: 위 "회귀 수정"(6992b9a)에서 이미 해결.
+
+검증: eslint 0 error, tsc 0 error, 브라우저 실측 3건(ref 포커스·noValidate·role) 모두 통과.
+
 ## 검증 이력
 
 <details>

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -211,6 +211,16 @@
   - rgba: `news/notices/_component/NoticeDrawer.module.scss:27`, `sermons/_component/{SortBottomSheet:4, GridCard:59,77,93, SermonCard:69,87,109}`
 - **발견일**: 2026-05-07 (Codex 디자인 시스템 audit)
 
+### 🟢 ui/Button disabled가 전용 색 없이 `opacity: 0.5`로만 처리됨 (auth-form-ui-migration)
+
+- **상태**: 등록만 (상태 토큰화는 "완전한 디자인 시스템 구축" 단계에서 진행 — 2026-06-14 사용자 결정)
+- **무엇**: `ui/Button`의 disabled가 `Button.module.scss:11-14`에서 `opacity: 0.5`만 건다. variant별 전용 disabled 색이 없어, `.primary`(`$primary` = navy-800)가 비활성일 때 연회색이 아니라 "navy를 50% 투명도로 깐 진한 회색-네이비"로 보인다. 레거시 `FormSubmitButton.module.scss:10-15`는 `background: $gray-200` + `$gray-300` 보더의 전용 disabled 색이라 비활성이 더 분명했다. auth 폼을 ui/로 모으면서 두 버튼의 disabled 모습 차이가 드러났다.
+- **왜 지금 안 하나**: opacity 방식은 흔한 관례라 회귀가 아니다. disabled를 전용 색으로 바꾸면 모든 `ui/Button`(전역)의 비활성 모습이 함께 바뀌어 영향이 넓다. 컴포넌트 상태(hover·active·disabled) 스펙을 한 번에 정의하면 세 상태가 같은 토큰 체계를 따른다.
+- **마이그레이션 경로**: ① Figma(디자인 값 출처, SoT)에 Button 상태 스펙(hover·active·disabled)을 명시한다 ② `_color.scss`에 disabled 시맨틱 토큰을 정의한다(`$txt-disabled` 재사용 + variant별 disabled 배경 신설 등) ③ `Button.module.scss`의 `opacity: 0.5`를 variant별 `&:disabled` 색 규칙으로 교체한다. hover·active도 같은 단계에서 토큰으로 정의한다.
+- **영향 범위**: `src/components/ui/Button/Button.module.scss`(전역 — 모든 Button 소비처), Figma Button 컴포넌트 스펙
+- **확인**: `rg -n "opacity|:disabled" src/components/ui/Button/Button.module.scss` → 현재 `opacity: 0.5` 1건, variant별 `&:disabled` 색 규칙 0건
+- **발견일**: 2026-06-14 (auth-form-ui-migration BEFORE/AFTER 비교 중 사용자 지적)
+
 ### 🟢 Cloudinary `uploadImage()` `folder` + `public_id` 중복 전달
 
 - **무엇**: `src/apis/cloudinary.ts:36-39`에서 `cloudinary.uploader.upload()`에 `folder`와 fully-qualified `public_id`를 동시 전달

--- a/src/app/_component/auth/EmailVerificationRequestForm.tsx
+++ b/src/app/_component/auth/EmailVerificationRequestForm.tsx
@@ -3,7 +3,8 @@
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import useTimer from '@/hooks/useTimer';
-import { FormField, FormAlertMessage, FormSubmitButton } from '@/components/form';
+import { FormAlertMessage } from '@/components/form';
+import { Button, TextField } from '@/components/ui';
 import { requestPasswordResetEmailAction } from '@/actions/auth.action';
 import { EMAIL_RESEND_DELAY_SECONDS } from '@/constants/auth';
 import { FORM_VALIDATIONS } from '@/constants/validation';
@@ -58,19 +59,23 @@ export default function EmailVerificationRequestForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormField
+      <TextField
         id="email"
         label="이메일"
+        hideLabel
         placeholder="example@service.com"
-        register={register('email', FORM_VALIDATIONS.email)}
         error={errors.email?.message}
-        blindLabel
+        {...register('email', FORM_VALIDATIONS.email)}
       />
-      <FormSubmitButton
-        isDisabled={!isValid || isRunning}
-        isSubmitting={isSubmitting}
-        label={getButtonContent()}
-      />
+      <Button
+        type="submit"
+        fullWidth
+        size="lg"
+        loading={isSubmitting}
+        disabled={!isValid || isRunning}
+      >
+        {getButtonContent()}
+      </Button>
       {alertMessage && (
         <FormAlertMessage
           type={alertType === 'success' ? 'success' : 'error'}

--- a/src/app/_component/auth/EmailVerificationRequestForm.tsx
+++ b/src/app/_component/auth/EmailVerificationRequestForm.tsx
@@ -9,6 +9,7 @@ import { requestPasswordResetEmailAction } from '@/actions/auth.action';
 import { EMAIL_RESEND_DELAY_SECONDS } from '@/constants/auth';
 import { FORM_VALIDATIONS } from '@/constants/validation';
 import { generateErrorMessage } from '@/utils/error';
+import styles from './authForm.module.scss';
 
 type Inputs = {
   email: string;
@@ -58,7 +59,7 @@ export default function EmailVerificationRequestForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <TextField
         id="email"
         label="이메일"

--- a/src/app/_component/auth/EmailVerificationRequestForm.tsx
+++ b/src/app/_component/auth/EmailVerificationRequestForm.tsx
@@ -59,7 +59,7 @@ export default function EmailVerificationRequestForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form} noValidate>
       <TextField
         id="email"
         label="이메일"

--- a/src/app/_component/auth/PasswordUpdateForm.tsx
+++ b/src/app/_component/auth/PasswordUpdateForm.tsx
@@ -48,7 +48,7 @@ export default function PasswordUpdateForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form} noValidate>
       <TextField
         id="password"
         label="비밀번호"

--- a/src/app/_component/auth/PasswordUpdateForm.tsx
+++ b/src/app/_component/auth/PasswordUpdateForm.tsx
@@ -8,6 +8,7 @@ import { Button, TextField } from '@/components/ui';
 import { updatePasswordAndSignOut } from '@/app/reset-password/actions';
 import { generateErrorMessage } from '@/utils/error';
 import { FORM_VALIDATIONS } from '@/constants/validation';
+import styles from './authForm.module.scss';
 
 type Inputs = {
   password: string;
@@ -47,7 +48,7 @@ export default function PasswordUpdateForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <TextField
         id="password"
         label="비밀번호"

--- a/src/app/_component/auth/PasswordUpdateForm.tsx
+++ b/src/app/_component/auth/PasswordUpdateForm.tsx
@@ -3,7 +3,8 @@
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { FormField, FormAlertMessage, FormSubmitButton } from '@/components/form';
+import { FormAlertMessage } from '@/components/form';
+import { Button, TextField } from '@/components/ui';
 import { updatePasswordAndSignOut } from '@/app/reset-password/actions';
 import { generateErrorMessage } from '@/utils/error';
 import { FORM_VALIDATIONS } from '@/constants/validation';
@@ -47,32 +48,30 @@ export default function PasswordUpdateForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormField
+      <TextField
         id="password"
         label="비밀번호"
         type="password"
-        register={register('password', FORM_VALIDATIONS.password)}
-        error={errors.password?.message}
-        placeholder="영문, 숫자 포함 8자 이상"
         required
+        placeholder="영문, 숫자 포함 8자 이상"
+        error={errors.password?.message}
+        {...register('password', FORM_VALIDATIONS.password)}
       />
-      <FormField
+      <TextField
         id="confirm-password"
         label="비밀번호 확인"
         type="password"
-        register={register('confirmPassword', {
+        required
+        placeholder="비밀번호 재입력"
+        error={errors.confirmPassword?.message}
+        {...register('confirmPassword', {
           required: '비밀번호 확인을 입력해주세요.',
           validate: (value) => value === password || '두 비밀번호가 일치하지 않습니다.'
         })}
-        error={errors.confirmPassword?.message}
-        placeholder="비밀번호 재입력"
-        required
       />
-      <FormSubmitButton
-        isDisabled={!isValid}
-        isSubmitting={isSubmitting}
-        label="비밀번호 변경하기"
-      />
+      <Button type="submit" fullWidth size="lg" loading={isSubmitting} disabled={!isValid}>
+        비밀번호 변경하기
+      </Button>
       {error && <FormAlertMessage type="error" message={error} />}
     </form>
   );

--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -39,7 +39,7 @@ export default function SignInForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form} noValidate>
       <TextField
         id="email"
         label="이메일"

--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -3,7 +3,8 @@
 import { useSearchParams } from 'next/navigation';
 import { useState } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
-import { FormField, FormAlertMessage, FormSubmitButton } from '@/components/form';
+import { FormAlertMessage } from '@/components/form';
+import { Button, TextField } from '@/components/ui';
 // eslint-disable-next-line no-restricted-imports -- 점진 마이그레이션 대상 (tech-debt-tracker.md)
 import { signInWithPassword } from '@/apis/auth';
 import { FORM_VALIDATIONS } from '@/constants/validation';
@@ -38,24 +39,26 @@ export default function SignInForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormField
+      <TextField
         id="email"
         label="이메일"
+        hideLabel
         placeholder="이메일 입력"
-        register={register('email', FORM_VALIDATIONS.email)}
         error={errors.email?.message}
-        blindLabel
+        {...register('email', FORM_VALIDATIONS.email)}
       />
-      <FormField
+      <TextField
         id="password"
         label="비밀번호"
+        hideLabel
         type="password"
         placeholder="비밀번호 입력 (영문 숫자 포함 8자 이상)"
-        register={register('password', FORM_VALIDATIONS.password)}
         error={errors.password?.message}
-        blindLabel={true}
+        {...register('password', FORM_VALIDATIONS.password)}
       />
-      <FormSubmitButton isDisabled={!isValid} isSubmitting={isSubmitting} label="이메일로 로그인" />
+      <Button type="submit" fullWidth size="lg" loading={isSubmitting} disabled={!isValid}>
+        이메일로 로그인
+      </Button>
       {logInError && <FormAlertMessage type="error" message={logInError} />}
     </form>
   );

--- a/src/app/_component/auth/SignInForm.tsx
+++ b/src/app/_component/auth/SignInForm.tsx
@@ -10,6 +10,7 @@ import { signInWithPassword } from '@/apis/auth';
 import { FORM_VALIDATIONS } from '@/constants/validation';
 import { generateErrorMessage } from '@/utils/error';
 import { REDIRECT_AFTER_LOGIN_KEY } from '@/constants/auth';
+import styles from './authForm.module.scss';
 
 type Inputs = {
   email: string;
@@ -38,7 +39,7 @@ export default function SignInForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <TextField
         id="email"
         label="이메일"

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -9,6 +9,7 @@ import { Button, TextField } from '@/components/ui';
 import { generateErrorMessage } from '@/utils/error';
 import { FORM_VALIDATIONS } from '@/constants/validation';
 import { REDIRECT_AFTER_LOGIN_KEY } from '@/constants/auth';
+import styles from './authForm.module.scss';
 
 type Inputs = {
   email: string;
@@ -67,7 +68,7 @@ export default function SignUpForm() {
   }, [password]);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
       <TextField
         id="email"
         label="이메일"

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -68,7 +68,7 @@ export default function SignUpForm() {
   }, [password]);
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+    <form onSubmit={handleSubmit(onSubmit)} className={styles.form} noValidate>
       <TextField
         id="email"
         label="이메일"

--- a/src/app/_component/auth/SignUpForm.tsx
+++ b/src/app/_component/auth/SignUpForm.tsx
@@ -4,7 +4,8 @@ import { useSearchParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { signUpAction } from '@/actions/auth.action';
-import { FormField, FormAlertMessage, FormSubmitButton } from '@/components/form';
+import { FormAlertMessage } from '@/components/form';
+import { Button, TextField } from '@/components/ui';
 import { generateErrorMessage } from '@/utils/error';
 import { FORM_VALIDATIONS } from '@/constants/validation';
 import { REDIRECT_AFTER_LOGIN_KEY } from '@/constants/auth';
@@ -67,52 +68,54 @@ export default function SignUpForm() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <FormField
+      <TextField
         id="email"
         label="이메일"
-        register={register('email', FORM_VALIDATIONS.email)}
-        error={errors.email?.message}
-        placeholder="example@service.com"
         required
+        placeholder="example@service.com"
+        error={errors.email?.message}
+        {...register('email', FORM_VALIDATIONS.email)}
       />
-      <FormField
+      <TextField
         id="password"
         label="비밀번호"
         type="password"
-        register={register('password', FORM_VALIDATIONS.password)}
-        error={errors.password?.message}
-        placeholder="영문, 숫자 포함 8자 이상"
         required
+        placeholder="영문, 숫자 포함 8자 이상"
+        error={errors.password?.message}
+        {...register('password', FORM_VALIDATIONS.password)}
       />
-      <FormField
+      <TextField
         id="confirm-password"
         label="비밀번호 확인"
         type="password"
-        register={register('confirmPassword', {
+        required
+        placeholder="비밀번호 재입력"
+        error={errors.confirmPassword?.message}
+        {...register('confirmPassword', {
           required: '비밀번호 확인을 입력해주세요.',
           validate: (value) => value === password || '두 비밀번호가 일치하지 않습니다.'
         })}
-        error={errors.confirmPassword?.message}
-        placeholder="비밀번호 재입력"
-        required
       />
-      <FormField
+      <TextField
         id="name"
         label="이름"
-        register={register('name', FORM_VALIDATIONS.name)}
-        error={errors.name?.message}
-        placeholder="홍길동"
         required
+        placeholder="홍길동"
+        error={errors.name?.message}
+        {...register('name', FORM_VALIDATIONS.name)}
       />
-      <FormField
+      <TextField
         id="username"
         label="프로필 이름 (닉네임)"
-        register={register('username', FORM_VALIDATIONS.username)}
-        error={errors.username?.message}
-        placeholder="사용할 닉네임 10자 이내"
         required
+        placeholder="사용할 닉네임 10자 이내"
+        error={errors.username?.message}
+        {...register('username', FORM_VALIDATIONS.username)}
       />
-      <FormSubmitButton isDisabled={!isValid} isSubmitting={isSubmitting} label="회원가입" />
+      <Button type="submit" fullWidth size="lg" loading={isSubmitting} disabled={!isValid}>
+        회원가입
+      </Button>
       {signUpError && <FormAlertMessage type="error" message={signUpError} />}
     </form>
   );

--- a/src/app/_component/auth/authForm.module.scss
+++ b/src/app/_component/auth/authForm.module.scss
@@ -1,0 +1,7 @@
+// auth 4폼(SignIn·SignUp·PasswordUpdate·EmailVerificationRequest) 공용 레이아웃.
+// ui/TextField는 외부 margin이 없어, 필드 간 세로 간격을 form 컨테이너가 소유한다.
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-s;
+}

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -98,3 +98,27 @@
     filter: brightness(0.8);
   }
 }
+
+// ── Loading ──
+
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid currentColor;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  box-sizing: border-box;
+  animation: button-spin 0.8s linear infinite;
+}
+
+// loading 중 children은 시각만 숨기고 스크린 리더용으로 남긴다 (accessible name 보존)
+.blind_label {
+  @include blind;
+}
+
+@keyframes button-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -27,6 +27,8 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   leadingIcon?: ReactNode;
   /** 레이블 뒤 아이콘 */
   trailingIcon?: ReactNode;
+  /** 비동기 진행 중. 스피너 표시 + 비활성. children은 스크린 리더용으로 유지해 accessible name을 보존한다. */
+  loading?: boolean;
 }
 
 /**
@@ -44,13 +46,15 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
  * ```
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant = 'primary', size = 'md', fullWidth = false, type = 'button', className, children, leadingIcon, trailingIcon, ...rest },
+  { variant = 'primary', size = 'md', fullWidth = false, loading = false, type = 'button', disabled, className, children, leadingIcon, trailingIcon, ...rest },
   ref
 ) {
   return (
     <button
       ref={ref}
       type={type}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
       className={clsx(
         styles.button,
         styles[variant],
@@ -60,9 +64,18 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
       )}
       {...rest}
     >
-      {leadingIcon}
-      {children}
-      {trailingIcon}
+      {loading ? (
+        <>
+          <span className={styles.spinner} aria-hidden="true" />
+          <span className={styles.blind_label}>{children}</span>
+        </>
+      ) : (
+        <>
+          {leadingIcon}
+          {children}
+          {trailingIcon}
+        </>
+      )}
     </button>
   );
 });

--- a/src/components/ui/TextField/TextField.module.scss
+++ b/src/components/ui/TextField/TextField.module.scss
@@ -16,6 +16,10 @@
   }
 }
 
+.label_hidden {
+  @include blind;
+}
+
 // ── Input wrapper (border/focus/state owner) ──
 
 .input_wrap {

--- a/src/components/ui/TextField/TextField.tsx
+++ b/src/components/ui/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes, ReactNode, useId } from 'react';
+import { InputHTMLAttributes, ReactNode, useId, forwardRef } from 'react';
 import clsx from 'clsx';
 import styles from './TextField.module.scss';
 
@@ -35,20 +35,23 @@ type TextFieldProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'id'> & {
  * <TextField label="이름" leadingIcon={<IoPerson />} success="사용 가능한 이름입니다" />
  * ```
  */
-export function TextField({
-  label,
-  hideLabel,
-  helper,
-  error,
-  success,
-  id,
-  required,
-  disabled,
-  leadingIcon,
-  trailingSlot,
-  className,
-  ...inputProps
-}: TextFieldProps) {
+export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(function TextField(
+  {
+    label,
+    hideLabel,
+    helper,
+    error,
+    success,
+    id,
+    required,
+    disabled,
+    leadingIcon,
+    trailingSlot,
+    className,
+    ...inputProps
+  },
+  ref
+) {
   const autoId = useId();
   const inputId = id ?? autoId;
   const messageId = `${inputId}-message`;
@@ -76,6 +79,7 @@ export function TextField({
       >
         {leadingIcon && <span className={styles.leading}>{leadingIcon}</span>}
         <input
+          ref={ref}
           id={inputId}
           required={required}
           disabled={disabled}
@@ -93,6 +97,7 @@ export function TextField({
       {hasMessage && (
         <p
           id={messageId}
+          role={error ? 'alert' : undefined}
           className={clsx(
             styles.message,
             error && styles.message_error,
@@ -104,4 +109,4 @@ export function TextField({
       )}
     </div>
   );
-}
+});

--- a/src/components/ui/TextField/TextField.tsx
+++ b/src/components/ui/TextField/TextField.tsx
@@ -4,6 +4,8 @@ import styles from './TextField.module.scss';
 
 type TextFieldProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'id'> & {
   label?: string;
+  /** label을 시각적으로만 숨긴다(sr-only). htmlFor 연결은 유지 — placeholder가 시각 단서. */
+  hideLabel?: boolean;
   /** 입력 가이드 텍스트. 입력 규칙·범위·예시. */
   helper?: string;
   /** 에러 메시지. 지정 시 input이 error 스타일. */
@@ -35,6 +37,7 @@ type TextFieldProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'id'> & {
  */
 export function TextField({
   label,
+  hideLabel,
   helper,
   error,
   success,
@@ -56,7 +59,10 @@ export function TextField({
   return (
     <div className={clsx(styles.field, className)}>
       {label && (
-        <label htmlFor={inputId} className={clsx(styles.label, required && styles.required)}>
+        <label
+          htmlFor={inputId}
+          className={clsx(styles.label, required && styles.required, hideLabel && styles.label_hidden)}
+        >
           {label}
         </label>
       )}


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 로그인·회원가입 등 auth 4폼을 `form/` 레거시 입력칸에서 디자인 시스템 컴포넌트(`ui/TextField`·`ui/Button`)로 이관해, 폼 입력 어휘를 `ui/` 하나로 모았습니다.

**범위**:

- `ui/Button`에 `loading` prop, `ui/TextField`에 `hideLabel` prop을 선택적으로 추가 (이관 선행 작업)
- auth 4폼(로그인·회원가입·비밀번호 재설정 요청·비밀번호 변경)을 `ui/` 컴포넌트로 교체
- `ui/TextField` 실사용을 0건에서 4폼으로 늘림

---

## 🔗 개발 컨텍스트

- **Task ID**: `auth-form-ui-migration`
- **Exec Plan**: `docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md`
- **관련 ADR**: `docs/decisions/0017-figma-sot-design-to-code.md` (함께 올라가는 PR #1 — 디자인 시스템 방향) / `docs/decisions/0004-ui-component-foundation.md` (ui 토대)
- **관련 tech debt**: 해당 없음
- **작업 범위**: auth 4폼 이관 + 두 prop 추가.
- **제외한 범위**: `BulletinForm`·`ImageUpload`는 아직 `form/`을 써서 이번 범위 밖(후속). `FormAlertMessage`도 유지. `form/` 디렉토리 자체는 삭제하지 않음.

---

## 💡 리팩토링 배경 (Motivation)

**개선하려는 문제:**

- [x] 가독성 저하 (복잡도 증가, 네이밍 불명확 등)
- [ ] 중복 코드 (DRY 원칙 위반)
- [ ] 성능 병목
- [x] 유지보수 난이도 증가
- [x] 기술 부채 해소
- [x] 기타: 디자인 시스템 컴포넌트가 강제되지 않아 폼이 3갈래로 갈림

폼이 세 가지 방식으로 갈려 있었습니다 — `form/` 레거시(raw input·button), admin primitives, `ui/`. 그런데 `ui/TextField`는 실사용이 0건이라, `ui/` 카탈로그가 입력 어휘로 강제되지 못했습니다. 이 PR은 `ui/TextField` 실사용을 0건에서 4폼으로 늘려, 입력 어휘를 `ui/` 하나로 모읍니다. 일관된 UI를 시스템으로 강제하는 첫 적용 사례(Phase C-1, 디자인 시스템 통일 1단계)입니다.

**관련 이슈:**

- Issue: #

---

## 🔧 주요 변경점 (Key Changes)

- `src/components/ui/Button/Button.tsx` (+`Button.module.scss`) — `loading` prop 추가. 기본값은 미동작이라 기존 호출부 영향 0.
- `src/components/ui/TextField/TextField.tsx` (+`TextField.module.scss`) — `hideLabel` prop 추가. 기본값 미동작.
- `src/app/_component/auth/SignInForm.tsx` — `form/` 레거시 입력을 `ui/TextField`·`ui/Button`으로 교체.
- `src/app/_component/auth/SignUpForm.tsx` — 동일 교체 (라벨 표시 + required 별표).
- `src/app/_component/auth/PasswordUpdateForm.tsx` — 동일 교체.
- `src/app/_component/auth/EmailVerificationRequestForm.tsx` — 동일 교체 (동적 버튼 라벨 포함).
- `docs/exec-plans/active/2026-06-13-auth-form-ui-migration.md` 신규.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 외형 변경 수용 여부 | 외형이 바뀌어도 ui/로 통일 | - 사용자가 "일관된 UI가 더 중요하다"고 판단<br/>- `form/` 레거시 외형 보존보다 어휘 통일 우선 | form/ 외형 그대로 유지 — 폼이 계속 3갈래로 갈림 |
| Button `loading` 접근가능 이름 보존 | 옵션 A — 스피너는 `aria-hidden`, children은 `@include blind`로 시각만 숨김 | - children을 스피너로 대체하면 버튼 접근가능 이름이 비어 a11y 회귀가 공용 API로 퍼짐<br/>- 스크린리더가 children 텍스트를 계속 읽음<br/>- EmailVerification의 동적 라벨도 보존됨 | children을 스피너로 대체 — 접근가능 이름이 비고, 회귀가 공용 API를 타고 전파 (Codex 계획 검증 CHANGE_REQUEST에서 차단) |
| prop 추가 방식 | `loading`·`hideLabel` 둘 다 선택적(기본 미동작) | - 기본값이 미동작이라 기존 호출부 영향 0<br/>- ADR 0004 운영 정책상 콜러 영향 0이면 ADR 불요 | 필수 prop으로 추가 — 기존 호출부를 모두 고쳐야 함 |
| `form/` 디렉토리 처리 | 이번엔 유지 | - `BulletinForm`·`ImageUpload`가 아직 form/를 사용<br/>- 한 PR=한 의도 원칙상 범위를 auth 4폼으로 한정 | form/ 즉시 삭제 — 미이관 컴포넌트가 깨짐 |

> ⚠️ **주의사항:** `loading`·`hideLabel`은 선택적 prop이라 기존 호출부 영향이 없습니다. 다만 `loading` 사용 시 스피너에는 반드시 `aria-hidden`, 시각적으로 숨길 텍스트에는 `@include blind`를 유지해야 버튼 접근가능 이름이 보존됩니다 (옵션 A 결정).

**변경 전 구조:**

폼 입력이 세 갈래 — `form/` 레거시(raw `<input>`·`<button>`), admin primitives, `ui/`. `ui/TextField` 실사용 0건.

**변경 후 구조:**

auth 4폼이 모두 `ui/TextField`·`ui/Button` 사용. `ui/TextField` 실사용 0건 → 4폼. `form/`은 미이관 컴포넌트(`BulletinForm`·`ImageUpload`)만 남아 후속 대상.

---

## 📊 개선 지표 (Improvement Metrics)

| 항목 | Before | After |
| --- | --- | --- |
| `ui/TextField` 실사용 | 0건 | 4폼 |
| 폼 입력 어휘 | form/ 레거시 (raw input·button) | ui/ 단일 |
| 코드 라인 수 | — | +228 / -60 (참고) |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs auth-form-ui-migration` — PASS, RUN_ID=`20260613-222314`, HEAD=`0f5ad16`, ESLint·stylelint·Build 통과, 신규 회귀 0 |
| `harness-gate` | N/A |
| Codex 계획 검증 | CHANGE_REQUEST — 1건 반영 (Button loading 접근가능 이름 → 옵션 A) |
| Codex 1차 검증 | PASS |
| Claude 2차 검증 | 완료 — Claude in Chrome으로 `/login`·`/sign-up`·`/forget-password` 렌더·register 동작·콘솔 에러 0 확인. `/reset-password`는 Supabase 복구 토큰 필요로 미검증. 콘솔 경고 1건은 Trancy 브라우저 확장의 하이드레이션 불일치로 앱과 무관. |
| ADR 판단 | 불필요 (ADR 0004 운영 정책 — 선택적 prop은 콜러 영향 0) |
| 남은 warning | 기존 부채 (Knip) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**리팩토링 완성도**

- [x] 외부 동작 변경 확인 — 폼 제출·검증 동작은 동일, 외형만 ui/로 바뀜 (사용자 합의된 변경)
- [x] 불필요한 기능 변경 미포함 확인 (이관 + 선행 prop 2개만)

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 불필요한 코드·디버그 로그 제거 여부

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: auth 4폼의 외형이 `ui/` 디자인 시스템으로 바뀝니다. 일관된 UI를 위해 사용자가 합의한 변경입니다 (아래 BEFORE/AFTER 표 참고).
- **운영 리스크**: 없음. 빌드·배포 경로 변화 없음.
- **QA 후속**: `/reset-password`는 Supabase 복구 토큰이 있어야 직접 렌더되어 자동 검증에서 빠졌습니다. 머지 후 토큰 보유 상태에서 한 번 확인하면 좋습니다.
- **롤백 시 영향**: 없음. 선택적 prop은 기존 호출부에 영향이 없어, 되돌려도 기존 동작이 유지됩니다.
- **먼저 볼 화면 / 흐름**: 아래 BEFORE/AFTER 표. 외형이 바뀌므로 4개 경로를 직접 비교합니다.

### BEFORE / AFTER 비교

> 아래 표의 각 셀에 스크린샷을 드래그·드롭으로 채웁니다. **BEFORE는 `develop` 브랜치(이관 전) 기준**, **AFTER는 이 브랜치(이관 후) 기준**으로 캡처합니다. `/reset-password`는 Supabase 복구 토큰이 필요해 선택 사항입니다.

| 페이지 (경로) | BEFORE — 이관 전 (`develop`) | AFTER — 이관 후 (이 브랜치) |
| --- | --- | --- |
| 로그인 `/login` | <img width="1000" height="820" alt="before-login" src="https://github.com/user-attachments/assets/baf8de22-9148-4894-9abd-b83afa5a3590" /> |  <img width="1000" height="820" alt="after-login" src="https://github.com/user-attachments/assets/d9edf20c-840f-4a4f-aea6-7b4b997d8bf8" />  |
| 회원가입 `/sign-up` | <img width="1000" height="820" alt="before-signup" src="https://github.com/user-attachments/assets/4d14311a-6960-4508-ab01-bfbf82e9982e" /> |<img width="1000" height="820" alt="after-signup" src="https://github.com/user-attachments/assets/83a6a5e8-7a29-4a08-b492-02f4d13252a8" />   |
| 비밀번호 재설정 요청 `/forget-password` | <img width="1000" height="820" alt="before-forget" src="https://github.com/user-attachments/assets/00bf5015-17fd-49e0-8073-6399aa1ba5af" /> | <img width="1000" height="820" alt="after-forget" src="https://github.com/user-attachments/assets/5a516001-9af4-4414-bd13-e58da6743cf2" />|

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 이 PR은 `ui/` 입력 어휘 통일의 첫 적용(Phase C-1)입니다. 후속으로 `BulletinForm`·`ImageUpload`도 `form/`에서 `ui/`로 이관하면 `form/` 디렉토리를 정리할 수 있습니다.
- `Button` `loading`은 접근성 때문에 옵션 A(스피너 `aria-hidden` + 텍스트 `@include blind`)로 구현했습니다. 다음에 `loading`을 다른 곳에 쓸 때도 같은 패턴을 유지해야 버튼 접근가능 이름이 비지 않습니다.
- 선택적 prop 추가는 ADR 0004 운영 정책상 콜러 영향 0이면 ADR이 필요 없습니다. 이번 두 prop이 그 사례입니다.
