### PR TITLE
[Feat] 흩어진 native select 3곳을 제어형 ui/Select로 통일

### DIFF
--- a/docs/exec-plans/active/2026-06-14-ui-select.md
+++ b/docs/exec-plans/active/2026-06-14-ui-select.md
@@ -1,0 +1,122 @@
+# ui-select
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-14
+- **브랜치**: feat/ui-select (feat/ui-search-select 위에 스택 — NoticeControlBar 공유)
+- **Open questions**: none
+- **ADR needed**: no — ui/ 신규 컴포넌트는 ADR 0004 범위. 단일값·즉시확정 정의와 단계화는 Codex 설계 분석으로 확정.
+
+## 목표
+
+흩어진 native `<select>` 3곳을 제어형 `ui/Select` 하나로 모은다. 트리거 스타일을 통일하고 `value`와 `onChange(value)` 계약을 고정한다. 그래서 뒤 단계에서 내부를 custom listbox나 반응형으로 바꿔도 호출부는 그대로 둔다. (이번은 native-trigger 기반 Phase 1 — 모바일 시트, admin Field Select, 열린 목록 완전 일관성은 후속 단계로 미룬다.)
+
+## 검증된 Assumptions
+
+(explorer가 `<select>` 전수 + BottomSheet 변형 + ui 패턴을 읽고 확인)
+
+- native `<select>`는 닫힌 트리거만 CSS로 스타일된다. 열린 옵션 목록은 OS/브라우저가 그려 일관 불가 → 완전 일관성은 custom listbox/시트가 필요(Phase 3).
+- select 4곳: A 공지 분류(`NoticeControlBar.tsx:94`, URL 쿼리·부모 prop, `NOTICE_CATEGORIES`), B 설교 정렬(`SermonResultHeader.tsx:53`, `useSermonFilter`, 인라인 옵션), C admin 페이지당 개수(`Pagination.tsx:95`, 부모 props, `PAGE_SIZE_OPTIONS`), D admin 폼 Select ×3(`primitives/Select.tsx`, `useFieldContext`+admin `.shell` 토큰).
+- A만 native↔BottomSheet 진짜 쌍(`CategoryBottomSheet`, CSS `pc_only`/`mobile_only` 분기). B 정렬은 모바일에서 `AdvancedFilterSheet`(staged 다필드)에 별도 존재. C·D는 모바일 짝 없음.
+- `CategoryBottomSheet`는 단일값 즉시확정(`ui/BottomSheet`+`ui/ListItem`+체크). `AdvancedFilterSheet`·`SeriesFilterBottomSheet`는 staged draft+적용 — 단일 Select가 아니다.
+- `ui/BottomSheet`는 `if (typeof window === 'undefined') return null` 뒤 `createPortal` — 알려진 hydration mismatch 부채. 반응형 Select가 시트를 소유하려면 ClientPortal 수정이 선행돼야 한다(Phase 2).
+- `ui/SearchField`(제어·값기반 onChange·aria-label prop)·`ui/Tabs`(`items[]`+제어값+onChange)가 Select API의 직접 선례.
+
+## Non-goals
+
+- 모바일 BottomSheet 통합 — Phase 3(반응형). 이번엔 `CategoryBottomSheet` 등 모바일 시트를 그대로 둔다.
+- 열린 옵션 목록 완전 일관성(custom listbox) — Phase 3. 이번은 native-trigger.
+- D admin 폼 Select(`useFieldContext`·admin 토큰 결합) — Phase 4.
+- B의 모바일 `AdvancedFilterSheet` 정렬 — staged 다필드라 Select 범위 밖, 유지.
+- size·variant 등 추측성 prop — 3곳이 실제로 필요로 할 때만.
+
+## Success Criteria
+
+- `src/components/ui/Select/`를 신설하고 barrel에 export한다. **제어 컴포넌트로 단일 값을 즉시 확정한다.** props는 `value: string`, `onChange: (value: string) => void`, `options: { value: string; label: string }[]`, `aria-label?`, `disabled?`, `id?`, `name?`, `className?`. **옵션은 `options` 배열로 받는다**(children `<option>` 아님 — Phase 3 custom listbox 업그레이드 때 호출부 불변).
+- styled native `<select>` + custom chevron(native 화살표 `appearance: none`으로 숨김, `IoChevronDown` 1개). 기본 시맨틱 토큰만(admin/content 분기 없음 — PR1 Option C와 동일). 하드코딩 px·hex 0.
+- A `NoticeControlBar` 분류 PC select가 ui/Select를 쓴다. `pc_only` 분기·`CategoryBottomSheet`(모바일)는 유지. `value`=`currentCategory ?? ''`, 옵션 첫 항목 `전체 분류`(value `''`).
+- B `SermonResultHeader` 정렬 select가 ui/Select를 쓴다(`recent`/`oldest`).
+- C admin `Pagination` 페이지당 개수 select가 ui/Select를 쓴다(`pageSize` 숫자↔문자 변환, `PAGE_SIZE_OPTIONS`). `<label>` 래핑 대신 `aria-label`.
+- a11y: 키보드(Tab·↑↓·Enter·Esc)는 native select가 보장. `aria-label` 또는 연결된 label로 접근성 이름.
+- `node scripts/verify-task.mjs ui-select` lint·stylelint·build 통과, knip 신규 0.
+- Claude in Chrome: `/news/notices`·`/sermons/all`(정렬)·admin 설교 목록(페이지당)에서 select가 렌더되고 값 변경이 URL/상태에 반영되며 콘솔 에러 0.
+
+## 영향받는 파일
+
+- 신설: `src/components/ui/Select/{Select.tsx, Select.module.scss}`, `src/components/ui/index.ts`(barrel), `src/components/ui/README.md`(표 1줄)
+- 이관: `src/app/(content)/news/notices/_component/NoticeControlBar.{tsx,module.scss}`, `src/app/(content)/sermons/_component/SermonListPage/SermonResultHeader.{tsx,module.scss}`, `src/components/admin/sermons/SermonListPage/parts/Pagination.{tsx,module.scss}`
+
+## 단계별 체크리스트
+
+- [x] 1. ui/Select 신설 — 제어·단일값·즉시확정, `options[]`, styled native `<select>`+chevron, 시맨틱 토큰. `display` 미선언(호출부 소유), `emphasized` 내부 cascade. barrel+README.
+- [x] 2. A `NoticeControlBar` 분류 PC select → ui/Select (`pc_only`·CategoryBottomSheet 유지, `category_select` 스타일 제거).
+- [x] 3. B `SermonResultHeader` 정렬 → ui/Select (`sort_select`는 반응형 display만, `sort_select_active`는 `emphasized`로 대체).
+- [x] 4. C admin `Pagination` 페이지당 개수 → ui/Select (숫자↔문자, aria-label, `.page_size`의 select 스타일 제거).
+- [x] 5. `verify-task` PASS + Claude in Chrome 3영역 검증.
+
+## Verification
+
+- `node scripts/verify-task.mjs ui-select`
+- Claude in Chrome: 위 3영역 select 렌더·값변경 반영·콘솔 0.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: PASS — 설계 분석 완료. ui/Select를 단일값·즉시확정 DS 컴포넌트로 정의하고 native-trigger Phase 1 + 단계화 채택.
+- **현재 판단**: multi-field staged 시트(AdvancedFilterSheet 등)는 Select가 아니라 filter form이라 흡수하지 않는다. 반응형(모바일 시트 소유)은 ClientPortal hydration 수정 뒤에 도입한다. PC/모바일 분기는 CSS(`pc_only`)를 표준으로 삼는다(useMediaQuery는 SSR 위험). D admin 폼 Select는 결합이 가장 강해 마지막 단계로 미룬다.
+- **다음 행동**: WORK — step 1 ui/Select 신설부터.
+
+## Codex 1차 검증
+
+- **결론**: 조건부 통과 — blocker 0. `multiple`·`size`·`children` 타입 제외 1건 반영.
+- **현재 판단**: `options`+`value`/`onChange(value)` 계약, display-not-set(호출부 소유), spread 순서 모두 OK로 판정. minor는 보류 — C의 wrapping `<label>`+`aria-label`은 동작·이름 깔끔해 유지, SearchField와 13px 높이차는 control-height 토큰 follow-up, `SelectOption.disabled`는 필요 시 확장(yagni).
+- **다음 행동**: verify-task + Claude 2차.
+
+## Claude 2차 검증
+
+- **최종 판단**: 통과. verify-task PASS(lint·styles·build), Chrome 3경로 동작 확인.
+- **현재 판단**: knip 신규는 `SelectOption` 타입 export 1종이다 — `ButtonVariant` 등 모든 ui 타입 export와 같이 무해하다(바깥에서 import하는 곳이 0). 새 unused 파일·값 export는 0이다. 소비자가 옵션 배열에 타입을 붙일 수 있게 유지한다.
+- **다음 행동**: doc-editor → COMMIT 승인.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260614-194250 | ✅ | ✅ | ✅ | `SelectOption` 타입(무해) | Chrome 3경로 |
+
+## 검증 이력
+
+<details>
+<summary>2026-06-14 Codex 설계 판단(트레이드오프 분석)</summary>
+
+- 판정: native 래퍼 단독은 목표 미달, custom listbox everywhere는 과투자, responsive는 ClientPortal 수정 후 단계 도입.
+- 이유: 열린목록 일관성·a11y 비용·portal hydration 위험을 한 PR에 몰면 위험.
+- 조치: Phase 1=foundational+A/B/C, Phase 2=ClientPortal, Phase 3=반응형, Phase 4=D.
+
+</details>
+
+<details>
+<summary>2026-06-14 Claude 2차 — Chrome 3경로 상세</summary>
+
+- A `/news/notices`: 분류 "예배" 선택 → `?category=예배` 필터(4건), emphasized로 primary 틴트.
+- B `/sermons/all`: 정렬 oldest 선택 → `?sort=oldest`, border·color `$primary`·bg `$primary-subtle`.
+- C `/admin/sermons`: "10/20/50/100개" 렌더·부모 props 제어, aria-label "페이지당 항목 수".
+
+</details>
+
+## 후속 작업
+
+- Phase 2 — `ClientPortal` mounted-state 헬퍼로 `BottomSheet`·`Modal` hydration mismatch 수정
+  - 이유: `typeof window` 가드가 server null↔client portal 불일치. 반응형 Select가 시트를 소유하기 전 선행 필요.
+  - 다음 기준: Phase 1 머지 후 `start-task.mjs client-portal-hydration`.
+  - 기록 위치: `docs/tech-debt/active.md`(portal hydration 항목)
+- Phase 3 — ui/Select 반응형 업그레이드(PC popover/custom listbox + 모바일 BottomSheet)
+  - 이유: native 열린목록 불일치를 완전 해소. 모바일 단일값 시트(CategoryBottomSheet)를 Select가 흡수.
+  - 다음 기준: Phase 2(ClientPortal) 완료 후.
+  - 기록 위치: 없음
+- Phase 4 — D admin 폼 Select(`useFieldContext`·admin 토큰) 이관
+  - 이유: Field context 연결·admin `.shell` 토큰 분리를 먼저 풀어야 한다.
+  - 다음 기준: ui/Select API 안정 후.
+  - 기록 위치: 없음
+- control-height 토큰으로 SearchField·Select 높이 통일
+  - 이유: 같은 toolbar에 SearchField(~53px)·Select(~40px)가 나란히 와서 13px 차이가 난다. 기능·a11y는 정상이나 시각 정렬이 어긋난다.
+  - 다음 기준: 두 컴포넌트가 한 줄에 자주 같이 쓰이는 화면이 늘면.
+  - 기록 위치: 없음

--- a/docs/exec-plans/active/2026-06-14-ui-select.md
+++ b/docs/exec-plans/active/2026-06-14-ui-select.md
@@ -68,13 +68,13 @@
 
 ## Codex 1차 검증
 
-- **결론**: 조건부 통과 — blocker 0. `multiple`·`size`·`children` 타입 제외 1건 반영.
+- **결론**: FIX_APPLIED — blocker 0. Codex가 짚은 `multiple`·`size`·`children` 타입 제외 1건을 반영했다.
 - **현재 판단**: `options`+`value`/`onChange(value)` 계약, display-not-set(호출부 소유), spread 순서 모두 OK로 판정. minor는 보류 — C의 wrapping `<label>`+`aria-label`은 동작·이름 깔끔해 유지, SearchField와 13px 높이차는 control-height 토큰 follow-up, `SelectOption.disabled`는 필요 시 확장(yagni).
 - **다음 행동**: verify-task + Claude 2차.
 
 ## Claude 2차 검증
 
-- **최종 판단**: 통과. verify-task PASS(lint·styles·build), Chrome 3경로 동작 확인.
+- **최종 판단**: PASS — verify-task(lint·styles·build) 통과, Chrome 3경로 동작 확인.
 - **현재 판단**: knip 신규는 `SelectOption` 타입 export 1종이다 — `ButtonVariant` 등 모든 ui 타입 export와 같이 무해하다(바깥에서 import하는 곳이 0). 새 unused 파일·값 export는 0이다. 소비자가 옵션 배열에 타입을 붙일 수 있게 유지한다.
 - **다음 행동**: doc-editor → COMMIT 승인.
 

--- a/src/app/(content)/news/notices/_component/NoticeControlBar.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeControlBar.module.scss
@@ -60,25 +60,6 @@
   flex-shrink: 0;
 }
 
-.category_select {
-  padding: 0 $spacing-8;
-  height: 3.2rem;
-  border: 1px solid $border-primary;
-  border-radius: 0.6rem;
-  background: $bg-secondary;
-  font-size: $font-size-12;
-  color: $txt-secondary;
-  cursor: pointer;
-  outline: none;
-
-  &.selected {
-    font-weight: $font-weight-semibold;
-    color: $txt-primary;
-  }
-
-  @include focus-ring('strong');
-}
-
 .category_btn {
   display: inline-flex;
   align-items: center;

--- a/src/app/(content)/news/notices/_component/NoticeControlBar.tsx
+++ b/src/app/(content)/news/notices/_component/NoticeControlBar.tsx
@@ -5,7 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import clsx from 'clsx';
 import { IoClose } from 'react-icons/io5';
 import { RiArrowDownSLine } from 'react-icons/ri';
-import { SearchField } from '@/components/ui';
+import { SearchField, Select } from '@/components/ui';
 import CategoryBottomSheet from '@/app/(content)/news/notices/_component/CategoryBottomSheet';
 import { NOTICE_CATEGORIES } from '@/constants/notice';
 import type { NoticeCategory } from '@/types/notice';
@@ -91,23 +91,17 @@ export default function NoticeControlBar({ total, currentCategory, currentSearch
       {/* 우측: 분류 + 검색 */}
       <div className={styles.bar_right}>
         {/* PC: select */}
-        <select
-          className={clsx(
-            styles.category_select,
-            styles.pc_only,
-            currentCategory && styles.selected
-          )}
+        <Select
+          className={styles.pc_only}
           value={currentCategory ?? ''}
-          onChange={(e) => handleCategoryChange(e.target.value)}
+          onChange={handleCategoryChange}
+          options={[
+            { value: '', label: '전체 분류' },
+            ...Object.entries(NOTICE_CATEGORIES).map(([key, label]) => ({ value: key, label }))
+          ]}
+          emphasized={Boolean(currentCategory)}
           aria-label="분류 선택"
-        >
-          <option value="">전체 분류</option>
-          {Object.entries(NOTICE_CATEGORIES).map(([key, label]) => (
-            <option key={key} value={key}>
-              {label}
-            </option>
-          ))}
-        </select>
+        />
 
         {/* Mobile: text button */}
         <button

--- a/src/app/(content)/sermons/_component/SermonListPage/SermonListPage.module.scss
+++ b/src/app/(content)/sermons/_component/SermonListPage/SermonListPage.module.scss
@@ -293,31 +293,12 @@ $radio-dot-size: 0.4rem;
 }
 
 .sort_select {
-  // mobile은 BottomSheet의 정렬 섹션이 단일 진입점 — sort_select 비표시
+  // 스타일은 ui/Select가 소유. 여기선 PC 전용 노출만(모바일은 BottomSheet 정렬 섹션).
   display: none;
-  padding: $spacing-8 $spacing-32 $spacing-8 $spacing-12;
-  font-size: $font-size-12;
-  font-weight: $font-weight-semibold;
-  font-family: inherit;
-  color: $txt-primary;
-  background-color: $bg-card;
-  border: 1px solid $border-primary;
-  border-radius: $radius-xs;
-  cursor: pointer;
-  appearance: none;
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23737373' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: right $spacing-10 center;
 
   @include respond-up($breakpoint-pc-sm) {
     display: inline-block;
   }
-}
-
-.sort_select_active {
-  color: $primary;
-  background-color: $primary-subtle;
-  border-color: $primary;
 }
 
 // ── Series Meta Card (시리즈 필터 활성 시) ──

--- a/src/app/(content)/sermons/_component/SermonListPage/SermonResultHeader.tsx
+++ b/src/app/(content)/sermons/_component/SermonListPage/SermonResultHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import clsx from 'clsx';
+import { Select } from '@/components/ui';
 import useSermonFilter from '@/hooks/useSermonFilter';
 import type { SermonSortKey } from '@/types/sermon';
 import styles from './SermonListPage.module.scss';
@@ -50,15 +50,17 @@ export default function SermonResultHeader({
           {sort === 'oldest' ? '오래된순' : '최신순'}
         </span>
       )}
-      <select
-        className={clsx(styles.sort_select, isActive && styles.sort_select_active)}
+      <Select
+        className={styles.sort_select}
         value={sort}
-        onChange={(event) => setSort(event.target.value as SermonSortKey)}
+        onChange={(value) => setSort(value as SermonSortKey)}
+        options={[
+          { value: 'recent', label: '정렬: 최신순' },
+          { value: 'oldest', label: '정렬: 오래된순' }
+        ]}
+        emphasized={isActive}
         aria-label="설교 정렬"
-      >
-        <option value="recent">정렬: 최신순</option>
-        <option value="oldest">정렬: 오래된순</option>
-      </select>
+      />
     </header>
   );
 }

--- a/src/components/admin/sermons/SermonListPage/parts/Pagination.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/Pagination.tsx
@@ -2,6 +2,7 @@
 
 import clsx from 'clsx';
 import { HiChevronLeft, HiChevronRight } from 'react-icons/hi';
+import { Select } from '@/components/ui';
 import { getTotalPages } from '@/utils/pagination';
 import styles from '../table.module.scss';
 
@@ -92,16 +93,12 @@ export default function Pagination({
       </div>
       <label className={styles.page_size}>
         페이지당
-        <select
-          value={pageSize}
-          onChange={(event) => onPageSizeChange(Number(event.target.value))}
-        >
-          {PAGE_SIZE_OPTIONS.map((size) => (
-            <option key={size} value={size}>
-              {size}개
-            </option>
-          ))}
-        </select>
+        <Select
+          value={String(pageSize)}
+          onChange={(value) => onPageSizeChange(Number(value))}
+          options={PAGE_SIZE_OPTIONS.map((size) => ({ value: String(size), label: `${size}개` }))}
+          aria-label="페이지당 항목 수"
+        />
       </label>
     </div>
   );

--- a/src/components/admin/sermons/SermonListPage/table.module.scss
+++ b/src/components/admin/sermons/SermonListPage/table.module.scss
@@ -406,21 +406,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-
-  select {
-    padding: 5px 8px;
-    background: $bg-card;
-    border: 1px solid $border-admin;
-    border-radius: 5px;
-    color: $txt-secondary;
-    font-size: 12px;
-    cursor: pointer;
-
-    &:focus {
-      outline: none;
-      border-color: $primary-soft;
-    }
-  }
+  // select 스타일은 ui/Select가 소유.
 }
 
 .mobile_list {

--- a/src/components/ui/README.md
+++ b/src/components/ui/README.md
@@ -19,6 +19,7 @@ import { Button, TextField, Modal, Label } from '@/components/ui';
 | **Button** | 액션 트리거 | `variant`(primary/secondary/ghost/danger), `size`(sm/md/lg), `leadingIcon`/`trailingIcon`, `fullWidth` |
 | **TextField** | 단일 줄 입력 | `label`, `helper`/`error`/`success`, `leadingIcon`/`trailingSlot` |
 | **Textarea** | 멀티라인 입력 | `label`, `error`/`success`, `showCounter` + `maxLength`, `autoGrow` |
+| **Select** | 단일 값 선택 (styled native `<select>`) | `value`/`onChange(value)`, `options[]`, `emphasized`(활성 필터 강조) |
 | **Modal** | PC 우선 다이얼로그 | `open`, `title`, `size`(sm 32rem / md 48rem / lg 64rem), `role`(dialog/alertdialog), `footer` |
 | **BottomSheet** | 모바일 시트 (PC ≥pc-sm 이상은 중앙 모달) | `open`, `title`, `showClose`, `footer` |
 | **Tabs** | 탭 네비게이션 | `variant`(underline/pill), `size`, `items`(label/count/leadingIcon/panelId), `fitted` |

--- a/src/components/ui/Select/Select.module.scss
+++ b/src/components/ui/Select/Select.module.scss
@@ -1,0 +1,35 @@
+// display는 선언하지 않는다 — 반응형 노출(pc_only 등)은 호출부 className이 소유한다.
+// (cross-module cascade 충돌을 피하려고 ui/Select가 display를 잡지 않음)
+.select {
+  padding: $spacing-8 $spacing-32 $spacing-8 $spacing-12;
+  font-size: $font-size-13;
+  font-family: inherit;
+  color: $txt-primary;
+  background-color: $bg-card;
+  border: 1px solid $border-primary;
+  border-radius: $radius-xs;
+  cursor: pointer;
+  appearance: none;
+
+  // chevron — $txt-tertiary 계열 회색. data-uri라 토큰을 직접 주입할 수 없어 16진값 고정.
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23737373' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right $spacing-10 center;
+
+  &:focus-visible {
+    outline: none;
+    border-color: $border-focus;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    color: $txt-disabled;
+  }
+}
+
+// 비기본 값(활성 필터) 강조. `.select` 뒤에 와서 같은 모듈 내 cascade로 안전하게 덮는다.
+.emphasized {
+  color: $primary;
+  background-color: $primary-subtle;
+  border-color: $primary;
+}

--- a/src/components/ui/Select/Select.module.scss
+++ b/src/components/ui/Select/Select.module.scss
@@ -1,3 +1,8 @@
+@use 'sass:string';
+
+// chevron stroke 색은 $txt-tertiary를 따른다. data-uri라 #을 %23로 인코딩해 주입한다.
+$chevron-stroke: '%23' + string.slice('#{$txt-tertiary}', 2);
+
 // display는 선언하지 않는다 — 반응형 노출(pc_only 등)은 호출부 className이 소유한다.
 // (cross-module cascade 충돌을 피하려고 ui/Select가 display를 잡지 않음)
 .select {
@@ -11,14 +16,16 @@
   cursor: pointer;
   appearance: none;
 
-  // chevron — $txt-tertiary 계열 회색. data-uri라 토큰을 직접 주입할 수 없어 16진값 고정.
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23737373' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  // chevron — 색은 위 $chevron-stroke($txt-tertiary)를 따른다.
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='#{$chevron-stroke}' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right $spacing-10 center;
 
+  // border-color는 emphasized와 같은 $primary로 묻히므로, border와 분리된 offset
+  // outline으로 포커스를 표시한다 (일반·emphasized 상태 모두에서 보이게).
   &:focus-visible {
-    outline: none;
-    border-color: $border-focus;
+    outline: 2px solid $border-focus;
+    outline-offset: 2px;
   }
 
   &:disabled {

--- a/src/components/ui/Select/Select.tsx
+++ b/src/components/ui/Select/Select.tsx
@@ -1,0 +1,56 @@
+import { SelectHTMLAttributes } from 'react';
+import clsx from 'clsx';
+import styles from './Select.module.scss';
+
+export type SelectOption = { value: string; label: string };
+
+// multiple·size·children은 단일 값 계약과 충돌하므로 타입에서 제외(Codex 1차).
+type SelectProps = Omit<
+  SelectHTMLAttributes<HTMLSelectElement>,
+  'value' | 'onChange' | 'multiple' | 'size' | 'children'
+> & {
+  /** 현재 값 (제어 컴포넌트). */
+  value: string;
+  /** 값 변경. 이벤트가 아닌 선택된 값 문자열을 직접 받는다. */
+  onChange: (value: string) => void;
+  /** 옵션 목록. `<option>` children이 아니라 배열로 받는다 — 내부 구현이 바뀌어도 호출부 불변. */
+  options: SelectOption[];
+  /** 비기본 값이 선택됐음을 강조(활성 필터 표시). */
+  emphasized?: boolean;
+};
+
+/**
+ * 단일 값 선택 (제어 컴포넌트). styled native `<select>` + custom chevron.
+ *
+ * - 값 즉시 확정(`onChange`가 바로 호출됨) — 다중 필드 staged 시트와는 다른 용도다
+ * - 옵션은 `options` 배열로 받는다(children `<option>` 아님)
+ * - `display`를 직접 정하지 않는다 — 반응형 노출은 호출부가 `className`으로 제어한다
+ * - 시각 레이블이 없으면 `aria-label`을 넘겨 접근성 이름을 준다
+ *
+ * @example
+ * ```tsx
+ * <Select
+ *   value={sort}
+ *   onChange={setSort}
+ *   options={[{ value: 'recent', label: '최신순' }, { value: 'oldest', label: '오래된순' }]}
+ *   emphasized={sort !== 'recent'}
+ *   aria-label="설교 정렬"
+ * />
+ * ```
+ */
+export function Select({ value, onChange, options, emphasized, className, ...rest }: SelectProps) {
+  return (
+    <select
+      {...rest}
+      className={clsx(styles.select, emphasized && styles.emphasized, className)}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -31,6 +31,9 @@ export { Pill } from './Pill/Pill';
 
 export { SearchField } from './SearchField/SearchField';
 
+export { Select } from './Select/Select';
+export type { SelectOption } from './Select/Select';
+
 export { Skeleton } from './Skeleton/Skeleton';
 
 export { Tabs } from './Tabs/Tabs';


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 페이지마다 제각각이던 native `<select>` 3곳을 제어형 `ui/Select` 하나로 모아 트리거 스타일과 `value`/`onChange(value)` 계약을 통일한다.

**범위**:

- `src/components/ui/Select/` 신설 — 제어 컴포넌트, 단일값 즉시 확정, `options[]` 배열 계약
- 공지 분류(PC)·설교 정렬(PC)·admin 페이지당 개수 3곳을 `ui/Select`로 이관
- 이번은 native-trigger 기반 Phase 1 — 모바일 시트·열린 목록 완전 일관성·admin 폼 Select는 후속 단계

> ⚠️ **stacked PR**: 본 PR(PR2)은 아직 develop에 머지 안 된 `feat/ui-search-select`(PR1) 위에 스택됐습니다. **PR1 머지 후 base를 `develop`로 바꾸고** diff가 본 PR 고유 커밋만 남는지 확인하세요.

---

## 🔗 개발 컨텍스트

- **Task ID**: `ui-select`
- **Exec Plan**: `docs/exec-plans/active/2026-06-14-ui-select.md`
- **관련 ADR**: ADR 0004(ui/ 컴포넌트 범위) 안 — 신규 ADR 불필요. 단일값·즉시확정 정의와 단계화는 Codex 설계 분석으로 확정
- **제외한 범위**: 모바일 BottomSheet 통합(Phase 3), 열린 목록 custom listbox(Phase 3), admin 폼 Select(Phase 4), 설교 모바일 AdvancedFilterSheet 정렬(staged 다필드라 Select 범위 밖)

---

## 💡 변경 배경 (Motivation)

native `<select>`는 닫힌 트리거만 CSS로 스타일된다. 열린 옵션 목록은 OS·브라우저가 직접 그려 화면마다 모양이 달라진다. 게다가 공지 분류·설교 정렬·admin 페이지당 개수 3곳이 각자 다른 스타일을 들고 있어 디자인 시스템에 구멍이 났다. API를 지금 고정해 두면, 뒤 단계에서 내부를 custom listbox나 반응형 시트로 바꿔도 호출부 코드는 그대로 둘 수 있다.

---

## 🔧 주요 변경점 (Key Changes)

- `src/components/ui/Select/{Select.tsx, Select.module.scss}` 신설 — styled native `<select>` + custom chevron(native 화살표는 `appearance: none`으로 숨김). props는 `value: string`·`onChange: (value: string) => void`·`options: { value; label }[]`·`aria-label?`·`disabled?`·`id?`·`name?`·`className?`
- 공지 분류(PC) `NoticeControlBar` 이관 — `pc_only` 분기와 모바일 `CategoryBottomSheet`는 그대로 유지, 기존 `category_select` 스타일 제거
- 설교 정렬(PC) `SermonResultHeader` 이관 — `sort_select`는 반응형 `display`만 남기고, 활성 강조 `sort_select_active`는 `emphasized` prop으로 대체
- admin 페이지당 개수 `Pagination` 이관 — `pageSize` 숫자↔문자 변환, `aria-label`, 기존 select 스타일 제거
- `src/components/ui/index.ts` barrel export + `README.md` 표 1줄 추가

---

## 🧩 설계 단계화 (Phased Plan)

API를 한 번 고정하고, 비용이 큰 부분은 뒤 단계로 미뤘다. 각 단계는 호출부를 건드리지 않고 내부만 교체한다.

| 단계 | 범위 | 이 PR |
| --- | --- | --- |
| Phase 1 | native-trigger 기반 ui/Select + 3곳 이관 | ✅ 본 PR |
| Phase 2 | `ClientPortal`로 BottomSheet·Modal hydration 부채 수정 | 후속 |
| Phase 3 | 반응형 업그레이드(PC popover/custom listbox + 모바일 BottomSheet) | 후속 |
| Phase 4 | admin 폼 Select(`useFieldContext`·admin 토큰) 이관 | 후속 |

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| `display` 소유 주체 | 호출부가 소유, ui/Select는 미선언 | 모듈 경계를 넘는 cascade 충돌을 피함 | ui/Select가 `display`를 잡으면 호출부의 반응형 `display`와 충돌 |
| 활성 필터 강조 방식 | `emphasized` prop(내부 cascade) | 같은 모듈 안 cascade라 안전 | 호출부 클래스 override는 cross-module이라 깨지기 쉬움 |
| 토큰 분기 | 기본 시맨틱 토큰만(admin/content 분기 없음) | ADR 0012 Option C와 동일, 하드코딩 px·hex 0 | admin `.shell` 토큰 결합은 Phase 4 admin 폼 Select로 미룸 |
| 옵션 전달 방식 | `options[]` 배열 | Phase 3 custom listbox 업그레이드 때 호출부 불변 | children `<option>`은 내부 구현을 native에 묶어 교체를 막음 |

> ⚠️ **트레이드오프**: native-trigger라 열린 옵션 목록은 여전히 OS·브라우저가 그린다. 완전한 시각 일관성은 Phase 3 custom listbox까지 미뤘다. 같은 toolbar의 SearchField(~53px)와 Select(~40px) 사이 13px 높이 차이도 control-height 토큰 follow-up으로 남았다.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| `verify-task` | PASS, RUN_ID=`20260614-201918`, lint·styles·build 통과 |
| Codex 계획 검증 | PASS — 단일값·즉시확정 정의 + native-trigger Phase 1 + 단계화 채택 |
| Codex 1차 검증 | FIX_APPLIED — `multiple`·`size`·`children` 타입 제외 1건 반영, blocker 0 |
| Claude 2차 검증 | PASS — knip 신규는 `SelectOption` 타입 export 1종(모든 ui 타입 export와 같은 무해 클래스, 바깥 import 0). Chrome 3경로 동작 확인 |
| ADR 판단 | 불필요 — ADR 0004 범위 |

**Claude 2차 검증 — Chrome 3경로 실측**

| 경로 | 렌더 | 값 변경 | emphasized |
| --- | --- | --- | --- |
| `/news/notices` (분류) | ✓ 10옵션 | "예배" → `?category=예배` 필터(4건) | primary 틴트 적용 |
| `/sermons/all` (정렬) | ✓ | oldest → `?sort=oldest` | border·color `$primary`·bg `$primary-subtle` |
| `/admin/sermons` (페이지당) | ✓ "10/20/50/100개" | 부모 props 제어 | — |

---

## 📝 리뷰어를 위한 메모

- `options[]` 계약을 고정한 이유는 Phase 3에서 내부를 custom listbox로 바꿔도 호출부를 안 건드리려는 것이다. children `<option>`으로 받으면 이 자유도가 사라진다.
- `display`를 ui/Select가 안 잡는 규칙을 깨면 호출부 반응형 `display`와 cascade 충돌이 난다. 새 호출부를 붙일 때 `display`는 호출부 모듈에서 선언한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
