### PR TITLE
[Fix] Modal·BottomSheet portal hydration mismatch 해소

### DIFF
--- a/docs/exec-plans/active/2026-06-15-client-portal-hydration.md
+++ b/docs/exec-plans/active/2026-06-15-client-portal-hydration.md
@@ -1,0 +1,115 @@
+# client-portal-hydration
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-15
+- **브랜치**: fix/client-portal-hydration
+- **Open questions**: none (focus-timing 리스크는 호출부 6곳 전부 closed-start 확인으로 해소)
+- **ADR needed**: no — 신규 ui/ 유틸은 ADR 0004 범위, 기존 mounted two-pass 패턴 적용이라 구조 결정 없음.
+
+## 목표
+
+Modal·BottomSheet의 hydration mismatch(서버 null vs 첫 클라 portal)를 없앤다. 공통 `ui/ClientPortal`(mounted two-pass)로 첫 client render를 서버와 같은 null로 맞춘 뒤 portal을 생성한다. tech-debt `portal hydration` 항목을 해소한다.
+
+## 검증된 Assumptions
+
+(EXPLORE: Read + Grep로 확인)
+
+- Modal(`Modal.tsx:78,86,123`)·BottomSheet(`BottomSheet.tsx:54,62,100`)는 `typeof window` 가드 뒤 `createPortal`을 하고 **항상 렌더**(open/close는 CSS+aria-hidden/inert). → 서버 null vs 첫 클라 portal로 mismatch (tech-debt 등록분, `/sermons/[id]` BottomSheet 콘솔 에러).
+- NoticeDrawer(`NoticeDrawer.tsx:40`)는 `if (!isOpen || typeof window...) return null`, `isOpen = notice !== null`. 초기 notice=null이라 서버·첫 클라 모두 null → mismatch 없음. createPortal은 `!isOpen` 가드 뒤라 서버에서 도달 안 함 → `typeof window`는 redundant.
+- `getElementById('modal-root') ?? document.body` 타깃 해석이 3파일에 중복.
+- `useDialog.ts:48–91` focus effect는 deps `[open, disableEscape]`, 내부에서 `panelRef.current`가 null이면 focus skip, 이후 panel이 붙어도 재실행 안 함 → initially-open에서만 focus 누락 위험.
+- Modal/BottomSheet 호출부 6곳(SermonMetaActions·SeriesFilterBottomSheet·AdvancedFilterSheet·FilterDropdown·CategoryBottomSheet·ConfirmModal) 전부 `open`이 state/prop으로 closed-start → initially-open 없음 → focus 위험 미발생.
+
+## 접근법
+
+- Modal·BottomSheet를 `ClientPortal`로 래핑하고 `typeof window` 가드·수동 `createPortal`·`getElementById`를 제거한다. always-mounted 구조라 두 패스 전환이 앱 mount 시 한 번만 일어나, 다이얼로그를 열 때마다 생기는 지연은 없다.
+- NoticeDrawer는 redundant `typeof window` 한 줄만 지운다. 닫히면 컴포넌트가 unmount되는 구조라 ClientPortal로 바꾸면 열 때마다 1프레임 지연이 생기므로 통일하지 않는다.
+- 대안 4종을 기각했다 (Codex 분석).
+  - `suppressHydrationWarning`: 서버 null과 클라 portal의 구조 차이를 못 덮는다.
+  - `useSyncExternalStore`: mount 감지 하나에 과한 추상화다.
+  - `dynamic ssr:false`: 컴포넌트 전체를 클라 전용으로 돌려 범위가 너무 넓다.
+  - guard 제거: 서버에 `document`가 없어 throw한다.
+
+## Success Criteria
+
+- `src/components/ui/ClientPortal/ClientPortal.tsx` 신설 — mounted two-pass + 타깃 해석. Modal·BottomSheet가 직접 import해 portal 위임.
+- Modal·BottomSheet에서 `typeof window` 가드·`createPortal`·`getElementById` 직접 호출 0.
+- NoticeDrawer는 `if (!isOpen) return null`로 축소(typeof window 제거), 동작·open timing 불변.
+- `verify-task` lint·stylelint·build 통과, knip 신규 0(또는 무해 export만).
+- Claude in Chrome: `/sermons/[id]`에서 BottomSheet·Modal 열기 → 콘솔 hydration 경고 0, open 시 focus 정상.
+
+## 영향받는 파일
+
+- 신설: `src/components/ui/ClientPortal/ClientPortal.tsx`
+- 수정: `src/components/ui/Modal/Modal.tsx`, `src/components/ui/BottomSheet/BottomSheet.tsx`, `src/app/(content)/news/notices/_component/NoticeDrawer.tsx`
+
+## Non-goals
+
+- NoticeDrawer를 ClientPortal로 통일하지 않는다. 통일하면 열 때마다 1프레임 지연만 더해지고, NoticeDrawer는 이미 서버·첫 클라 모두 null이라 mismatch가 없다.
+- useDialog focus effect 리팩터 — 현재 호출부 전부 closed-start라 불필요.
+- Modal/BottomSheet의 open/close 메커니즘(항상 렌더+CSS) 변경.
+
+## 단계별 체크리스트
+
+- [ ] 1. `ui/ClientPortal` 신설 (mounted two-pass + 타깃, closed-start 주석).
+- [ ] 2. Modal → ClientPortal 래핑, typeof window·createPortal·getElementById 제거.
+- [ ] 3. BottomSheet → 동일.
+- [ ] 4. NoticeDrawer → `typeof window` 한 줄 제거.
+- [ ] 5. CODEX_FIRST_PASS → verify-task → Chrome hydration 0 실측.
+- [ ] 6. tech-debt portal hydration 항목 → resolved.
+
+## Verification
+
+- `node scripts/verify-task.mjs client-portal-hydration`
+- Claude in Chrome: `/sermons/[id]` BottomSheet·Modal 열기 → 콘솔 hydration 경고 0, focus 정상.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: PASS — ClientPortal mounted two-pass(Modal·BottomSheet) + NoticeDrawer MINIMAL 채택. 대안 4종(suppressHydrationWarning·useSyncExternalStore·dynamic ssr:false·guard 제거) 기각 근거 확인.
+- **현재 판단**: Codex가 focus-timing(initially-open일 때 panelRef가 null이라 focus가 skip되는 경로)을 검증 필수 항목으로 짚었다. EXPLORE에서 호출부 6곳이 전부 closed-start임을 확인해 해소했다. useDialog 수정은 필요 없다.
+- **다음 행동**: WORK — step 1 ClientPortal부터.
+
+## Codex 1차 검증
+
+- **결론**: PASS — 5항목(ClientPortal SSR 안전·Modal/BottomSheet 동작 유지·NoticeDrawer 제거 안전·import/순환 무관·eslint-disable 정당) 모두 통과. blocker 0.
+- **현재 판단**: closed-start라 open 시 focus trap 정상(initially-open만 보정 필요, 현재 없음). eslint-disable는 `useDrawerHistory.ts`·`ConfirmModal` 선례와 동일 규칙. Codex 권고 — NoticeDrawer `notice`가 SSR 시점 non-null이 될 변경이 생기면 `typeof window` 제거를 재검토(현재 `drawerNotice` 초기값 null이라 안전).
+- **다음 행동**: Claude 2차(완료) → COMMIT.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task(ESLint·stylelint·build) 통과 + Chrome 실측으로 hydration 경고 0·BottomSheet 동작 확인.
+- **현재 판단**: `/sermons/2` 하드 리로드 시 콘솔 hydration mismatch 0(유일 메시지는 무관한 locatorjs 확장 로그). 공유 BottomSheet가 ClientPortal 통해 PC 중앙 모달로 정상 open(타이틀·옵션·백드롭·close). closed-start라 open 시점엔 mounted=true이고 panel이 존재해 focus가 정상 동작한다. ESLint `set-state-in-effect` 경고는 mount 게이트가 effect에서 state를 한 번 바꾸는 구조에서 나온다. 다른 방법으로는 못 없애므로 line-disable에 사유 주석을 붙여 뒀다(queueMicrotask 금지 규칙 준수).
+- **다음 행동**: tech-debt portal hydration → resolved(머지 후), COMMIT 승인.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260615-150615 | ✅ | ✅ | ✅ | 0(기존 부채만) | Chrome `/sermons/2` hydration 0·BottomSheet open |
+
+## 검증 이력
+
+<details>
+<summary>2026-06-15 Codex 트레이드오프 분석</summary>
+
+- 판정: ClientPortal two-pass(Modal/BottomSheet) + NoticeDrawer MINIMAL 권장
+- 이유: hydration contract 충족, 대안은 숨김·과추상·범위과대·SSR throw로 열위
+- 조치: focus-timing은 호출부 closed-start 확인으로 해소
+
+</details>
+
+<details>
+<summary>2026-06-15 Codex 1차 검증 1차 시도</summary>
+
+- 판정: BLOCK (Codex 샌드박스 spawn 오류로 파일 미검증 — 환경 문제, 코드 무관)
+- 이유: 실행 환경 오류라 5항목 모두 미검증
+- 조치: 환경 복구 후 재시도 → 실파일 검증 PASS
+
+</details>
+
+## 후속 작업
+
+- initially-open 다이얼로그가 필요해지면 useDialog focus를 portal mount 트리거로 재실행하도록 보정
+  - 이유: ClientPortal 첫 패스가 null이라 그 시점 focus effect가 panel 부재로 skip.
+  - 다음 기준: open=true로 mount하는 호출부가 생길 때.
+  - 기록 위치: 없음 (본 plan 후속)

--- a/src/app/(content)/news/notices/_component/NoticeDrawer.tsx
+++ b/src/app/(content)/news/notices/_component/NoticeDrawer.tsx
@@ -37,7 +37,7 @@ export default function NoticeDrawer({ notice, onClose, onNavigate, hasPrev, has
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, handleKeyDown]);
 
-  if (!isOpen || typeof window === 'undefined') return null;
+  if (!isOpen) return null;
 
   const isNew = isRecent(notice.created_at);
   const isUrgent = notice.category === '긴급';

--- a/src/components/ui/BottomSheet/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet/BottomSheet.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { MouseEvent, PropsWithChildren, ReactNode, useRef } from 'react';
-import { createPortal } from 'react-dom';
 import clsx from 'clsx';
 import { IoClose } from 'react-icons/io5';
 import { useDialog } from '@/hooks/useDialog';
+import { ClientPortal } from '../ClientPortal/ClientPortal';
 import styles from './BottomSheet.module.scss';
 
 type Props = PropsWithChildren<{
@@ -51,52 +51,51 @@ export function BottomSheet({
     componentName: 'BottomSheet'
   });
 
-  if (typeof window === 'undefined') return null;
-
   const showHeader = Boolean(trimmedTitle) || showClose;
 
   const handleOverlayClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === overlayRef.current) onClose();
   };
 
-  return createPortal(
-    <div
-      ref={overlayRef}
-      className={clsx(styles.overlay, open && styles.open)}
-      onClick={handleOverlayClick}
-      aria-hidden={!open}
-      inert={!open}
-    >
+  return (
+    <ClientPortal>
       <div
-        ref={panelRef}
-        className={clsx(styles.sheet, open && styles.open)}
-        role="dialog"
-        aria-modal="true"
-        {...(trimmedTitle
-          ? { 'aria-labelledby': titleId }
-          : { 'aria-label': accessibleLabel })}
-        tabIndex={-1}
+        ref={overlayRef}
+        className={clsx(styles.overlay, open && styles.open)}
+        onClick={handleOverlayClick}
+        aria-hidden={!open}
+        inert={!open}
       >
-        <div className={styles.handle} aria-hidden="true" />
-        {showHeader && (
-          <header className={styles.header}>
-            {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
-            {showClose && (
-              <button
-                type="button"
-                className={styles.close_btn}
-                onClick={onClose}
-                aria-label="닫기"
-              >
-                <IoClose />
-              </button>
-            )}
-          </header>
-        )}
-        <div className={styles.body}>{children}</div>
-        {footer && <footer className={styles.footer}>{footer}</footer>}
+        <div
+          ref={panelRef}
+          className={clsx(styles.sheet, open && styles.open)}
+          role="dialog"
+          aria-modal="true"
+          {...(trimmedTitle
+            ? { 'aria-labelledby': titleId }
+            : { 'aria-label': accessibleLabel })}
+          tabIndex={-1}
+        >
+          <div className={styles.handle} aria-hidden="true" />
+          {showHeader && (
+            <header className={styles.header}>
+              {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
+              {showClose && (
+                <button
+                  type="button"
+                  className={styles.close_btn}
+                  onClick={onClose}
+                  aria-label="닫기"
+                >
+                  <IoClose />
+                </button>
+              )}
+            </header>
+          )}
+          <div className={styles.body}>{children}</div>
+          {footer && <footer className={styles.footer}>{footer}</footer>}
+        </div>
       </div>
-    </div>,
-    document.getElementById('modal-root') ?? document.body
+    </ClientPortal>
   );
 }

--- a/src/components/ui/ClientPortal/ClientPortal.tsx
+++ b/src/components/ui/ClientPortal/ClientPortal.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { PropsWithChildren, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * children을 `modal-root`(없으면 `document.body`)로 포털한다.
+ *
+ * 서버와 첫 클라이언트 렌더를 모두 null로 맞춰 hydration mismatch를 막는다 —
+ * `mounted`는 서버·hydration에서 `false`라 둘 다 null을 내고, portal은 `useEffect`가
+ * 도는 두 번째 패스에서만 생성된다(hydration 이후라 검사 대상 아님).
+ *
+ * 전제: 닫힌 상태로 시작하는(closed-start) 다이얼로그용. 처음부터 열린 채(open=true)
+ * mount되면 첫 패스가 null이라 useDialog focus effect가 panel 부재로 focus를 건너뛴다.
+ * 그런 호출부가 생기면 focus를 portal mount 이후로 보정해야 한다.
+ */
+export function ClientPortal({ children }: PropsWithChildren) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // 서버·hydration 첫 렌더를 null로 맞춘 뒤 mount 후 1회만 portal을 켠다.
+    // 이 client-only 게이트는 set-state-in-effect가 본질이라 의도적 (queueMicrotask 금지 규칙 준수).
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setMounted(true);
+  }, []);
+
+  if (!mounted) return null;
+
+  return createPortal(children, document.getElementById('modal-root') ?? document.body);
+}

--- a/src/components/ui/Modal/Modal.tsx
+++ b/src/components/ui/Modal/Modal.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { MouseEvent, PropsWithChildren, ReactNode, useRef } from 'react';
-import { createPortal } from 'react-dom';
 import clsx from 'clsx';
 import { IoClose } from 'react-icons/io5';
 import { useDialog } from '@/hooks/useDialog';
+import { ClientPortal } from '../ClientPortal/ClientPortal';
 import styles from './Modal.module.scss';
 
 export type ModalSize = 'sm' | 'md' | 'lg';
@@ -75,51 +75,50 @@ export function Modal({
     disableEscape: role === 'alertdialog'
   });
 
-  if (typeof window === 'undefined') return null;
-
   const showHeader = Boolean(trimmedTitle) || showClose;
 
   const handleOverlayClick = (e: MouseEvent<HTMLDivElement>) => {
     if (e.target === overlayRef.current) onClose();
   };
 
-  return createPortal(
-    <div
-      ref={overlayRef}
-      className={clsx(styles.overlay, open && styles.open)}
-      onClick={handleOverlayClick}
-      aria-hidden={!open}
-      inert={!open}
-    >
+  return (
+    <ClientPortal>
       <div
-        ref={panelRef}
-        className={clsx(styles.panel, styles[`size_${size}`])}
-        role={role}
-        aria-modal="true"
-        {...(trimmedTitle
-          ? { 'aria-labelledby': titleId }
-          : { 'aria-label': accessibleLabel })}
-        tabIndex={-1}
+        ref={overlayRef}
+        className={clsx(styles.overlay, open && styles.open)}
+        onClick={handleOverlayClick}
+        aria-hidden={!open}
+        inert={!open}
       >
-        {showHeader && (
-          <header className={styles.header}>
-            {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
-            {showClose && (
-              <button
-                type="button"
-                className={styles.close_btn}
-                onClick={onClose}
-                aria-label="닫기"
-              >
-                <IoClose />
-              </button>
-            )}
-          </header>
-        )}
-        <div className={styles.body}>{children}</div>
-        {footer && <footer className={styles.footer}>{footer}</footer>}
+        <div
+          ref={panelRef}
+          className={clsx(styles.panel, styles[`size_${size}`])}
+          role={role}
+          aria-modal="true"
+          {...(trimmedTitle
+            ? { 'aria-labelledby': titleId }
+            : { 'aria-label': accessibleLabel })}
+          tabIndex={-1}
+        >
+          {showHeader && (
+            <header className={styles.header}>
+              {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
+              {showClose && (
+                <button
+                  type="button"
+                  className={styles.close_btn}
+                  onClick={onClose}
+                  aria-label="닫기"
+                >
+                  <IoClose />
+                </button>
+              )}
+            </header>
+          )}
+          <div className={styles.body}>{children}</div>
+          {footer && <footer className={styles.footer}>{footer}</footer>}
+        </div>
       </div>
-    </div>,
-    document.getElementById('modal-root') ?? document.body
+    </ClientPortal>
   );
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: Modal·BottomSheet가 서버에서 null, 첫 클라이언트 렌더에서 portal을 그려 생기던 React hydration mismatch를 없앤다.

**범위**:

- 신규 `ui/ClientPortal`로 서버·첫 클라이언트 렌더를 둘 다 null로 맞춘 뒤 portal 생성
- Modal·BottomSheet를 ClientPortal로 래핑, 중복 `createPortal`·타깃 해석 제거
- NoticeDrawer의 불필요한 `typeof window` 한 줄 제거

---

## 🔗 개발 컨텍스트

- **Task ID**: `client-portal-hydration`
- **Exec Plan**: `docs/exec-plans/active/2026-06-15-client-portal-hydration.md`
- **관련 ADR**: `docs/decisions/0004` (ui/ 범위 — 신규 ADR 불필요, 기존 mounted two-pass 패턴 적용)
- **관련 tech debt**: `docs/tech-debt/active.md` `portal hydration` 항목 (머지 후 resolved 이동)
- **작업 범위**: Modal·BottomSheet의 portal 생성 시점, 3파일에 중복된 타깃 해석 집약
- **제외한 범위**: NoticeDrawer를 ClientPortal로 통일하지 않음, useDialog focus effect 리팩터, open/close 메커니즘(항상 렌더+CSS) 변경

---

## 🐛 버그 리포트 (Bug Report)

**재현 조건:**

- 환경: `/sermons/[id]` 페이지, 서버 렌더 후 하드 리로드
- 재현 절차:
  1. `/sermons/2`를 하드 리로드한다
  2. 콘솔을 연다
  3. 공유 BottomSheet가 포함된 페이지에서 hydration 경고를 확인한다
- 기대 동작: 콘솔에 hydration 경고가 없다
- 실제 동작: 서버 null과 첫 클라이언트 portal의 구조 차이로 hydration mismatch 경고가 출력된다

**근본 원인 (Root Cause):**

- Modal·BottomSheet가 `if (typeof window === 'undefined') return null` 뒤 `createPortal`을 호출하고 항상 렌더된다. 서버는 null, 첫 클라이언트 렌더는 portal이라 두 결과가 어긋난다.

**관련 이슈:**

- Issue: N/A (tech-debt `portal hydration` 항목)

---

## 🔧 수정 내용 (Fix Details)

- 신규 `src/components/ui/ClientPortal/ClientPortal.tsx` — mounted 상태로 서버·첫 클라이언트 렌더를 둘 다 null로 맞추고, `useEffect` 이후 portal을 만든다. `getElementById('modal-root') ?? document.body` 타깃 해석도 이 한 곳으로 모은다(3파일 중복 제거).
- `src/components/ui/Modal/Modal.tsx`·`src/components/ui/BottomSheet/BottomSheet.tsx` — ClientPortal로 래핑하고 직접 호출하던 `typeof window`·`createPortal`·`getElementById`를 제거한다. hook 순서·ref·aria-hidden/inert·CSS는 그대로다.
- `src/app/(content)/news/notices/_component/NoticeDrawer.tsx` — `!isOpen`(초기 notice=null) 가드 때문에 서버에서 `createPortal`에 도달하지 않아 mismatch가 없다. 불필요한 `typeof window` 한 줄만 제거한다.
- mount 게이트의 set-state-in-effect는 line-disable + 사유 주석으로 둔다. queueMicrotask 금지 규칙을 지키며, `useDrawerHistory`·`ConfirmModal` 선례와 같은 처리다.

---

## ⚠️ 영향 범위 (Impact)

**변경된 동작:**

- Modal·BottomSheet의 portal이 앱 mount 직후 한 번 생성된다. always-mounted 구조라 다이얼로그를 열 때마다 생기는 지연은 없다.

**영향받는 컴포넌트·모듈:**

- `ui/Modal`, `ui/BottomSheet`를 쓰는 호출부 6곳(SermonMetaActions·SeriesFilterBottomSheet·AdvancedFilterSheet·FilterDropdown·CategoryBottomSheet·ConfirmModal) — 전부 `open`이 closed-start라 초기 focus 누락 위험 없음
- `news/notices`의 NoticeDrawer

**사이드 이펙트 가능성:**

> 없음. 호출부 6곳 모두 closed-start라 open 시점에는 mounted=true·panel 존재로 focus가 정상 동작한다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| mismatch 해소 방식 | ClientPortal mounted two-pass | 서버·첫 클라이언트 렌더를 같은 null로 맞춰 hydration contract를 지킨다 | `suppressHydrationWarning`: 서버 null과 클라 portal의 구조 차이를 못 덮음 / `useSyncExternalStore`: mount 감지 하나에 과한 추상화 / `dynamic ssr:false`: 컴포넌트 전체를 클라 전용으로 돌려 범위 과대 / guard 제거: 서버에 `document`가 없어 throw |
| NoticeDrawer 처리 | `typeof window` 한 줄만 제거 | 이미 서버·첫 클라 모두 null이라 mismatch 없음. ClientPortal로 통일하면 열 때마다 1프레임 지연만 더해짐 | ClientPortal 통일: 동작 이득 없이 지연만 추가 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs client-portal-hydration` — PASS, RUN_ID=`20260615-150615`, HEAD=`3af545b`, failed=0, warned=Knip |
| `harness-gate` | 머지 직전 실행 예정 |
| Codex 계획 검증 | PASS (트레이드오프 분석, 대안 4종 기각) |
| Codex 1차 검증 | PASS (5항목) |
| Claude 2차 검증 | PASS |
| ADR 판단 | 불필요 (ui/ 범위는 ADR 0004) |
| 남은 warning | 기존 부채 (Knip) |

**수동 확인:**

| Before (버그 상태) | After (수정 후) |
| ------------------ | --------------- |
| `/sermons/2` 하드 리로드 시 콘솔에 hydration mismatch 경고 출력 | `/sermons/2` 하드 리로드 시 hydration 경고 0 (유일 메시지는 무관한 locatorjs 확장 로그), 공유 BottomSheet가 PC 중앙 모달로 정상 open |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**버그 수정 완성도**

- [x] 근본 원인(Root Cause) 해결 여부 (증상만 억제한 것은 아닌지 확인)
- [x] 동일 패턴의 잠재적 버그 추가 점검 여부 (NoticeDrawer까지 확인)
- [x] 수정 범위가 버그와 무관한 코드를 포함하지 않는지 확인

**코드 품질**

- [x] 불필요한 코드·디버그 로그 제거 여부

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 콘솔에 보이는 hydration 경고가 사라진다. 화면 동작은 그대로다.
- **운영 리스크**: 없음. portal 생성 시점만 mount 직후로 옮겼고 open/close 동작은 바뀌지 않았다.
- **QA 후속**: 없음. Chrome 실측으로 `/sermons/2` hydration 0·BottomSheet open을 확인했다.
- **롤백 시 영향**: 없음. ClientPortal을 되돌리면 기존 mismatch가 다시 나타날 뿐 다른 영향은 없다.
- **먼저 볼 화면 / 흐름**: `/sermons/2`에서 공유 BottomSheet 열기 → 콘솔 hydration 경고 0 확인

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- initially-open(`open=true`로 mount하는) 다이얼로그 호출부가 생기면 useDialog focus를 재검토한다. ClientPortal 첫 패스가 null이라 그 시점 focus effect가 panel 부재로 skip된다. 지금은 호출부 6곳이 모두 closed-start라 문제가 없다.
- NoticeDrawer의 `notice`가 SSR 시점에 non-null이 될 변경이 생기면 `typeof window` 제거를 재검토한다(현재 `drawerNotice` 초기값 null이라 안전).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
