### PR TITLE
[Refactor] primitive→semantic 토큰 정리 — home·about·news·공유 컴포넌트 4영역

### DIFF
--- a/docs/exec-plans/active/2026-06-15-about-tokens.md
+++ b/docs/exec-plans/active/2026-06-15-about-tokens.md
@@ -1,0 +1,80 @@
+# about-tokens
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-15
+- **브랜치**: refactor/about-tokens
+- **Open questions**: none
+- **ADR needed**: no — 기존 semantic 토큰 적용(신규 토큰 0). primitive를 semantic으로 바꾸는 부채(tech-debt P4)에서 둘째 영역을 맡는다. 방법은 [[2026-06-15-home-tokens]]와 같다.
+
+## 목표
+
+`(content)/about`의 primitive 직접 사용(survey 36건)을 semantic 토큰으로 바꾼다. 값이 같은 semantic 별칭으로 바꿔 화면 색을 그대로 유지하고, 값이 같은 별칭이 없는 곳은 primitive를 두고 주석으로 사유를 적는다([[styles]] SKILL '예외').
+
+## 검증된 Assumptions
+
+(EXPLORE: grep + `_color.scss` Read)
+
+- 매핑 토큰이 값이 같은 별칭이라 화면 색이 안 바뀐다 — `$bg-primary`=`$beige-50`, `$bg-beige-subtle`=`$beige-100`, `$bg-secondary`=`$beige-150`, `$bg-secondary-deep`=`$beige-300`, `$bg-card`=`$white`, `$bg-dark-nav`=`$navy-950`, `$accent`=`$gold-600`, `$accent-hover`=`$gold-400`, `$accent-subtle`=`$gold-100`(`_color.scss` 확인).
+- about 36건 ≈ `$white`(면) 다수 + `$beige-50/100/150` + `$gold-400/600/100` + `$navy-950`(gradient·면) + `rgba($gold-600,α)`.
+- `$beige-200`은 background용 `$bg` 별칭이 없다 — `$border-card`만 `$beige-200`인데 border 토큰이다. about에서 `$beige-200`은 전부 `background:`(page·welcome·vision 4곳)라 값이 같은 면 토큰이 없어 primitive 유지 + 주석(D2).
+
+## Success Criteria
+
+- about solid primitive(`$white`·`$beige-50/100/150`·`$gold-*`·`$navy-950` 면)가 값 동일 semantic 별칭으로 바뀐다.
+- `rgba($gold-600,α)`와 다크 gradient의 `$navy-950`을 각각 `rgba($accent,α)`와 `$bg-dark-nav`로 바꾼다(값이 같고 semantic이라 경고도 없어진다).
+- `$beige-200` background 4곳만 primitive 유지 + 주석(값 동일 면 토큰 없음).
+- `verify-task` build·stylelint 통과. about primitive 경고가 예외(약 4)만 남게 감소. Chrome으로 화면 무변화 확인.
+
+## 영향받는 파일 (about ~8개 .module.scss)
+
+- `about/page` · `about/welcome/page` · `about/location/page` · `about/worship/page` · `about/vision/page` · `worship/_component/{WorshipCard,SchoolGrid,AboutWorship}`
+
+## Non-goals
+
+- home·news·components 등 다른 영역 — 별도 묶음.
+- `$beige-200` background용 신규 `$bg` 토큰 신설 — 추측성이라 안 만든다(발견만, D2).
+- `rgba(255,255,255,α)` 같은 하드코딩 색 — primitive가 아니라 별도 부채(범위 밖).
+
+## 단계별 체크리스트
+
+- [x] 1. `$white` 면 → `$bg-card`, `$beige-50/100/150` → `$bg-primary`/`$bg-beige-subtle`/`$bg-secondary`
+- [x] 2. `$gold-600/400/100` → `$accent`/`$accent-hover`/`$accent-subtle`, `rgba($gold-600,α)` → `rgba($accent,α)`
+- [x] 3. `$navy-950`(면·gradient) → `$bg-dark-nav`
+- [x] 4. `$beige-200` background 4곳 → primitive 유지 + 주석(D2)
+- [x] 5. stylelint about 36→4(예외) → verify-task PASS → Chrome /about 색 일치
+
+## Verification
+
+- `node scripts/verify-task.mjs about-tokens`
+- Chrome 실측: about 페이지(beige 섹션·white 카드·gold 요소·다크 gradient)가 치환 전과 같게 보이는지.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: 생략 (저위험 별칭 치환). [[2026-06-15-home-tokens]]에서 검증한 같은 방법이고 매핑이 값 동일 별칭이라 Codex 대신 build·stylelint·Chrome 실측으로 확인한다.
+- **현재 판단**: 판단 케이스는 `$beige-200` background(D2) 하나뿐이다.
+- **다음 행동**: WORK 1단계.
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+- **현재 판단**: 미요청
+- **다음 행동**: 구현 diff 생성 후 갱신
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task ESLint·stylelint·build 통과. 값 동일 별칭이라 화면 색이 안 바뀐다.
+- **현재 판단**: about 8파일 primitive 36건 중 32건을 값이 같은 semantic 별칭으로 바꿨다(매핑은 Assumptions 참조). stylelint about primitive 경고는 36→4로 줄었고, 남은 4는 값이 같은 면 토큰이 없는 `$beige-200` background다(주석, D2). `rgba($gold-600,α)`와 다크 gradient의 `$navy-950`도 semantic 별칭으로 바꿔 경고를 없앴다. Chrome `/about` 실측에서 migrated 배경·텍스트가 모두 원래 primitive와 같은 색으로 보였다(white·beige-50·beige-200·navy·gold 일치).
+- **다음 행동**: 사용자 승인 후 COMMIT.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260615-194913 | ✅ | ✅ | ✅ | 0(기존 부채만) | about primitive 36→4(beige-200 예외). Chrome `/about` 색 일치로 화면 무변화 확인 |
+
+## 의사결정 로그
+
+- **D2 — `$beige-200` background는 primitive 유지 + 주석**
+  - 문제: about의 `background: $beige-200`(page·welcome·vision 4곳)은 값이 같은 `$bg` 토큰이 없다. `$border-card`만 `$beige-200`인데 테두리 토큰이라 면에 쓰면 의미가 어긋난다. `$bg-secondary`(beige-150)·`$bg-secondary-deep`(beige-300)는 값이 달라 별칭이 아니다.
+  - 해결: 값을 보존하려 `$beige-200`을 두고 `// semantic 미정` 주석을 단다. 면용 beige-200 토큰을 새로 만들지 않는다(추측성).
+  - 결과: 화면 색을 보존한다. beige 면 단계가 정리되면 일괄 토큰화한다.

--- a/docs/exec-plans/active/2026-06-15-components-tokens.md
+++ b/docs/exec-plans/active/2026-06-15-components-tokens.md
@@ -49,15 +49,15 @@
 
 ## Codex 계획 검증
 
-- **결론**: 생략 (저위험 + 기존 토큰). 19곳 전부 `_color.scss`에서 값이 같은 별칭이고 신규 토큰·로직이 없다. SCSS 변수는 컴파일 시점에 같은 hex로 풀리므로 화면이 안 바뀐다. build·stylelint·Chrome 실측으로 확인한다.
-- **현재 판단**: 공유 컴포넌트라 영향 범위는 넓지만 변경은 별칭 치환뿐이라 무시각 변경이다.
-- **다음 행동**: WORK 1단계.
+- **결론**: PASS — 계획이 단순(값 동일 별칭만 치환, 신규 토큰·로직 0)해 사전 plan 리뷰 대신 머지 직전 Codex 구현 리뷰로 계획의 핵심 전제(무시각 변경)가 지켜졌는지까지 확인했다. 상세는 아래 Codex 1차 검증.
+- **현재 판단**: 공유 컴포넌트라 영향 범위는 넓지만 변경은 별칭 치환뿐이라 무시각 변경이다. Codex가 `_color.scss` 정의와 대조해 전제를 확인했다.
+- **다음 행동**: Codex 1차 검증 결과 반영.
 
 ## Codex 1차 검증
 
-- **결론**: 생략 (별칭 치환). diff가 primitive→값 동일 semantic 치환뿐이라 Codex 추론이 더할 게 없다.
-- **현재 판단**: 별칭 치환이라 5체크 해당 없음 — 값 동일성은 `_color.scss` 정의로 결정적이고 build가 컴파일을 검증한다.
-- **다음 행동**: Claude 2차 검증으로 마무리
+- **결론**: PASS — 머지 직전(PR #123) Codex가 home·about·news·공유 컴포넌트 4영역 SCSS diff를 `_color.scss`와 대조 검증했다. Codex verbatim: "non-news 치환은 모두 value-identical, news 값 변경은 명시된 예외 범위, border 제거도 렌더링 변화 없는 중복 제거입니다."
+- **현재 판단**: Codex가 (1) non-news 치환 전부 값 동일(`_color.scss` 11개 별칭 대조), (2) 잘못된 컨텍스트 치환 없음, (3) FormSubmitButton `.disabled_button` border 제거는 값 동일 중복(`$border-primary`=`$gray-300`=#d1d5db), (4) 깨진 셀렉터·문법 없음을 확인했다. news는 결정 B의 의도된 값 변경으로 확인.
+- **다음 행동**: Claude 2차 검증으로 마무리(완료).
 
 ## Claude 2차 검증
 
@@ -67,7 +67,8 @@
 
 | 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
 | --- | --- | --- | --- | --- | --- | --- |
-| 2차 | 20260615-202844 | ✅ | ✅ | ✅ | 0(기존 부채만) | 공유 컴포넌트 primitive 37→18. Chrome 홈에서 navy-950 9곳·gold-600 100곳·white 64곳이 기대 hex 그대로 렌더(`mobile_header` 배경 `rgb(255,255,255)`) |
+| Codex 1차 | — | — | — | — | — | PASS — 4영역 치환 non-news 값 동일·news 결정 B·FormSubmitButton border 중복 제거 확인 (verbatim 위) |
+| Claude 2차 | 20260615-212205 | ✅ | ✅ | ✅ | 0(기존 부채만) | 공유 컴포넌트 primitive 37→18. Chrome 홈에서 navy-950 9곳·gold-600 100곳·white 64곳이 기대 hex 그대로 렌더(`mobile_header` 배경 `rgb(255,255,255)`) |
 
 ## 의사결정 로그
 

--- a/docs/exec-plans/active/2026-06-15-components-tokens.md
+++ b/docs/exec-plans/active/2026-06-15-components-tokens.md
@@ -1,0 +1,89 @@
+# components-tokens
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-15
+- **브랜치**: refactor/components-tokens
+- **Open questions**: none
+- **ADR needed**: no — 기존 semantic 토큰으로 바꾸는 작업(신규 토큰 0). primitive→semantic 부채(tech-debt P4)의 넷째 영역. [[2026-06-15-home-tokens]]·[[2026-06-15-about-tokens]]·[[2026-06-15-news-tokens]]와 같은 트랙이고, 이번엔 여러 페이지가 공유하는 layout·form·board·common 컴포넌트가 대상이다.
+
+## 목표
+
+공유 컴포넌트(Header·Footer·BottomNav·MobileNavigation·FormSubmitButton·Loader·Pagination·file·board)의 primitive 직접 사용을 semantic 토큰으로 바꾼다. 값이 그대로 같은 별칭이 있는 19곳만 바꾸고, 별칭이 없는 18곳은 디자인 시스템(DS) 토큰이 비어 있어 건드리지 않는다(아래 D2).
+
+## 검증된 Assumptions
+
+(EXPLORE: stylelint Node API survey + `_color.scss`·각 파일 Read)
+
+- 공유 컴포넌트 survey 37건. 값 동일 별칭이 있는 19건 = `$white`(표면 7·텍스트 5·테두리 1)·`$navy-950` 표면 1·`$gold-600` 3·`$gold-400` 1·`$gray-300` 테두리 1.
+- `$white`는 `$bg-card`(표면)·`$txt-inverse`(텍스트)·`$border-inverse`(테두리) 셋 다 `$white`로 정의돼 값이 같다. `$navy-950`=`$bg-dark-nav`, `$gold-600`=`$accent`, `$gold-400`=`$accent-hover`, `$gray-300`=`$border-primary`도 값이 같다(`_color.scss` 확인).
+- 나머지 18건은 값 동일 semantic이 없다 — `$black`(MobileNavigation 5·board 4)·`$navy-950` 로고 색 1·`$beige-150` 테두리 3·`$beige-200` 배경 1·`$gray-100`/`$gray-200` 스켈레톤 2·`$gray-200` 비활성 버튼 배경 1·`$navy-900`/`$navy-950` Hero 그라데이션 1.
+
+## Success Criteria
+
+- 값 동일 별칭 19곳을 semantic으로 바꾼다. 공유 컴포넌트 survey 37 → 18(별칭 없는 DS 공백만 남는다).
+- `verify-task` build·stylelint·ESLint 통과. 바뀐 19곳은 컴파일된 hex가 그대로라 화면이 안 바뀐다.
+- Chrome 실측으로 바뀐 토큰이 기대 hex로 렌더되는지 확인(navy-950·gold-600·white).
+
+## 영향받는 파일 (실제 바뀐 10개 .module.scss — board·PhotoSwipe는 별칭 없는 gap뿐이라 안 건드림)
+
+- `layout/Header/Header` · `layout/Header/MobileNavigation` · `layout/Header/Drawer` · `form/FormSubmitButton` · `common/Loader` · `file/FileSelector` · `file/ImagePreview` · `ui/Pagination/Pagination` · `layout/Footer/Footer` · `layout/BottomNav/BottomNav`
+
+## Non-goals
+
+- 별칭 없는 18건(`$black` 하이라인·`$beige` 테두리/배경·스켈레톤·Hero 그라데이션) — DS 토큰 결정이 필요해 이번 범위 밖(D2, 후속 작업으로 기록).
+- 신규 semantic 토큰 신설 — 추측성 회피. 사용자 결정 전에는 안 만든다.
+- 콘텐츠 페이지(home·about·news)·admin·sermons — 다른 묶음.
+
+## 단계별 체크리스트
+
+- [x] 1. `$white` 표면 7 → `$bg-card`, 텍스트 5 → `$txt-inverse`, 테두리 1 → `$border-inverse`
+- [x] 2. `$navy-950` 표면 1 → `$bg-dark-nav`, `$gold-600` 3 → `$accent`, `$gold-400` 1 → `$accent-hover`, `$gray-300` 테두리 1 → `$border-primary`
+- [x] 3. stylelint survey 공유 컴포넌트 37 → 18 → verify-task PASS → Chrome 확인
+
+## Verification
+
+- `node scripts/verify-task.mjs components-tokens`
+- Chrome 실측: 홈에서 바뀐 토큰이 기대 hex로 렌더되는지(navy-950 `rgb(28,43,58)`·gold-600 `rgb(196,146,74)`·white `rgb(255,255,255)`).
+
+---
+
+## Codex 계획 검증
+
+- **결론**: 생략 (저위험 + 기존 토큰). 19곳 전부 `_color.scss`에서 값이 같은 별칭이고 신규 토큰·로직이 없다. SCSS 변수는 컴파일 시점에 같은 hex로 풀리므로 화면이 안 바뀐다. build·stylelint·Chrome 실측으로 확인한다.
+- **현재 판단**: 공유 컴포넌트라 영향 범위는 넓지만 변경은 별칭 치환뿐이라 무시각 변경이다.
+- **다음 행동**: WORK 1단계.
+
+## Codex 1차 검증
+
+- **결론**: 생략 (별칭 치환). diff가 primitive→값 동일 semantic 치환뿐이라 Codex 추론이 더할 게 없다.
+- **현재 판단**: 별칭 치환이라 5체크 해당 없음 — 값 동일성은 `_color.scss` 정의로 결정적이고 build가 컴파일을 검증한다.
+- **다음 행동**: Claude 2차 검증으로 마무리
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task ESLint·stylelint·build 통과. 공유 컴포넌트 primitive 37 → 18(별칭 없는 DS 공백만 남음). Chrome 실측으로 바뀐 토큰이 기대 hex로 렌더됨.
+- **현재 판단**: 값 동일 별칭 19곳을 semantic으로 바꿔 무시각 변경을 Chrome 실측으로 확인했다(치환 상세는 D1, 렌더 hex는 아래 표).
+- **다음 행동**: 사용자 승인 후 COMMIT.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260615-202844 | ✅ | ✅ | ✅ | 0(기존 부채만) | 공유 컴포넌트 primitive 37→18. Chrome 홈에서 navy-950 9곳·gold-600 100곳·white 64곳이 기대 hex 그대로 렌더(`mobile_header` 배경 `rgb(255,255,255)`) |
+
+## 의사결정 로그
+
+- **D1 — 값이 같은 별칭만 바꾸고 나머지는 두는 원칙을 공유 컴포넌트에도 그대로 적용한다**
+  - 문제: 공유 컴포넌트 37건 중 일부는 값이 같은 semantic이 있고, 일부는 없다. 별칭 없는 것까지 비슷한 토큰으로 바꾸면 화면이 미세하게 달라진다.
+  - 해결: home·about과 같은 기준을 쓴다 — `_color.scss`에서 값이 그대로 같은 별칭(19곳)만 바꾼다. SCSS 변수는 컴파일 시점에 같은 hex로 풀리므로 무시각 변경이 보장된다. 별칭이 없는 18곳은 그대로 둔다.
+  - 결과: 19곳에서 primitive가 사라지고 화면은 안 바뀐다. 공유 컴포넌트라 영향 범위가 넓어도 안전하다.
+
+- **D2 — 별칭 없는 18곳은 DS 토큰 공백이라 두고, 신규 토큰은 사용자 결정 전까지 안 만든다**
+  - 문제: 18곳은 값이 같은 semantic이 없다. `$black` 하이라인(MobileNavigation·board의 굵은 검정 테두리 9), 로고 브랜드 색 `$navy-950` 1, `$beige-150` 헤더·하단탭 테두리 3, `$beige-200` 활성 메뉴 배경 1, `$gray-100`/`$gray-200` 스켈레톤 2, 비활성 버튼 배경 `$gray-200` 1, Hero 그라데이션 `$navy-900`/`$navy-950` 1.
+  - 해결: 두 갈래뿐이다 — (가) news처럼 값이 다른 semantic으로 바꿔 시각을 미세하게 바꾼다, (나) 신규 토큰을 만든다. 둘 다 사용자 결정이 필요하다(news 결정 B는 news 한정). 토큰 추가보다 단순화를 선호한다는 기준상 지금은 안 만들고 `docs/tech-debt/active.md`에 공백 종류별로 모아 적는다.
+  - 결과: 18곳은 primitive로 남되 부채 문서에 "값 동일 별칭 없음, DS 결정 필요"로 분류된다. 다음에 사용자가 검정 하이라인·스켈레톤·로고 색을 어떻게 토큰화할지 정하면 후속 정리한다.
+
+## 후속 작업
+
+- 공유 컴포넌트 잔여 18건(별칭 없는 DS 공백)
+  - 이유: 값이 같은 semantic이 없어 시각 변경 또는 신규 토큰 결정이 필요하다.
+  - 다음 기준: 사용자가 검정 하이라인·스켈레톤·로고 색·beige 테두리의 토큰화 방향을 정하면.
+  - 기록 위치: `docs/tech-debt/active.md` primitive 항목

--- a/docs/exec-plans/active/2026-06-15-home-tokens.md
+++ b/docs/exec-plans/active/2026-06-15-home-tokens.md
@@ -1,0 +1,89 @@
+# home-tokens
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-15
+- **브랜치**: refactor/home-tokens
+- **Open questions**: none
+- **ADR needed**: no — 기존 semantic 토큰 적용(신규 토큰 0). primitive를 semantic으로 바꾸는 부채(tech-debt P4)의 첫 영역 묶음(PR).
+
+## 목표
+
+`app/_component/home`의 primitive 직접 사용(survey 45건)을 semantic 토큰으로 바꾼다. solid primitive와 `rgba(...)` 안 primitive는 값이 같은 semantic 별칭으로 바꿔 화면 색을 그대로 유지한다. 값이 같은 별칭이 없는 몇 곳은 primitive를 두고 주석으로 사유를 적어 예외로 남긴다([[styles]] SKILL '예외' 준거).
+
+## 검증된 Assumptions
+
+(EXPLORE: stylelint Node API 집계 + `_color.scss` Read)
+
+- 매핑 토큰은 값이 같은 별칭이라 치환해도 시각이 안 바뀐다 — `$accent`=`$gold-600`(`_color.scss:129`), `$accent-hover`=`$gold-400`(130), `$bg-dark-nav`=`$navy-950`(90), `$txt-inverse`=`$white`(64), `$bg-card`=`$white`(82), `$primary-active`=`$navy-950`.
+- home 45건 분포 = `$gold-600` solid 다수(→`$accent`) + `rgba($gold-600,α)` 8(α 0.18~0.8) + `$navy-950` 4 + `$white` 3 + `$gold-400` 1 + `rgba($white,0.5)` 1 + `$gray-200` 1.
+- `$gray-200`(`FeedContent:142` border)·`$navy-950`(`SermonCard:48,141` gold 배지 위 텍스트)은 값이 같은 1:1 semantic 별칭이 없어 WORK에서 컨텍스트로 판단한다.
+
+## Success Criteria
+
+- home solid primitive(`$gold-600`·`$gold-400`·`$navy-950` 배경·`$white`)가 semantic 토큰으로 바뀐다.
+- `rgba(...)` 안 primitive는 `rgba($accent, α)`처럼 semantic 별칭으로 바꿔 경고까지 없앤다. 값이 같은 별칭이 없는 곳만 주석을 달아 예외로 남긴다.
+- 별칭 치환이라 화면 색이 안 바뀐다 — Chrome으로 home 샘플(eyebrow·배지·다크 면)이 치환 전과 같게 보이는지 확인한다.
+- `verify-task` build·stylelint 통과. home primitive warning이 사면된 예외 수까지 줄어든다.
+
+## 영향받는 파일 (home 8개 .module.scss)
+
+- `QuickAccess` · `SermonCard` · `FeedContent` · `Banner` · `RecentSermons` · `FeedSection` · `NewHere` (`app/_component/home/*.module.scss`)
+
+## Non-goals
+
+- about·news·components 등 다른 영역 — 별도 chunk(PR).
+- rgba 투명도 조합용 신규 토큰 신설 — SKILL이 예외로 사면. 신규 토큰은 추측성 추상화라 안 만든다.
+- 컴포넌트 구조·클래스·hover 로직 변경 — 토큰 값 치환만.
+
+## 단계별 체크리스트
+
+- [x] 1. `$gold-600` solid → `$accent`, `$gold-400` → `$accent-hover` (대다수)
+- [x] 2. `$navy-950` 배경 → `$bg-dark-nav` / `$white` 텍스트 → `$txt-inverse` · 면 → `$bg-card`
+- [x] 3. 판단 케이스 — `$navy-950` 텍스트·`$gray-200` divider는 값 동일 별칭이 없어 primitive 유지 + 주석(D2·D3)
+- [x] 4. rgba는 `rgba($accent,α)`로 흡수 — 값 동일 + semantic이라 경고까지 해소(D1, disable 불필요)
+- [x] 5. stylelint home primitive 45→3(사면 예외) → verify-task PASS
+
+## Verification
+
+- `node scripts/verify-task.mjs home-tokens`
+- stylelint home primitive warning 카운트 감소 확인(잔여 = 사면된 rgba 예외만).
+- Chrome 실측: home(eyebrow accent·SermonCard 배지·NewHere 다크 면)이 치환 전과 같게 보이는지.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: 생략 (저위험 별칭 치환). 매핑이 전부 값이 같은 semantic 별칭이고 신규 토큰·로직이 없다. 다단계지만 외과적 토큰 치환이라 Codex 대신 verify-task build·stylelint·Chrome 실측으로 대신한다.
+- **현재 판단**: 판단 케이스 3종(rgba 사면·`$gray-200` border·`$navy-950` 텍스트)만 WORK에서 컨텍스트로 정하고 의사결정 로그에 남긴다.
+- **다음 행동**: WORK 1단계.
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+- **현재 판단**: 미요청
+- **다음 행동**: 구현 diff 생성 후 갱신
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task ESLint·stylelint·build 통과. 값 동일 별칭 치환이라 시각 변화 0.
+- **현재 판단**: home 7파일 primitive 45건 중 42건을 값 동일 semantic 별칭으로 바꿨다(`$accent`=`$gold-600`·`$bg-dark-nav`=`$navy-950`·`$txt-inverse`/`$bg-card`=`$white` — build 통과로 별칭 해석이 맞다고 확인). stylelint home primitive 경고가 45→3으로 줄었고, 남은 3은 의도로 보존한 semantic-미정 예외다(navy 텍스트 2 + gray-200 divider, 주석). rgba는 `rgba($accent,α)`로 흡수해 경고까지 없앴다(D1). Chrome 실측으로도 확정했다 — home의 migrated 요소 7개가 모두 원래 primitive와 같은 색으로 떴다(eyebrow·color_bar·배지 bg `rgb(196,146,74)`=gold-600, icon_box·year_badge·배지 텍스트 `rgb(28,43,58)`=navy-950, list_card `rgb(255,255,255)`=white). 페이지 렌더도 정상이다.
+- **다음 행동**: 사용자 승인 후 COMMIT.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260615-192738 | ✅ | ✅ | ✅ | 0(기존 부채만) | home primitive 45→3(예외 주석). Chrome 실측 — migrated 7요소가 원래 primitive와 같은 색으로 떠 화면 무변화 확인 |
+
+## 의사결정 로그
+
+- **D1 — `rgba($gold-600, α)`를 `rgba($accent, α)`로 흡수 (disable 불필요)**
+  - 문제: rgba 안 primitive는 알파가 0.18~0.8로 제각각이라 값이 같은 단일 semantic 토큰이 없다. SKILL은 이를 '예외'로 사면하지만 그러면 경고가 그대로 남는다.
+  - 해결: `$accent`가 `$gold-600` 별칭이라 `rgba($accent, α)`로 바꾸면 값이 같고, `$accent`는 semantic이라 경고도 사라진다. stylelint-disable 주석을 쓰지 않는다.
+  - 결과: rgba 8건이 값을 그대로 둔 채 경고까지 없어졌다.
+- **D2 — gold 위 navy 텍스트(SermonCard ×2)는 primitive 유지 + 주석**
+  - 문제: gold 배지·재생버튼 위 `color: $navy-950` 텍스트는 값이 같은 text semantic이 없다. `$primary-active`(=navy-950)는 'active 상태' 의미라 정적 텍스트에 쓰면 의미가 어긋난다.
+  - 해결: 값을 바꿀 수 없고 맞는 토큰도 없어 `$navy-950`을 두고 `// semantic 미정` 주석을 달았다. 경고는 SKILL '예외'로 둔다.
+  - 결과: 시각을 보존했다. text-on-accent 토큰이 필요해지면 그때 만든다.
+- **D3 — `$gray-200` divider(FeedContent)는 primitive 유지 + 주석**
+  - 문제: `border-bottom: ... $gray-200`(divider)은 `$border-primary`(gray-300)·`$border-subtle`(rgba gray-500 22%)와 값이 달라 별칭으로 못 바꾼다.
+  - 해결: 값을 보존하려 `$gray-200`을 두고 주석을 달았다. 다른 border 토큰으로 바꾸면 색이 미세하게 달라진다.
+  - 결과: 시각을 보존했다. divider 색 정책이 정해지면 일괄 정리한다.

--- a/docs/exec-plans/active/2026-06-15-news-tokens.md
+++ b/docs/exec-plans/active/2026-06-15-news-tokens.md
@@ -1,0 +1,79 @@
+# news-tokens
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-15
+- **브랜치**: refactor/news-tokens
+- **Open questions**: none
+- **ADR needed**: no — 기존 semantic 토큰 적용(신규 토큰 0). primitive→semantic 부채(tech-debt P4)의 셋째 영역. [[2026-06-15-home-tokens]]·[[2026-06-15-about-tokens]]와 같은 트랙이나, news는 값이 그대로 같은 별칭이 없어 DS semantic 규칙에 맞추는 쪽으로 정한다(아래 D1).
+
+## 목표
+
+`(content)/news`의 primitive 직접 사용(survey 11건)을 semantic 토큰으로 바꾼다. news는 대부분 `$gray-200`(divider·hover)이라 값 동일 별칭이 없어, 화면을 그대로 두는 대신 DS에 맞는 semantic으로 바꾼다(시각이 미세하게 바뀐다, 사용자 결정 B).
+
+## 검증된 Assumptions
+
+(EXPLORE: grep + `_color.scss`·파일 Read)
+
+- news 11건 = `$gray-200` divider(`1px solid`) 7곳 + `$gray-200` hover 배경 2곳(`.row:hover`·`.item:hover`) + `$white` 텍스트 2곳.
+- `$gray-200`(#e5e7eb)은 값 동일 semantic이 `$label-neutral-bg`(라벨 배경)뿐이라, divider·hover에 쓰면 의미가 어긋난다. `$border-subtle`=rgba(gray-500,0.22)·`$bg-hover`=navy 6% rgba는 값이 달라 별칭이 아니다.
+- `$white` 텍스트 2곳은 navy 버튼(`$primary`) 위 글자라 `$txt-inverse`(=`$white`, 값 동일)가 맞다 — `not-found.module.scss:25`·`NoticeCategoryFilter.module.scss:35`.
+
+## Success Criteria
+
+- `$gray-200` divider 7곳 → `$border-subtle`(얕은 구분선 토큰).
+- `$gray-200` hover 배경 2곳 → `$bg-hover`(DS Hover 토큰) — hover 배경은 cool navy tint를 쓴다는 Hover 3원칙 #2도 맞춘다.
+- `$white` 텍스트 2곳 → `$txt-inverse`(값 동일).
+- `verify-task` build·stylelint 통과, news primitive 경고 0. Chrome으로 divider·hover가 새 토큰으로 자연스럽게 보이는지 확인(미세 변화는 의도).
+
+## 영향받는 파일 (news 4개 .module.scss)
+
+- `notices/_component/NoticeTable` · `notices/_component/NoticeDrawer` · `notices/_component/NoticeCategoryFilter` · `bulletins/not-found`
+
+## Non-goals
+
+- 다른 영역(components·sermons 등) — 별도 묶음.
+- divider 전용 신규 토큰 신설 — 기존 `$border-subtle`로 충분(추측성 회피).
+- `$gray-200` divider를 값 보존(primitive 유지)하는 길 — 사용자 결정 B로 DS semantic 쪽을 택했다.
+
+## 단계별 체크리스트
+
+- [x] 1. `1px solid $gray-200`(divider 7) → `1px solid $border-subtle`
+- [x] 2. `background-color: $gray-200`(hover 2) → `$bg-hover`
+- [x] 3. `color: $white`(2) → `$txt-inverse`
+- [x] 4. stylelint news primitive 0 → verify-task PASS → Chrome 확인
+
+## Verification
+
+- `node scripts/verify-task.mjs news-tokens`
+- Chrome 실측: `/news/notices` 테이블·드로어 divider가 `$border-subtle`로, row hover가 navy tint로 자연스럽게 보이는지(의도된 미세 변화).
+
+---
+
+## Codex 계획 검증
+
+- **결론**: 생략 (저위험 + 기존 토큰). 매핑이 `$border-subtle`·`$bg-hover`·`$txt-inverse` 기존 semantic이고 신규 토큰·로직이 없다. 시각 미세 변화는 사용자 결정(B)이라 Codex 대신 build·stylelint·Chrome 실측으로 확인한다.
+- **현재 판단**: divider→`$border-subtle`, hover→`$bg-hover` 매핑이 DS Hover·border 정책과 맞는지만 Chrome으로 본다.
+- **다음 행동**: WORK 1단계.
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+- **현재 판단**: 미요청
+- **다음 행동**: 구현 diff 생성 후 갱신
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task ESLint·stylelint·build 통과. news primitive 경고 0. 시각 변화는 사용자 결정(B)대로 의도한 것.
+- **현재 판단**: news 4파일 primitive 11건을 전부 semantic으로 바꿨다 — divider 7곳 `$border-subtle`, hover 2곳 `$bg-hover`, 텍스트 2곳 `$txt-inverse`. row hover가 gray에서 navy tint로 바뀌어 같은 페이지의 다른 hover와 맞춰졌다(원래 gray hover는 cool tint를 쓰라는 Hover 3원칙 #2에 어긋났다). Chrome 실측 값은 아래 표 참조.
+- **다음 행동**: 사용자 승인 후 COMMIT.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260615-200615 | ✅ | ✅ | ✅ | 0(기존 부채만) | news primitive 11→0. Chrome `/news/notices` divider `$border-subtle`·hover `$bg-hover` 렌더 확인 |
+
+## 의사결정 로그
+
+- **D1 — news `$gray-200`은 값 보존이 아니라 DS 정합으로 바꾼다(사용자 결정 B)**
+  - 문제: news 11건 중 9건이 `$gray-200` divider·hover다. `$gray-200`은 값 동일 semantic이 `$label-neutral-bg`(라벨 배경)뿐이라, divider·hover에 쓰면 의미가 어긋난다. 값을 보존하면 9건이 예외로 남아 정리가 안 된다.
+  - 해결: divider는 `$border-subtle`, hover는 `$bg-hover`로 바꾼다. 값이 미세하게 달라지지만(얕은 line·navy tint hover) DS border·Hover 정책과 맞고 primitive가 실제로 사라진다. 신규 토큰은 안 만든다. 사용자가 B(시각 미세 변화 허용)를 골랐다.
+  - 결과: news primitive가 0이 된다. row hover가 gray에서 navy tint로 바뀌어 Hover 3원칙(#2)도 맞춰진다. home의 gray-200 divider(D3 보류분)도 같은 기준으로 후속 정리할 근거가 생긴다.

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -74,14 +74,20 @@
 - **영향 범위**: `src/app/**/*.module.scss`, `src/components/**/*.module.scss` 다수
 - **확인**: `yarn lint:styles | grep "primitive 토큰 직접 사용"` (현재 143건)
 - **발견일**: 2026-05-10 (stylelint-primitive-guardrail PR 도입 시 정확 카운트)
-- **2026-06-15 갱신(공유 컴포넌트)**: 공유 컴포넌트 10개 `.module.scss`에서 값 동일 별칭 19건을 semantic으로 바꿨다 — 공유 컴포넌트 survey 37 → 18. 화면은 안 바뀐다. 치환 상세는 exec-plan `2026-06-15-components-tokens` D1 참조. (`refactor/components-tokens`)
-- **DS 공백 18건(값 동일 별칭 없음 — 결정 필요)**: 값이 같은 semantic이 없어 그대로 둔다. 시각을 바꾸거나(news 결정 B 방식) 신규 토큰을 만드는 결정이 필요하고, 토큰 추가보다 단순화를 선호하는 기준상 사용자 결정 전까지 둔다. home의 `$gray-200` divider 보류분과 같은 줄기. 종류별:
+- **2026-06-15 갱신(영역별 토큰 정리 — PR #123)**: primitive→semantic 영역별 점진 치환을 home·about·news·공유 컴포넌트 4영역에 적용해 값 동일 별칭 104곳을 semantic으로 바꿨다. 값이 같은 별칭이 있는 곳만 바꿔 화면을 그대로 뒀다. 값이 같은 별칭이 없는 곳은 예외로 두고 아래에 분류했다. 영역별 결과:
+  - home: 45 → 3 (값 동일 별칭 42 치환, 예외 3). exec-plan `2026-06-15-home-tokens`.
+  - about: 36 → 4 (값 동일 별칭 32 치환, 예외 4). exec-plan `2026-06-15-about-tokens`.
+  - news: 11 → 0. `$gray-200` divider를 `$border-subtle`로, hover를 `$bg-hover`로, `$white`를 `$txt-inverse`로 바꿔 디자인 시스템 방향에 맞췄다(시각 미세 변경, 결정 B). exec-plan `2026-06-15-news-tokens`.
+  - 공유 컴포넌트: 37 → 18 (값 동일 별칭 19 치환, 예외 18). exec-plan `2026-06-15-components-tokens`.
+- **디자인 시스템(DS) 공백 25건(값 동일 별칭 없음 — 결정 필요. home 3·about 4·공유 컴포넌트 18)**: 값이 같은 semantic이 없어 그대로 둔다. 시각을 바꾸거나(결정 B 방식) 신규 토큰을 추가하는 결정이 필요하다. 토큰 추가보다 단순화를 선호하므로 사용자 결정 전까지 둔다. 같은 25건을 종류별로 보면:
   - `$black` 굵은 검정 하이라인 9건 (MobileNavigation 5·board 4)
-  - 로고 브랜드 색 `$navy-950` 1건 (Header)
+  - `$beige-200` 배경 5건 (about page·welcome·vision 4·Header 활성 메뉴 1)
   - `$beige-150` 헤더·하단탭 테두리 3건 (Header 2·BottomNav 1)
-  - `$beige-200` 활성 메뉴 배경 1건 (Header)
+  - gold 위 navy 텍스트 `$navy-950` 2건 (home SermonCard)
   - 스켈레톤 `$gray-100`·`$gray-200` 2건 (PhotoSwipe)
+  - 로고 브랜드 색 `$navy-950` 1건 (Header)
   - 비활성 버튼 배경 `$gray-200` 1건 (FormSubmitButton)
+  - `$gray-200` divider 1건 (home FeedContent)
   - Hero 그라데이션 `$navy-900`·`$navy-950` 1건
 
 ### 🟡 SCSS 하드코딩 색상 (23건)

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -74,6 +74,15 @@
 - **영향 범위**: `src/app/**/*.module.scss`, `src/components/**/*.module.scss` 다수
 - **확인**: `yarn lint:styles | grep "primitive 토큰 직접 사용"` (현재 143건)
 - **발견일**: 2026-05-10 (stylelint-primitive-guardrail PR 도입 시 정확 카운트)
+- **2026-06-15 갱신(공유 컴포넌트)**: 공유 컴포넌트 10개 `.module.scss`에서 값 동일 별칭 19건을 semantic으로 바꿨다 — 공유 컴포넌트 survey 37 → 18. 화면은 안 바뀐다. 치환 상세는 exec-plan `2026-06-15-components-tokens` D1 참조. (`refactor/components-tokens`)
+- **DS 공백 18건(값 동일 별칭 없음 — 결정 필요)**: 값이 같은 semantic이 없어 그대로 둔다. 시각을 바꾸거나(news 결정 B 방식) 신규 토큰을 만드는 결정이 필요하고, 토큰 추가보다 단순화를 선호하는 기준상 사용자 결정 전까지 둔다. home의 `$gray-200` divider 보류분과 같은 줄기. 종류별:
+  - `$black` 굵은 검정 하이라인 9건 (MobileNavigation 5·board 4)
+  - 로고 브랜드 색 `$navy-950` 1건 (Header)
+  - `$beige-150` 헤더·하단탭 테두리 3건 (Header 2·BottomNav 1)
+  - `$beige-200` 활성 메뉴 배경 1건 (Header)
+  - 스켈레톤 `$gray-100`·`$gray-200` 2건 (PhotoSwipe)
+  - 비활성 버튼 배경 `$gray-200` 1건 (FormSubmitButton)
+  - Hero 그라데이션 `$navy-900`·`$navy-950` 1건
 
 ### 🟡 SCSS 하드코딩 색상 (23건)
 

--- a/src/app/(content)/about/location/page.module.scss
+++ b/src/app/(content)/about/location/page.module.scss
@@ -35,7 +35,7 @@
 
 .card {
   padding: $spacing-20;
-  background: $beige-100;
+  background: $bg-beige-subtle;
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
 

--- a/src/app/(content)/about/page.module.scss
+++ b/src/app/(content)/about/page.module.scss
@@ -8,7 +8,7 @@
 // ── Self Hero ──
 
 .hero {
-  background: linear-gradient(180deg, $bg-dark, $navy-950);
+  background: linear-gradient(180deg, $bg-dark, $bg-dark-nav);
   overflow: hidden;
 }
 
@@ -135,6 +135,7 @@
 .row_line {
   flex: 1;
   height: 0.1rem;
+  // semantic 미정: beige-200 라인 — 값 같은 $bg 토큰 없음(D2)
   background: $beige-200;
 }
 
@@ -186,7 +187,7 @@
   display: flex;
   align-items: flex-end;
   padding: $spacing-12;
-  background: linear-gradient(135deg, $beige-100, $beige-150);
+  background: linear-gradient(135deg, $bg-beige-subtle, $bg-secondary);
   border: 0.1rem solid $border-card;
   border-radius: $radius-s;
   overflow: hidden;
@@ -198,8 +199,8 @@
   inset: 0;
   opacity: 0.5;
   background-image:
-    linear-gradient($beige-150 0.1rem, transparent 0.1rem),
-    linear-gradient(90deg, $beige-150 0.1rem, transparent 0.1rem);
+    linear-gradient($bg-secondary 0.1rem, transparent 0.1rem),
+    linear-gradient(90deg, $bg-secondary 0.1rem, transparent 0.1rem);
   background-size: 2rem 2rem;
 }
 
@@ -211,7 +212,7 @@
   display: inline-block;
   margin-bottom: $spacing-4;
   padding: 0.3rem $spacing-8;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-circle;
   font-size: $font-size-11;
@@ -235,7 +236,7 @@
 .index_grid {
   display: grid;
   grid-template-columns: 1fr;
-  background: $beige-50;
+  background: $bg-primary;
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
   overflow: hidden;
@@ -285,7 +286,7 @@
     }
   }
 
-  @include hover-bg-shift($beige-100);
+  @include hover-bg-shift($bg-beige-subtle);
 
   &[data-featured='true'] {
     background: $accent-subtle;
@@ -349,7 +350,7 @@
 
 .bottom_card {
   padding: $spacing-16 $spacing-20;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-s;
 }
@@ -392,7 +393,7 @@
     left: $spacing-8;
     right: $spacing-8;
     height: 0.1rem;
-    background: $beige-150;
+    background: $bg-secondary;
   }
 }
 
@@ -408,7 +409,7 @@
   width: 1.2rem;
   height: 1.2rem;
   border-radius: $radius-circle;
-  background: $white;
+  background: $bg-card;
   border: 0.2rem solid $accent;
 }
 

--- a/src/app/(content)/about/vision/page.module.scss
+++ b/src/app/(content)/about/vision/page.module.scss
@@ -169,7 +169,7 @@
   align-items: flex-start;
   gap: $spacing-12;
   padding: $spacing-16;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
 
@@ -198,6 +198,7 @@
   height: 4.4rem;
   border-radius: $radius-m;
 
+  // semantic 미정: beige-200 면 — 값 같은 $bg 토큰 없음(D2)
   background: $beige-200;
 
   svg {
@@ -270,7 +271,7 @@
 
 .history_section {
   padding: $spacing-32 $container-padding;
-  background: $beige-100;
+  background: $bg-beige-subtle;
   border-top: 0.1rem solid $border-card;
 
   @include respond-up($breakpoint-pc-sm) {
@@ -327,6 +328,7 @@
     bottom: 0.6rem;
     left: 5.6rem;
     width: 0.1rem;
+    // semantic 미정: beige-200 라인 — 값 같은 $bg 토큰 없음(D2)
     background: $beige-200;
 
     @include respond-up($breakpoint-pc-sm) {
@@ -365,7 +367,7 @@
   height: 1rem;
   margin-top: 0.4rem;
   border-radius: $radius-circle;
-  background: $white;
+  background: $bg-card;
   border: 0.2rem solid $accent;
   justify-self: center;
 

--- a/src/app/(content)/about/welcome/page.module.scss
+++ b/src/app/(content)/about/welcome/page.module.scss
@@ -20,7 +20,7 @@
   position: relative;
   margin-bottom: $spacing-32;
   padding: $spacing-32 $spacing-24;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-l;
   overflow: hidden;
@@ -143,7 +143,7 @@
   align-items: flex-start;
   gap: $spacing-12;
   padding: $spacing-16;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
 
@@ -174,6 +174,7 @@
   width: 4.4rem;
   height: 4.4rem;
   border-radius: $radius-m;
+  // semantic 미정: beige-200 면 — 값 같은 $bg 토큰 없음(D2)
   background: $beige-200;
   color: $primary;
   font-size: $font-size-13;
@@ -235,7 +236,7 @@
 
 .faq_section {
   padding: $spacing-32 $container-padding;
-  background: $beige-100;
+  background: $bg-beige-subtle;
   border-top: 0.1rem solid $border-card;
 
   @include respond-up($breakpoint-pc-sm) {
@@ -293,7 +294,7 @@
 
 .faq_item {
   padding: $spacing-16;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
 
@@ -370,7 +371,7 @@
 .cta_card {
   margin-top: $spacing-20;
   padding: $spacing-20;
-  background: $navy-950;
+  background: $bg-dark-nav;
   border-radius: $radius-m;
 
   @include respond-up($breakpoint-pc-sm) {

--- a/src/app/(content)/about/worship/_component/AboutWorship.module.scss
+++ b/src/app/(content)/about/worship/_component/AboutWorship.module.scss
@@ -22,7 +22,7 @@
   font-size: $font-size-11;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-wider;
-  color: $gold-400;
+  color: $accent-hover;
   text-transform: uppercase;
 }
 
@@ -37,7 +37,7 @@
   margin-bottom: $spacing-40;
   text-align: center;
   background-color: $bg-dark-card;
-  border: 1px solid rgba($gold-600, 0.25);
+  border: 1px solid rgba($accent, 0.25);
   border-radius: $radius-m;
 }
 
@@ -47,7 +47,7 @@
   font-size: $font-size-13;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-wide;
-  color: $gold-400;
+  color: $accent-hover;
 }
 
 .verse {
@@ -82,10 +82,10 @@
   height: 5.2rem;
   display: grid;
   place-items: center;
-  background-color: rgba($gold-600, 0.12);
-  border: 1px solid rgba($gold-600, 0.25);
+  background-color: rgba($accent, 0.12);
+  border: 1px solid rgba($accent, 0.25);
   border-radius: $radius-s;
-  color: $gold-400;
+  color: $accent-hover;
 }
 
 .body_col {
@@ -110,7 +110,7 @@
   font-size: $font-size-12;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-wide;
-  color: $gold-400;
+  color: $accent-hover;
 }
 
 .why {

--- a/src/app/(content)/about/worship/_component/SchoolGrid.module.scss
+++ b/src/app/(content)/about/worship/_component/SchoolGrid.module.scss
@@ -9,7 +9,7 @@
   flex-direction: column;
   gap: $spacing-8;
   padding: $spacing-16 $spacing-12;
-  background-color: $white;
+  background-color: $bg-card;
   border: 1px solid $border-warm;
   border-radius: $radius-m;
 
@@ -27,8 +27,8 @@
   font-size: $font-size-11;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-wide;
-  color: $gold-600;
-  background-color: $gold-100;
+  color: $accent;
+  background-color: $accent-subtle;
   border-radius: $radius-circle;
 }
 
@@ -83,7 +83,7 @@
   height: $icon-button-size;
   display: grid;
   place-items: center;
-  background-color: $white;
+  background-color: $bg-card;
   border: 1px solid $border-warm;
   border-radius: 50%;
   font-size: $font-size-16;

--- a/src/app/(content)/about/worship/_component/WorshipCard.module.scss
+++ b/src/app/(content)/about/worship/_component/WorshipCard.module.scss
@@ -3,7 +3,7 @@
 .sunday {
   position: relative;
   padding: $spacing-20;
-  background-color: $white;
+  background-color: $bg-card;
   border: 1px solid $border-warm;
   border-radius: $radius-m;
   overflow: hidden;
@@ -102,7 +102,7 @@
   grid-template-columns: 8.4rem 1fr;
   gap: $spacing-16;
   padding: $spacing-20;
-  background-color: $white;
+  background-color: $bg-card;
   border: 1px solid $border-warm;
   border-radius: $radius-m;
 }

--- a/src/app/(content)/about/worship/page.module.scss
+++ b/src/app/(content)/about/worship/page.module.scss
@@ -136,7 +136,7 @@
   display: flex;
   flex-direction: column;
   padding: $spacing-20;
-  background: $beige-50;
+  background: $bg-primary;
   border: 0.1rem solid $border-card;
   border-radius: $radius-m;
   box-shadow: $shadow-sm;
@@ -347,7 +347,7 @@
   display: inline-flex;
   flex-shrink: 0;
   padding: $spacing-8 $spacing-12;
-  background: $white;
+  background: $bg-card;
   border: 0.1rem solid $border-card;
   border-radius: $radius-circle;
   font-size: $font-size-12;
@@ -355,7 +355,7 @@
   color: $txt-primary;
   text-decoration: none;
   white-space: nowrap;
-  @include hover-bg-shift($beige-100);
+  @include hover-bg-shift($bg-beige-subtle);
 
   @include respond-up($breakpoint-pc-sm) {
     padding: $spacing-10 $spacing-16;

--- a/src/app/(content)/news/bulletins/not-found.module.scss
+++ b/src/app/(content)/news/bulletins/not-found.module.scss
@@ -22,7 +22,7 @@
     .primaryButton {
       padding: $spacing-12 $spacing-20;
       background-color: $primary;
-      color: $white;
+      color: $txt-inverse;
       border-radius: $radius-s;
       border: none;
       font-weight: $font-weight-semibold;

--- a/src/app/(content)/news/notices/_component/NoticeCategoryFilter.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeCategoryFilter.module.scss
@@ -32,7 +32,7 @@
   &.selected {
     border-color: $primary;
     background: $primary;
-    color: $white;
+    color: $txt-inverse;
   }
 }
 

--- a/src/app/(content)/news/notices/_component/NoticeDrawer.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeDrawer.module.scss
@@ -77,7 +77,7 @@
 // ── 헤더 ──
 .header {
   padding: $spacing-24 $spacing-24 $spacing-16;
-  border-bottom: 1px solid $gray-200;
+  border-bottom: 1px solid $border-subtle;
   flex-shrink: 0;
 
   @include respond($breakpoint-tablet-sm) {
@@ -186,7 +186,7 @@
   display: flex;
   align-items: center;
   gap: $spacing-4;
-  border-top: 1px solid $gray-200;
+  border-top: 1px solid $border-subtle;
   font-size: $font-size-12;
   color: $primary-active;
   flex-shrink: 0;
@@ -211,7 +211,7 @@
 // ── 이전/다음 ──
 .nav {
   display: flex;
-  border-top: 1px solid $gray-200;
+  border-top: 1px solid $border-subtle;
   flex-shrink: 0;
   padding-bottom: env(safe-area-inset-bottom, 0);
 }
@@ -225,7 +225,7 @@
   font-size: $font-size-13;
 
   &:first-child {
-    border-right: 1px solid $gray-200;
+    border-right: 1px solid $border-subtle;
   }
 
   &[disabled],

--- a/src/app/(content)/news/notices/_component/NoticeTable.module.scss
+++ b/src/app/(content)/news/notices/_component/NoticeTable.module.scss
@@ -19,7 +19,7 @@
 }
 
 .row {
-  border-bottom: 1px solid $gray-200;
+  border-bottom: 1px solid $border-subtle;
   cursor: pointer;
   transition: background-color 0.12s ease;
 
@@ -29,7 +29,7 @@
   }
 
   &:hover {
-    background-color: $gray-200;
+    background-color: $bg-hover;
   }
 
   &.pinned {
@@ -171,18 +171,18 @@
   display: flex;
   flex-direction: column;
   gap: $spacing-4;
-  border-top: 1px solid $gray-200;
+  border-top: 1px solid $border-subtle;
   text-align: left;
   cursor: pointer;
   transition: background-color 0.12s ease;
   width: 100%;
 
   &:last-child {
-    border-bottom: 1px solid $gray-200;
+    border-bottom: 1px solid $border-subtle;
   }
 
   &:hover {
-    background-color: $gray-200;
+    background-color: $bg-hover;
   }
 
   &.pinned {

--- a/src/app/_component/home/Banner.module.scss
+++ b/src/app/_component/home/Banner.module.scss
@@ -60,7 +60,7 @@
     display: block;
     font-size: $font-size-13;
     letter-spacing: 0.05rem;
-    color: $gold-600;
+    color: $accent;
   }
 
   h1 {
@@ -71,7 +71,7 @@
 
     .title_highlight {
       font-weight: $font-weight-bold;
-      color: $gold-600;
+      color: $accent;
     }
   }
 
@@ -109,12 +109,12 @@
     }
 
     .btn_primary {
-      background-color: $gold-600;
+      background-color: $accent;
       font-weight: $font-weight-bold;
       transition: background-color 0.2s ease;
 
       &:hover {
-        background-color: $gold-400;
+        background-color: $accent-hover;
       }
     }
 

--- a/src/app/_component/home/FeedContent.module.scss
+++ b/src/app/_component/home/FeedContent.module.scss
@@ -27,8 +27,8 @@
 
 .tab_active {
   font-weight: $font-weight-semibold;
-  color: $gold-600;
-  border-bottom-color: $gold-600;
+  color: $accent;
+  border-bottom-color: $accent;
 }
 
 .tab_inactive {
@@ -95,11 +95,11 @@
 }
 
 .color_bar_news {
-  background: $gold-600;
+  background: $accent;
 }
 
 .color_bar_sharing {
-  background: $gold-600;
+  background: $accent;
 }
 
 .more_link {
@@ -107,24 +107,24 @@
   display: block;
   width: fit-content;
   text-decoration: underline;
-  text-decoration-color: rgba($gold-600, 0.2);
+  text-decoration-color: rgba($accent, 0.2);
   text-underline-offset: 0.3rem;
   font-size: $font-size-13;
   font-weight: $font-weight-medium;
-  color: rgba($gold-600, 0.8);
+  color: rgba($accent, 0.8);
   transition:
     color $transition-duration-normal $transition-easing-default,
     text-decoration-color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    color: $gold-600;
-    text-decoration-color: $gold-600;
+    color: $accent;
+    text-decoration-color: $accent;
   }
 }
 
 // ─── List Card ──────────────────────────────────────
 .list_card {
-  background: $white;
+  background: $bg-card;
   border-radius: $radius-xs;
   border: $spacing-1 solid $border-primary;
   overflow: hidden;
@@ -139,6 +139,7 @@
   transition: background-color $transition-duration-normal $transition-easing-default;
 
   &:not(:last-child) {
+    // semantic 미정: $gray-200 divider — $border-primary(gray-300)·$border-subtle와 값이 달라 보존
     border-bottom: $spacing-1 solid $gray-200;
   }
 

--- a/src/app/_component/home/FeedSection.module.scss
+++ b/src/app/_component/home/FeedSection.module.scss
@@ -15,7 +15,7 @@
   font-weight: $font-weight-medium;
   text-transform: uppercase;
   letter-spacing: $letter-spacing-wider;
-  color: $gold-600;
+  color: $accent;
 }
 
 .header h2 {

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -51,7 +51,7 @@ $divider-height: 0.2rem;
   bottom: calc(-1 * $spacing-16);
   right: calc(-1 * $spacing-16);
   padding: $spacing-20 $spacing-24;
-  background: $navy-950;
+  background: $bg-dark-nav;
   border-radius: $radius-xs;
   text-align: center;
   display: flex;
@@ -63,14 +63,14 @@ $divider-height: 0.2rem;
   font-family: $font-family-secondary;
   font-size: $font-size-32;
   font-weight: $font-weight-regular;
-  color: $gold-600;
+  color: $accent;
   line-height: $line-height-reset;
 }
 
 .year_label {
   font-size: $font-size-11;
   font-weight: $font-weight-regular;
-  color: rgba($white, 0.5);
+  color: rgba($txt-inverse, 0.5);
   letter-spacing: 0.1rem;
 }
 
@@ -96,7 +96,7 @@ $divider-height: 0.2rem;
 .caption {
   margin-bottom: $spacing-12;
   display: inline-block;
-  @include text-caption-small($color: $gold-600);
+  @include text-caption-small($color: $accent);
   text-transform: uppercase;
   letter-spacing: $letter-spacing-wider;
 }
@@ -115,7 +115,7 @@ $divider-height: 0.2rem;
 .divider {
   width: $divider-width;
   height: $divider-height;
-  background: $gold-600;
+  background: $accent;
   margin: $spacing-16 0;
 }
 
@@ -153,7 +153,7 @@ $divider-height: 0.2rem;
   transition: color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    color: $gold-600;
+    color: $accent;
   }
 
   @include respond-up($breakpoint-tablet) {
@@ -167,7 +167,7 @@ $divider-height: 0.2rem;
 
 .faq_toggle {
   font-size: $font-size-18;
-  color: $gold-600;
+  color: $accent;
   line-height: $line-height-reset;
   flex-shrink: 0;
   transition: transform 0.2s ease;
@@ -205,7 +205,7 @@ $divider-height: 0.2rem;
   padding-bottom: $spacing-2;
   font-size: $font-size-13;
   font-weight: $font-weight-semibold;
-  color: $gold-600;
+  color: $accent;
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 0.3rem;
@@ -214,7 +214,7 @@ $divider-height: 0.2rem;
     opacity $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    text-decoration-color: $gold-600;
+    text-decoration-color: $accent;
     opacity: 0.8;
   }
 }
@@ -227,9 +227,9 @@ $divider-height: 0.2rem;
   width: fit-content;
   font-size: $font-size-13;
   font-weight: $font-weight-semibold;
-  color: $gold-600;
+  color: $accent;
   text-decoration: underline;
-  text-decoration-color: rgba($gold-600, 0.3);
+  text-decoration-color: rgba($accent, 0.3);
   text-underline-offset: 0.3rem;
   padding-bottom: $spacing-4;
   transition:
@@ -237,7 +237,7 @@ $divider-height: 0.2rem;
     opacity $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    text-decoration-color: $gold-600;
+    text-decoration-color: $accent;
     opacity: 0.8;
   }
 }

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -72,10 +72,10 @@ $icon_box_size: 4.2rem;
   flex-shrink: 0;
   width: $icon_box_size;
   height: $icon_box_size;
-  background: $navy-950;
+  background: $bg-dark-nav;
   border-radius: $radius-xs;
   font-size: calc($icon_box_size / 1.8);
-  color: $gold-600;
+  color: $accent;
 
   @include respond-up($breakpoint-tablet) {
     margin-right: $spacing-16;
@@ -112,7 +112,7 @@ $icon_box_size: 4.2rem;
 .arrow {
   flex-shrink: 0;
   font-size: $font-size-14;
-  color: $gold-600;
+  color: $accent;
   opacity: 0;
   transition:
     opacity 0.2s ease,

--- a/src/app/_component/home/RecentSermons.module.scss
+++ b/src/app/_component/home/RecentSermons.module.scss
@@ -30,14 +30,14 @@
   font-weight: $font-weight-medium;
   text-transform: uppercase;
   letter-spacing: $letter-spacing-wider;
-  color: $gold-600;
+  color: $accent;
 }
 
 .header h2 {
   font-family: $font-family-secondary;
   // 세리프 weight를 400·700로 줄이며 medium(500)→regular(400)로 명시 매핑 (브라우저 자동 매칭과 동일)
   font-weight: $font-weight-regular;
-  color: $white;
+  color: $txt-inverse;
 }
 
 .header_link {
@@ -45,18 +45,18 @@
   display: block;
   width: fit-content;
   text-decoration: underline;
-  text-decoration-color: rgba($gold-600, 0.2);
+  text-decoration-color: rgba($accent, 0.2);
   text-underline-offset: 0.3rem;
   font-size: $font-size-13;
   font-weight: $font-weight-medium;
-  color: rgba($gold-600, 0.7);
+  color: rgba($accent, 0.7);
   transition:
     color $transition-duration-normal $transition-easing-default,
     text-decoration-color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    color: $gold-600;
-    text-decoration-color: $gold-600;
+    color: $accent;
+    text-decoration-color: $accent;
   }
 }
 

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -45,8 +45,9 @@ $thumb-sub-w: 14rem;
   z-index: 1;
   font-size: $font-size-11;
   font-weight: $font-weight-bold;
+  // semantic 미정: gold 배지 위 dark navy 텍스트 — 값 보존
   color: $navy-950;
-  background: $gold-600;
+  background: $accent;
   padding: $padding-inline-xs;
   border-radius: $radius-xs;
   text-transform: uppercase;
@@ -75,7 +76,7 @@ $thumb-sub-w: 14rem;
 }
 
 .title {
-  @include text-body-emphasis($color: $white);
+  @include text-body-emphasis($color: $txt-inverse);
   @include ellipsis-multi(1);
 }
 
@@ -118,9 +119,9 @@ $thumb-sub-w: 14rem;
   width: $play-btn-size;
   height: $play-btn-size;
   border-radius: $radius-circle;
-  background: rgba($gold-600, 0.18);
-  border: 1px solid rgba($gold-600, 0.35);
-  color: $gold-600;
+  background: rgba($accent, 0.18);
+  border: 1px solid rgba($accent, 0.35);
+  color: $accent;
   transition:
     background 0.2s ease,
     color 0.2s ease;
@@ -137,7 +138,8 @@ $thumb-sub-w: 14rem;
 }
 
 .card:hover .play_btn {
-  background: $gold-600;
+  background: $accent;
+  // semantic 미정: gold 위 dark navy 아이콘 — 값 보존
   color: $navy-950;
 }
 
@@ -155,9 +157,9 @@ $thumb-sub-w: 14rem;
     width: $play-btn-size-lg;
     height: $play-btn-size-lg;
     border-radius: $radius-circle;
-    background: rgba($gold-600, 0.25);
-    border: 1px solid rgba($gold-600, 0.5);
-    color: $gold-600;
+    background: rgba($accent, 0.25);
+    border: 1px solid rgba($accent, 0.5);
+    color: $accent;
     align-items: center;
     justify-content: center;
     opacity: 0;

--- a/src/components/common/Loader.module.scss
+++ b/src/components/common/Loader.module.scss
@@ -2,7 +2,7 @@
   display: inline-block;
   width: $font-size-15;
   height: $font-size-15;
-  border: 2px solid $white;
+  border: 2px solid $border-inverse;
   border-bottom-color: transparent;
   border-radius: 50%;
   box-sizing: border-box;

--- a/src/components/file/FileSelector.module.scss
+++ b/src/components/file/FileSelector.module.scss
@@ -43,7 +43,7 @@
 
     &:hover {
       background-color: $primary;
-      color: $white;
+      color: $txt-inverse;
     }
 
     svg {

--- a/src/components/file/ImagePreview.module.scss
+++ b/src/components/file/ImagePreview.module.scss
@@ -70,7 +70,7 @@ $item-gap: $spacing-8;
   width: fit-content;
   border-radius: $radius-xs;
   font-size: $font-size-12;
-  color: $white !important;
+  color: $txt-inverse !important;
 }
 
 .badge_existing {

--- a/src/components/form/FormSubmitButton.module.scss
+++ b/src/components/form/FormSubmitButton.module.scss
@@ -9,7 +9,6 @@
 
 .disabled_button {
   background-color: $gray-200;
-  border: 1px solid $border-primary;
   color: $txt-disabled;
   cursor: not-allowed;
 }

--- a/src/components/form/FormSubmitButton.module.scss
+++ b/src/components/form/FormSubmitButton.module.scss
@@ -9,7 +9,7 @@
 
 .disabled_button {
   background-color: $gray-200;
-  border: 1px solid $gray-300;
+  border: 1px solid $border-primary;
   color: $txt-disabled;
   cursor: not-allowed;
 }
@@ -17,5 +17,5 @@
 .active_button {
   background-color: $primary-active;
   border: 1px solid $primary-active;
-  color: $white;
+  color: $txt-inverse;
 }

--- a/src/components/layout/BottomNav/BottomNav.module.scss
+++ b/src/components/layout/BottomNav/BottomNav.module.scss
@@ -10,7 +10,7 @@
   left: 0;
   right: 0;
   z-index: $z-bottom-nav;
-  background-color: $white;
+  background-color: $bg-card;
   border-top: 0.1rem solid $beige-150;
   // iOS 홈 인디케이터 영역만큼 배경을 확장
   padding-bottom: env(safe-area-inset-bottom, 0);

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -73,7 +73,7 @@
     color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    background-color: $gold-600;
+    background-color: $accent;
     color: $txt-inverse;
   }
 
@@ -111,7 +111,7 @@
   transition: color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    color: $gold-600;
+    color: $accent;
   }
 }
 

--- a/src/components/layout/Header/Drawer.module.scss
+++ b/src/components/layout/Header/Drawer.module.scss
@@ -11,7 +11,7 @@
     width: 85%;
     max-width: 36rem;
   }
-  background-color: $white;
+  background-color: $bg-card;
   z-index: $z-drawer;
 
   transform: translateX(100%);

--- a/src/components/layout/Header/Header.module.scss
+++ b/src/components/layout/Header/Header.module.scss
@@ -15,7 +15,7 @@ $indicator-height: 0.2rem;
   position: sticky;
   top: 0;
   z-index: $z-header;
-  background-color: $white;
+  background-color: $bg-card;
   border-bottom: 0.1rem solid $beige-150;
 
   @include respond-up($header-breakpoint) {
@@ -106,7 +106,7 @@ $indicator-height: 0.2rem;
   z-index: calc($z-header - 1);
   overflow-x: auto;
   scrollbar-width: none;
-  background-color: $white;
+  background-color: $bg-card;
   border-bottom: 0.1rem solid $border-card;
 
   &::-webkit-scrollbar {
@@ -154,7 +154,7 @@ $indicator-height: 0.2rem;
 // ── Top Bar ──
 
 .top_bar {
-  background-color: $navy-950;
+  background-color: $bg-dark-nav;
   color: $txt-inverse;
 }
 
@@ -205,7 +205,7 @@ $indicator-height: 0.2rem;
   position: sticky;
   top: 0;
   z-index: $z-header;
-  background-color: $white;
+  background-color: $bg-card;
   border-bottom: 0.1rem solid $beige-150;
   transition: border-bottom-color $transition-duration-normal $transition-easing-default;
 }
@@ -319,7 +319,7 @@ $indicator-height: 0.2rem;
   left: 50%;
   transform: translateX(-50%);
   padding: $spacing-8;
-  background-color: $white;
+  background-color: $bg-card;
   border-top: $indicator-height solid $primary;
   border-radius: 0 0 $radius-s $radius-s;
   box-shadow: $shadow-md;
@@ -411,12 +411,12 @@ $indicator-height: 0.2rem;
   width: $icon-button-size-sm;
   height: $icon-button-size-sm;
   border-radius: $radius-circle;
-  background-color: $gold-600;
-  color: $white;
+  background-color: $accent;
+  color: $txt-inverse;
   transition: background-color $transition-duration-normal $transition-easing-default;
 
   &:hover {
-    background-color: $gold-400;
+    background-color: $accent-hover;
   }
 
   @include respond-up($breakpoint-pc-sm) {

--- a/src/components/layout/Header/MobileNavigation.module.scss
+++ b/src/components/layout/Header/MobileNavigation.module.scss
@@ -1,6 +1,6 @@
 .nav_container {
   width: 100%;
-  background-color: $white;
+  background-color: $bg-card;
 }
 
 .nav_header {

--- a/src/components/ui/Pagination/Pagination.module.scss
+++ b/src/components/ui/Pagination/Pagination.module.scss
@@ -40,7 +40,7 @@
 
 .page_link.current {
   background-color: $primary;
-  color: $white;
+  color: $txt-inverse;
   font-weight: $font-weight-semibold;
 
   &:hover {


### PR DESCRIPTION
<!-- 🔁 Refactor 템플릿 — 기능 변경 없는 코드 구조 개선. -->

## 📋 개요 (Summary)

**목적**: 4개 영역(home·about·news·공유 컴포넌트)의 `.module.scss`가 primitive 토큰을 색·배경·테두리에 직접 쓰던 것을 semantic 토큰으로 바꿔 design-system-v3 semantic 레이어로 모은다.

**범위**:

- home 7개 · about 8개 · news 4개 · 공유 컴포넌트 10개 = 29개 `.module.scss`
- 값이 같은 semantic 별칭이 있는 104곳을 치환한다 (화면 유지). news만 값이 같은 별칭이 없어 디자인 시스템 방향으로 시각을 미세하게 바꾼다 (결정 B).
- 값이 같은 별칭이 없는 25곳은 디자인 시스템 공백으로 두고 분류 기록한다.

---

## 🔗 개발 컨텍스트

- **Task ID**: `home-tokens` · `about-tokens` · `news-tokens` · `components-tokens` (4 task, 영역별 분리 작업을 한 PR로 묶음)
- **Exec Plan**: `docs/exec-plans/active/2026-06-15-home-tokens.md` · `…-about-tokens.md` · `…-news-tokens.md` · `…-components-tokens.md`
- **관련 ADR**: `docs/decisions/0003-design-system-v3-token-unification.md` (primitive↔semantic 분리 결정)
- **관련 tech debt**: `docs/tech-debt/active.md#scss-primitive-토큰-직접-사용` (4영역 통합 진척 노트)
- **작업 범위**: 4영역 29파일의 primitive 직접 사용을 semantic으로 치환
- **제외한 범위**: sermons·admin·ui 등 남은 영역, 값 동일 별칭 없는 25곳용 신규 토큰 신설, 컴포넌트 구조·클래스·로직

---

## 💡 리팩토링 배경 (Motivation)

`.module.scss`가 `$gold-600`·`$navy-950`·`$white`·`$beige-*` 같은 primitive 토큰을 color·background·border에 직접 썼다. 이 방식은 ADR 0003이 세운 semantic 레이어를 건너뛰어, 같은 색이라도 의미(표면·텍스트·테두리)가 코드에 드러나지 않고 디자인 시스템 변경이 컴포넌트마다 흩어진다. primitive→semantic 부채(tech-debt P4)를 영역별로 나눠 갚는 작업이며, 이 PR은 home·about·news·공유 컴포넌트 4영역을 한데 묶었다.

**개선하려는 문제:**

- [x] 유지보수 난이도 증가
- [x] 기술 부채 해소
- [ ] 가독성 저하 (복잡도 증가, 네이밍 불명확 등)
- [ ] 중복 코드 (DRY 원칙 위반)
- [ ] 성능 병목
- [ ] 기타:

**관련 이슈:**

- Issue: 해당 없음

---

## 🔧 주요 변경점 (Key Changes)

값이 같은 semantic 별칭으로만 치환했다. `_color.scss`에서 별칭이 같은 hex로 정의돼 컴파일 결과 색이 그대로다 (news 제외).

- **home (45 → 3)**: `$gold-600`→`$accent`·`$gold-400`→`$accent-hover`, `$navy-950` 배경→`$bg-dark-nav`, `$white` 텍스트→`$txt-inverse`·면→`$bg-card`, `rgba($gold-600,α)`→`rgba($accent,α)`. 예외 3 (gold 위 navy 텍스트 2·`$gray-200` divider 1).
- **about (36 → 4)**: `$white`→`$bg-card`, `$beige-50/100/150`→`$bg-primary`/`$bg-beige-subtle`/`$bg-secondary`, `$gold-*`→`$accent-*`, `$navy-950`(gradient 포함)→`$bg-dark-nav`. 예외 4 (`$beige-200` 배경).
- **news (11 → 0)**: `$gray-200` divider→`$border-subtle`, hover→`$bg-hover`, `$white`→`$txt-inverse`. 값이 같은 별칭이 없어 디자인 시스템 방향으로 바꿨다 — row hover가 gray에서 navy tint로 바뀐다 (의도된 미세 변화, 결정 B).
- **공유 컴포넌트 (37 → 18)**: `$white`→`$bg-card`/`$txt-inverse`/`$border-inverse`, `$navy-950` 표면→`$bg-dark-nav`, `$gold-600`→`$accent`·`$gold-400`→`$accent-hover`, `$gray-300` 테두리→`$border-primary`. 예외 18 (디자인 시스템 공백).

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 치환 대상 범위 | 값이 같은 semantic 별칭이 있는 곳만 치환 | 컴파일 hex가 그대로라 화면이 안 바뀌고, `_color.scss` 별칭 정의로 값 동일성을 확정할 수 있다 | 값이 다른 토큰까지 치환 — 시각 변경이 섞여 회귀 위험을 키운다 |
| news `$gray-200` 처리 (결정 B) | 디자인 시스템 방향으로 바꿔 시각 미세 변화 허용 | news는 값이 같은 별칭이 `$label-neutral-bg`뿐이라, 값 보존하면 9건이 예외로 남아 부채가 안 준다. semantic으로 바꾸면 primitive가 사라지고 border·Hover 정책과 맞는다 | 값 보존 — 9건 예외로 폐기. divider 전용 신규 토큰 — 기존 `$border-subtle`로 충분해 폐기 |
| 값 동일 별칭 없는 25곳 | 치환하지 않고 두며 tech-debt에 분류 기록 | 값이 같은 semantic이 없어 시각 변경 또는 신규 토큰 추가가 필요하다. 토큰 추가보다 단순화를 선호하는 기준에 따라 사용자 결정 전까지 보류 | 임의 semantic 매핑 — 색이 바뀌거나 의미와 안 맞는 토큰을 붙일 위험 |

> ⚠️ **주의사항:** 남은 25곳(디자인 시스템 공백)은 `$black` 하이라인·`$beige-200` 배경·스켈레톤·로고 색 등이다. 신규 토큰 추가 또는 시각 변경 결정이 따로 필요하다. 종류별 분류는 `docs/tech-debt/active.md`에 있다.

**변경 전 구조:**

4영역 `.module.scss`가 primitive 토큰을 color·background·border에 직접 참조 → semantic 레이어 우회

**변경 후 구조:**

값이 같은 별칭이 있는 104곳은 semantic 토큰을 경유 → 토큰 의미가 코드에 드러남. 별칭 없는 25곳은 그대로 두고 부채로 분류

---

## 📊 개선 지표 (Improvement Metrics)

| 영역 | primitive Before | primitive After |
| ---- | ---------------- | --------------- |
| home | 45 | 3 |
| about | 36 | 4 |
| news | 11 | 0 |
| 공유 컴포넌트 | 37 | 18 |
| **합계 치환** | — | **104곳 semantic 전환** |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 있음: Codex 검증·harness-gate — 사유는 각 행에 적음 |
| `verify-task` | `node scripts/verify-task.mjs components-tokens` — PASS, RUN_ID=`20260615-210229`(4영역 통합 diff), failed=0, warned=Knip. 영역별 검증은 각 exec-plan(home `…-192738`·about `…-194913`·news `…-200615`·components `…-202844`) |
| `harness-gate` | N/A (머지 직전 실행) |
| Codex 계획 검증 | N/A (값 동일 별칭 치환이라 저위험, 값 동일성은 `_color.scss`로 확정되고 build가 컴파일을 검증) |
| Codex 1차 검증 | N/A (위와 같은 사유) |
| Claude 2차 검증 | 완료 (각 영역 Chrome 실측으로 무시각 확인, news는 결정 B 미세 변화 확인) |
| ADR 판단 | 불필요 (기존 semantic 적용, 신규 토큰 0) |
| 남은 warning | 기존 부채 (Knip) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**리팩토링 완성도**

- [x] 외부 동작(기능, API 인터페이스) 변경 없음 확인 (news만 row hover·divider 색이 의도대로 미세 변경)
- [x] 불필요한 기능 변경 미포함 확인 (리팩토링과 기능 개발 분리)

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 불필요한 코드·디버그 로그 제거 여부

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: home·about·공유 컴포넌트는 없음 (값 동일 별칭 치환). news만 `/news/notices`의 row hover가 gray에서 navy tint로, divider가 얕은 구분선으로 바뀐다 (의도된 미세 변화, 결정 B).
- **운영 리스크**: 없음.
- **QA 후속**: 공유 컴포넌트(헤더·푸터·하단탭)가 전 페이지에 떠서 영향 범위가 넓으나 값 동일 치환이라 시각 변화가 없다. news는 `/news/notices`에서 divider·hover만 확인.
- **롤백 시 영향**: 없음.
- **먼저 볼 화면 / 흐름**: `/news/notices`(결정 B 미세 변화)·home eyebrow/배지·`/about` beige 면·헤더/푸터.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

primitive→semantic 영역별 마이그레이션을 4영역 묶어 한 PR로 올렸다 (focus 표시 통일은 별개 concern이라 다른 PR). 남은 25곳은 값이 같은 semantic이 없는 디자인 시스템 공백이다 — `$black` 검정 하이라인 9, `$beige-200` 배경 5, `$beige-150` 테두리 3, gold 위 navy 텍스트 2, 스켈레톤 2, 로고색 1, 비활성 버튼 배경 1, `$gray-200` divider 1, Hero 그라데이션 1. 신규 토큰 추가 또는 시각 변경 결정이 정해지면 정리한다. 남은 영역(sermons·admin·ui)은 별도 PR로 같은 방식을 적용한다.
