### PR TITLE
[Style] focus 표시를 공통 토큰·패턴으로 통일

### DIFF
--- a/docs/design-system/context.md
+++ b/docs/design-system/context.md
@@ -65,7 +65,7 @@ Phase 1 감사가 이 가설들을 file:line 증거로 검증한다. 가설이 �
 
 - semantic 토큰을 도입했지만 영역별로 다른 토큰을 쓰지 않나.
 - 확인 방법: primitive 직접 사용 카운트(`rg "\$gray-|\$beige-|\$navy-|\$gold-" src -g '*.scss'`), semantic 분포 샘플.
-- 이미 알려진 위반: focus-ring 10곳, primitive 직접 사용 143건, 하드코딩 색상 49건.
+- 이미 알려진 위반: primitive 직접 사용 143건, 하드코딩 색상 49건. (focus-ring은 해소 — 위 활성 tech-debt 발췌 참조)
 
 ### 4. 상호작용·빈 상태 비일관
 
@@ -80,7 +80,7 @@ Phase 1 감사가 이 가설들을 file:line 증거로 검증한다. 가설이 �
 | **P1. 감사** | 1주 | `(content)` 7 도메인·36 페이지를 유형별로 분류하고 4 영역 위반을 file:line 증거로 식별 | `docs/design-system/audit.md` + 신규 tech-debt 후보 |
 | **P2. 페이지 유형 카탈로그** | 1주 | 발견된 유형(리스트·디테일·아카이브·랜딩·폼)별 표준 패턴 정의와 ADR 작성 | `docs/design-system/page-patterns.md` + 신규 ADR |
 | **P3. next-gen 신규 도메인** | 1–2주 | 카탈로그를 첫 적용 사례로 next-gen 페이지 구축 | next-gen 페이지·컴포넌트·SCSS |
-| **P4. 기존 페이지 마이그레이션** | 2주+ | 카탈로그에 맞춰 sermons 외 도메인 정리. focus-ring 10곳·primitive 직접 사용 등 활성 부채 포함 | 페이지별 분리 PR |
+| **P4. 기존 페이지 마이그레이션** | 2주+ | 카탈로그에 맞춰 sermons 외 도메인 정리. primitive 직접 사용 등 활성 부채 포함 | 페이지별 분리 PR |
 | **P5. 자동화** | 1–2주 | 페이지간 일관성 감사 에이전트 + 시각 회귀 테스트(Playwright) | 신규 에이전트·CI 설정 |
 
 각 Phase는 별도 task + 분리 PR. develop으로 단계별 머지. 본 표는 진행 결과에 따라 갱신한다.

--- a/docs/design-system/context.md
+++ b/docs/design-system/context.md
@@ -40,7 +40,7 @@
 
 `docs/tech-debt/active.md`에 등록된 항목 중 디자인 시스템 통합에 직결되는 것:
 
-- **focus-ring 패턴 통일 (10곳)** — `$primary`/`$primary-active`/`$border-focus`/`$border-primary` 4종 혼재. width `2px`·`0.2rem` 혼재. offset 양수·음수 혼재. globals만 `$focus-ring-*` 토큰화 완료.
+- ~~focus-ring 패턴 통일~~ → ✅ 해소: `focus-ring` mixin·`$focus-ring-*` 토큰으로 통일하고, 남아 있던 `ui/Select`와 admin focus까지 바꿨다(PR #108 + focus-ring-unify 2026-06-15). 상세는 [`../tech-debt/resolved.md`](../tech-debt/resolved.md).
 - **SCSS primitive 토큰 직접 사용 (143건)** — `$gray-*`·`$navy-*`·`$gold-*`·`$beige-*`를 컴포넌트 SCSS에서 직접 사용. stylelint warning은 도입돼 있지만 error는 못 올림.
 - **SCSS 하드코딩 색상 (49건)** — `.module.scss`에서 hex 색 직접 사용. `color-no-hex` 룰을 warning으로 운영.
 - **SCSS 네이밍 패턴 위반 (12건)** — snake_case 위반 className 5건, kebab-case 위반 SCSS 변수 7건.

--- a/docs/exec-plans/active/2026-06-15-focus-ring-unify.md
+++ b/docs/exec-plans/active/2026-06-15-focus-ring-unify.md
@@ -35,7 +35,7 @@ content/ui와 admin의 `:focus` 표시를 일관된 토큰·패턴으로 모은�
 - `src/components/ui/Select/Select.module.scss` — 수동 outline → `@include focus-ring()`
 - `src/components/form/FormField.module.scss` — `:focus` `!important` 제거
 - `src/components/admin/sermons/SermonForm/primitives/primitives.module.scss` — rgba ×2 → `$primary-soft-subtle`
-- `src/components/admin/sermons/SermonListPage/dropdown.module.scss` — focus `$primary`/`$primary-subtle` → `$primary-soft`/`$primary-soft-subtle`
+- `src/components/admin/sermons/SermonListPage/dropdown.module.scss` — `.date_input:focus`를 peri(`$primary-soft`/`$primary-soft-subtle`)로. **리뷰 반영(PR #124)**: 실제 트리거 버튼 `.filter_trigger`·메뉴 `.dropdown_item`·`.date_clear`에 focus 규칙이 없어 전역 navy outline으로 폴백하던 것을 peri focus로 추가(아래 D2·리뷰 반영 섹션)
 - `src/components/admin/layout/AdminHeader/index.module.scss` — `:focus-visible`를 `:hover`와 분리 + admin recipe 적용(`outline:none` 유지. `$primary-soft` border가 포커스 표시 — hover의 gray border와 구분, glow는 보조)
 - `docs/tech-debt/resolved.md` — PR #108 focus-ring 항목에 잔여 사이트(Select·admin) 완료 note 추가 / `docs/design-system/context.md` — 활성 부채 발췌의 stale focus-ring 줄을 해소로 정정 (active.md엔 focus-ring 항목 없음 — 이미 PR #108에서 resolved로 이관됨)
 
@@ -69,9 +69,12 @@ content/ui와 admin의 `:focus` 표시를 일관된 토큰·패턴으로 모은�
 
 ## Codex 1차 검증
 
-- **결론**: 생략 (저위험 SCSS). CODEX_FIRST_PASS 위임 트리거(큰 diff·고위험 파일·레이어 변경·검증 실패) 어디에도 해당 안 됨. 계획 단계 Codex 검증(CHANGE_REQUEST)을 이미 반영했고, Codex 윈도 런타임이 이번 세션에 3번 멈춰서(hang) 직접 측정으로 대신한다.
-- **현재 판단**: 구현 diff는 SCSS 줄 단위 교체뿐(토큰·믹스인 1:1 치환, 신규 로직 0). verify-task build가 `@include focus-ring()`·`$primary-soft`·`$primary-soft-subtle` 해석을 실증한다. Claude 자체 교차 확인 — 5개 diff 모두 토큰/믹스인 치환이고, AdminHeader만 hover/focus 규칙 분리를 더했다.
-- **다음 행동**: Claude 2차(verify-task) 기록 → COMMIT.
+- **결론**: PASS — 원 구현은 저위험 SCSS 치환(토큰·믹스인 1:1, 신규 로직 0)이라 1차 위임 트리거에 안 걸려 build·Claude 교차로 대신했다. 이후 PR #124 자동 리뷰 4건을 `codex:rescue`로 교차검증했다 — 수정 필요 1건(P2), 확인 3건(①·②·P3).
+- **현재 판단**: Codex verbatim —
+  > P2가 가장 무겁고 fix 범위가 `.filter_trigger` 하나에서 `.dropdown_item`, `.date_clear`까지 확장된다는 점이 사용자 판단과의 핵심 차이다. ①②는 같은 PR이 건드린 파일의 일관성 문제라 deferred할 이유가 없다. P3는 커밋된 doc에 생긴 내부 충돌이므로 같이 정리하는 것이 맞다.
+
+  풀이: 트리거가 `.filter_trigger` 하나가 아니라 셋이라 P2 범위를 넓혔고, 짚은 4건을 모두 반영했다. 버튼별 처리는 D2, FormField·context.md 안전성은 리뷰 반영 섹션 참조.
+- **다음 행동**: Claude 2차(verify-task 220114) 기록 → COMMIT.
 
 ## Claude 2차 검증
 
@@ -82,8 +85,26 @@ content/ui와 admin의 `:focus` 표시를 일관된 토큰·패턴으로 모은�
 | 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
 | --- | --- | --- | --- | --- | --- | --- |
 | 2차 | 20260615-181611 | ✅ | ✅ | ✅ | 0(기존 부채만) | Chrome 실측 — admin focus 4곳이 같은 peri recipe로, Select가 공통 링으로 떴다 (키보드 포커스 확인) |
+| 리뷰 반영 | 20260615-220114 | ✅ | ✅ | ✅ | 0(기존 부채만) | PR #124 리뷰 4건 반영 후 build·stylelint 통과(상세는 리뷰 반영 섹션). `.filter_trigger`는 원 PR에서 실측한 border+glow와 같은 토큰. `.dropdown_item` inset 링·`.date_clear` outline은 새 합성이라 build 컴파일만 확인(시각 미실측) |
+
+## 리뷰 반영 (PR #124 자동 리뷰 + Codex 교차검증)
+
+PR #124에 GitHub 자동 리뷰(Gemini 2 + Codex 2)가 4건을 지적했고, `codex:rescue` 교차검증으로 모두 확인한 뒤 반영했다.
+
+- **P2 (Codex, 핵심)**: focus 통일이 `.date_input`만 덮고 실제 dropdown 트리거 버튼은 빠졌다. `.filter_trigger`·`.dropdown_item`·`.date_clear`(전부 `<button>`)에 focus 규칙이 없어 전역 navy outline(`globals.scss:173`)으로 폴백했다. 셋 다 peri focus를 더했다(요소 형태별 처리는 아래 D2). Codex 교차검증이 `.dropdown_item`·`.date_clear`를 추가로 짚어 범위를 넓혔다.
+- **① (Gemini)**: `AdminHeader`의 `:focus-visible` glow가 `transition` 목록에 `box-shadow`가 없어 즉시 떴다. `transition`에 `box-shadow 0.15s`를 더해 `primitives`와 맞췄다(CONFIRMED).
+- **② (Gemini)**: `FormField` `:focus`가 `border` 단축을 다시 선언했다. 부모 `input`이 `1px solid $border-primary`라 `border-color: $border-focus`로 바꿔도 안전하다(CONFIRMED).
+- **P3 (Codex)**: `context.md:43`이 focus-ring 해소를 표시하는데 같은 문서 `:68`·`:83`에 "focus-ring 10곳"이 위반·로드맵으로 남아 모순이었다. 두 줄에서 지웠다(CONFIRMED).
 
 ## 의사결정 로그
+
+- **D2 — dropdown focus 통일을 트리거 버튼까지 넓힌다 (PR #124 리뷰 반영)**
+  - 문제: 원래 plan은 dropdown focus를 `.date_input`만 peri로 바꿨다. 리뷰가 실제 트리거 버튼 `.filter_trigger`와 메뉴 `.dropdown_item`·`.date_clear`는 focus 규칙이 없어 전역 navy outline으로 떠서, "admin dropdown focus 통일"이 미완임을 짚었다.
+  - 해결: 세 버튼에 peri focus를 더한다. 색은 셋 다 `$primary-soft`로 모으되, 요소 형태가 달라 한 recipe를 그대로 못 쓴다:
+    - `.filter_trigger` — border가 있어 `border-color` + glow (transition에 `box-shadow` 추가).
+    - `.dropdown_item` — borderless 메뉴라 inset peri 링.
+    - `.date_clear` — 패딩 0 텍스트 버튼이라 peri outline.
+  - 결과: dropdown 안 키보드 focus가 navy 없이 peri로 통일됐다. item active(`dropdown:142-149`)의 navy 배경은 focus가 아니라 selected 상태라 이번 범위 밖이다.
 
 - **D1 — admin focus accent를 `$primary-soft`(peri)로 통일**
   - 문제: admin focus가 dropdown(`$primary` navy + `$primary-subtle`), primitives(`$primary-soft` peri + 하드코딩 rgba), AdminHeader(`$txt-admin-tertiary`)로 제각각이다. admin 안에서 peri와 navy가 섞여 있다 — dropdown은 filter active를 peri로 두지만(`dropdown:32-40`) 트리거 focus는 navy(`dropdown:235`)다.

--- a/docs/exec-plans/active/2026-06-15-focus-ring-unify.md
+++ b/docs/exec-plans/active/2026-06-15-focus-ring-unify.md
@@ -1,0 +1,98 @@
+# focus-ring-unify
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-15
+- **브랜치**: style/focus-ring-unify
+- **Open questions**: none
+- **ADR needed**: no — 기존 토큰·믹스인 적용. docs/decisions·skills 변경 없음. 다단계라 CODEX_PLAN_REVIEW만 수행.
+
+## 목표
+
+content/ui와 admin의 `:focus` 표시를 일관된 토큰·패턴으로 모은다. 마지막 남은 수동 outline 링(`ui/Select`)을 `focus-ring` 믹스인으로 바꾸고, `FormField`의 `!important`를 없앤다. admin focus는 admin accent(`$primary-soft`) border와 glow(`$primary-soft-subtle`)로 맞추고, 하드코딩 rgba도 토큰으로 바꾼다.
+
+## 검증된 Assumptions
+
+(EXPLORE: Read + Grep로 확인)
+
+- `focus-ring` 믹스인·토큰 SSOT 존재 — `_mixins.scss:232` + `_semantic.scss:97-107`($spacing-2=0.2rem·$border-focus·$primary-active). ListItem·Pagination·NoticeTable·NoticeDrawer·NoticeControlBar가 이미 채택.
+- content/ui 입력 4개는 이미 `border-color: $border-focus`(링 억제)로 일관 — TextField:52·SearchField:37은 안쪽 input `outline:none` + wrapper `:focus-within` border, Textarea:42·FormField:34는 자기 `outline:none`. → 변경 불필요.
+- 수동 outline 링은 `ui/Select`(`Select.module.scss:27` `outline: 2px solid $border-focus`) 1곳만 남음. 루트가 `font-size: 2.777778vw`(globals.scss:112)라 `$spacing-2`=`0.2rem`은 360px 기준 2px이고 다른 폭에선 다른 모든 focus 링처럼 스케일한다 — 고정 2px이던 Select를 사이트 공통 토큰 링에 맞춘다(무변화 아님, 의도된 정렬).
+- 하드코딩 `rgba(91,107,165,0.08)`(`primitives:25,70`)은 토큰 `$primary-soft-subtle`(`_color.scss:125`)과 1:1 동일.
+- admin accent는 `$primary-soft`(#5b6ba5)로 확립 — active/selected/badge 15곳+(table·PageHeader·AdminSidebar·SermonForm·dropbar 등). dropdown 스타일은 selected를 peri로 두면서(`dropdown:33-49`) focus만 navy(`dropdown:235` `$primary`)라, 한 컴포넌트 안에서 색이 어긋난다.
+- `FormField`는 `BulletinForm.tsx` 1곳에서 사용 중(살아있음) — `rg FormField src -g '*.tsx'`.
+
+## Success Criteria
+
+- `ui/Select`가 `@include focus-ring()` 사용, 하드코딩 outline px 0.
+- `form/FormField` `:focus`에 `!important` 0.
+- admin `primitives`에 하드코딩 rgba 0(`$primary-soft-subtle` 토큰).
+- admin `dropdown`·`AdminHeader` focus가 `$primary-soft` border + `$primary-soft-subtle` glow recipe로 통일.
+- `AdminHeader`가 `:focus-visible`를 `:hover`와 분리해, 키보드 포커스에서 `$primary-soft` border(+ 보조 glow)가 hover의 gray border와 다르게 보인다.
+- `verify-task` lint/styles/build 통과, knip 신규 0.
+
+## 영향받는 파일
+
+- `src/components/ui/Select/Select.module.scss` — 수동 outline → `@include focus-ring()`
+- `src/components/form/FormField.module.scss` — `:focus` `!important` 제거
+- `src/components/admin/sermons/SermonForm/primitives/primitives.module.scss` — rgba ×2 → `$primary-soft-subtle`
+- `src/components/admin/sermons/SermonListPage/dropdown.module.scss` — focus `$primary`/`$primary-subtle` → `$primary-soft`/`$primary-soft-subtle`
+- `src/components/admin/layout/AdminHeader/index.module.scss` — `:focus-visible`를 `:hover`와 분리 + admin recipe 적용(`outline:none` 유지. `$primary-soft` border가 포커스 표시 — hover의 gray border와 구분, glow는 보조)
+- `docs/tech-debt/resolved.md` — PR #108 focus-ring 항목에 잔여 사이트(Select·admin) 완료 note 추가 / `docs/design-system/context.md` — 활성 부채 발췌의 stale focus-ring 줄을 해소로 정정 (active.md엔 focus-ring 항목 없음 — 이미 PR #108에서 resolved로 이관됨)
+
+## Non-goals
+
+- content/ui 입력 4개(TextField·SearchField·Textarea·FormField)의 border 메커니즘 구조 변경 — 이미 일관, 토큰만 손댄다.
+- admin glow를 outline 링으로 교체 — admin은 glow 언어를 의도적으로 유지([[feedback_portal_tokens]]).
+- focus 외 admin 토큰 정리(예: `FormField`의 `$red-500` primitive 직접 사용) — 이번 범위에서 빼고, 발견 사실만 적는다.
+
+## 단계별 체크리스트
+
+- [x] 1. `ui/Select` → `@include focus-ring()` (수동 outline 제거)
+- [x] 2. `form/FormField` → `!important` 제거
+- [x] 3. admin `primitives` → rgba ×2를 `$primary-soft-subtle`로
+- [x] 4. admin `dropdown` → focus 색을 peri(`$primary-soft`)로
+- [x] 5. admin `AdminHeader` → focus/hover 분리 + peri(`$primary-soft`) glow
+- [x] 6. CODEX_FIRST_PASS 생략(저위험) → `verify-task` PASS → tech-debt 갱신(resolved.md·context.md)
+
+## Verification
+
+- `node scripts/verify-task.mjs focus-ring-unify`
+- Chrome 수동: admin 폼 입력·dropdown·헤더 검색버튼·`ui/Select`를 키보드로 포커스해 표시(peri glow / outline 링) 확인.
+
+---
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST (블로커 2). 안전성·완전성은 통과 — FormField `!important` 제거는 특이도로 안전, dropdown 색 변경은 CSS 충돌 없음, admin accent=`$primary-soft` 결정 타당.
+- **현재 판단**: Codex verbatim — (1) "`Select` 변경은 '무시각 변경'이 아닙니다. 계획에 '의도적 rem 기반 미세 변화'로 고치거나 … 재검토해야 합니다." (2) "`AdminHeader`는 glow 단독을 a11y 근거로 쓰면 안 됩니다. … '고대비 `$primary-soft` border + 보조 glow'로 고치고 …" 풀이: 루트가 `font-size: 2.777778vw`(globals.scss:112)라 `0.2rem`은 360px에서만 2px이고 다른 폭에선 다른 모든 링처럼 스케일한다 — Assumptions와 영향 파일을 "고정 2px→공통 토큰 링 정렬(무변화 아님)"로 고쳤다. AdminHeader 포커스 표시 주체를 glow→`$primary-soft` border로 고쳤다. 정정: Codex가 짚었다 — dropdown은 filter active만 peri, item active(`dropdown:142-149,196-198`)는 navy다. 그래서 "자기모순 해소"는 과장이라 D1에서 뺐다.
+- **다음 행동**: 계획 수정 완료 → WORK 1단계(Select). CHANGE_REQUEST라 Codex 재요청 안 함.
+
+## Codex 1차 검증
+
+- **결론**: 생략 (저위험 SCSS). CODEX_FIRST_PASS 위임 트리거(큰 diff·고위험 파일·레이어 변경·검증 실패) 어디에도 해당 안 됨. 계획 단계 Codex 검증(CHANGE_REQUEST)을 이미 반영했고, Codex 윈도 런타임이 이번 세션에 3번 멈춰서(hang) 직접 측정으로 대신한다.
+- **현재 판단**: 구현 diff는 SCSS 줄 단위 교체뿐(토큰·믹스인 1:1 치환, 신규 로직 0). verify-task build가 `@include focus-ring()`·`$primary-soft`·`$primary-soft-subtle` 해석을 실증한다. Claude 자체 교차 확인 — 5개 diff 모두 토큰/믹스인 치환이고, AdminHeader만 hover/focus 규칙 분리를 더했다.
+- **다음 행동**: Claude 2차(verify-task) 기록 → COMMIT.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — verify-task 필수 단계 중 ESLint·stylelint·build 통과. Knip는 기존 부채 warning(비차단).
+- **현재 판단**: build가 5개 SCSS 변경을 컴파일해 토큰·믹스인 해석을 실증했다. 변경 파일 stylelint도 0 error(경고 4건은 내가 안 건드린 줄의 기존 hex·primitive 부채). admin focus가 dropdown·primitives·AdminHeader에서 `$primary-soft` + `$primary-soft-subtle` 한 recipe로 모였고, `ui/Select`는 공통 `focus-ring` 토큰 링을 쓴다. Chrome 3개 라우트(`/news/notices`·`/admin/sermons`·`/admin/sermons/new`)의 서버 CSS로도 실측했다. `ui/Select`는 globals·ListItem·Pagination과 같은 `outline: rgb(44,62,80) solid 0.2rem`을 썼다. admin 4곳(dropdown·AdminHeader·primitives `control`·`group`)은 전부 `border rgb(91,107,165)`(peri, `$primary-soft`) + `box-shadow rgba(91,107,165,0.08) 3px`로 일치했다. 키보드 Tab으로 폼 입력에 포커스하니 `matchesFocusVisible=true`였고 peri glow가 화면에 떴다.
+- **다음 행동**: tech-debt 갱신 완료 → 사용자 승인 후 COMMIT.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260615-181611 | ✅ | ✅ | ✅ | 0(기존 부채만) | Chrome 실측 — admin focus 4곳이 같은 peri recipe로, Select가 공통 링으로 떴다 (키보드 포커스 확인) |
+
+## 의사결정 로그
+
+- **D1 — admin focus accent를 `$primary-soft`(peri)로 통일**
+  - 문제: admin focus가 dropdown(`$primary` navy + `$primary-subtle`), primitives(`$primary-soft` peri + 하드코딩 rgba), AdminHeader(`$txt-admin-tertiary`)로 제각각이다. admin 안에서 peri와 navy가 섞여 있다 — dropdown은 filter active를 peri로 두지만(`dropdown:32-40`) 트리거 focus는 navy(`dropdown:235`)다.
+  - 해결: navy(`$primary`)와 peri(`$primary-soft`) 중 peri로 모은다. admin accent가 active·selected·badge 15곳+에서 이미 peri라, navy로 가면 focus 하나만 admin accent에서 튄다. peri는 바꿀 사이트도 더 적다(primitives는 토큰화만, dropdown·AdminHeader만 색 변경).
+  - 결과: admin focus가 admin의 지배적 accent(peri)와 일치한다. dropdown item active(`dropdown:142-149`)의 navy는 이번 범위 밖이다.
+
+## 후속 작업
+
+- admin focus를 content와 같은 outline 링으로 합칠지 — 이번엔 admin glow 언어를 유지했다.
+  - 이유: glow는 admin 폼 컨트롤의 의도된 시각 언어라 outline 링으로 바꾸면 변화가 크다.
+  - 다음 기준: admin/content focus 시각을 완전히 한 가지로 통일하기로 결정될 때.
+  - 기록 위치: 없음 (본 plan 후속)

--- a/docs/exec-plans/active/2026-06-15-focus-ring-unify.md
+++ b/docs/exec-plans/active/2026-06-15-focus-ring-unify.md
@@ -85,7 +85,7 @@ content/ui와 admin의 `:focus` 표시를 일관된 토큰·패턴으로 모은�
 | 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
 | --- | --- | --- | --- | --- | --- | --- |
 | 2차 | 20260615-181611 | ✅ | ✅ | ✅ | 0(기존 부채만) | Chrome 실측 — admin focus 4곳이 같은 peri recipe로, Select가 공통 링으로 떴다 (키보드 포커스 확인) |
-| 리뷰 반영 | 20260615-220114 | ✅ | ✅ | ✅ | 0(기존 부채만) | PR #124 리뷰 4건 반영 후 build·stylelint 통과(상세는 리뷰 반영 섹션). `.filter_trigger`는 원 PR에서 실측한 border+glow와 같은 토큰. `.dropdown_item` inset 링·`.date_clear` outline은 새 합성이라 build 컴파일만 확인(시각 미실측) |
+| 리뷰 반영 | 20260615-220114 | ✅ | ✅ | ✅ | 0(기존 부채만) | PR #124 리뷰 4건 반영 후 build·stylelint 통과. Chrome `/admin/sermons` served-CSS 실측: `.filter_trigger`·`.dropdown_item`·`.date_clear`·AdminHeader `.search` focus가 전부 peri `rgb(91,107,165)`(`$primary-soft`)로 렌더, navy 0곳. AdminHeader transition에 `box-shadow 0.15s` 포함 확인(① 반영) |
 
 ## 리뷰 반영 (PR #124 자동 리뷰 + Codex 교차검증)
 

--- a/docs/tech-debt/resolved.md
+++ b/docs/tech-debt/resolved.md
@@ -21,6 +21,7 @@
 - **부채**: `:focus-visible` outline 10곳과 `Pagination.module.scss`의 `:focus` outline 1곳이 색·폭·offset을 직접 선언해 SSOT가 없었다
 - **해소**: `focus-ring($variant, $offset)` mixin(`@content`로 추가 속성 수용)과 `$focus-ring-strong-color` 토큰을 도입해 11곳(Notice 8·ListItem·SermonNoteEditor·Pagination)을 교체했다
 - **확인**: `rg -n ":focus|outline" src/components/ui/Pagination/Pagination.module.scss` → transition 선언 1건, focus outline 선언 0건. admin box-shadow 패턴은 범위 밖
+- **후속 (2026-06-15, focus-ring-unify)**: PR #108이 범위 밖으로 둔 마지막 두 곳을 마무리했다. `ui/Select`의 수동 `outline: 2px`를 `focus-ring` mixin으로 바꾸고(고정 px → 공통 토큰 링), admin focus(`dropdown`·`primitives`·`AdminHeader`)를 admin accent `$primary-soft` + glow `$primary-soft-subtle` 한 recipe로 통일했다. 하드코딩 `rgba(91,107,165,0.08)`도 `$primary-soft-subtle` 토큰으로 바꿨다. content/ui 입력 4개는 이미 `border-color: $border-focus`로 일관해 손대지 않았다.
 
 ### ✅ useDrawerHistory 라우트 이동 시 가짜 history 항목 (2026-06-02 해소, PR #108)
 

--- a/src/components/admin/layout/AdminHeader/index.module.scss
+++ b/src/components/admin/layout/AdminHeader/index.module.scss
@@ -100,10 +100,15 @@
     border-color 0.15s,
     color 0.15s;
 
-  &:hover,
-  &:focus-visible {
+  &:hover {
     border-color: $txt-admin-tertiary;
     color: $txt-secondary;
+  }
+
+  &:focus-visible {
+    border-color: $primary-soft;
+    color: $txt-secondary;
+    box-shadow: 0 0 0 3px $primary-soft-subtle;
     outline: none;
   }
 

--- a/src/components/admin/layout/AdminHeader/index.module.scss
+++ b/src/components/admin/layout/AdminHeader/index.module.scss
@@ -98,7 +98,8 @@
   cursor: pointer;
   transition:
     border-color 0.15s,
-    color 0.15s;
+    color 0.15s,
+    box-shadow 0.15s;
 
   &:hover {
     border-color: $txt-admin-tertiary;

--- a/src/components/admin/sermons/SermonForm/primitives/primitives.module.scss
+++ b/src/components/admin/sermons/SermonForm/primitives/primitives.module.scss
@@ -22,7 +22,7 @@
 
   &:focus-visible {
     border-color: $primary-soft;
-    box-shadow: 0 0 0 3px rgba(91, 107, 165, 0.08);
+    box-shadow: 0 0 0 3px $primary-soft-subtle;
   }
 
   &:disabled {
@@ -67,7 +67,7 @@
 
   &:focus-within {
     border-color: $primary-soft;
-    box-shadow: 0 0 0 3px rgba(91, 107, 165, 0.08);
+    box-shadow: 0 0 0 3px $primary-soft-subtle;
   }
 
   .control {

--- a/src/components/admin/sermons/SermonListPage/dropdown.module.scss
+++ b/src/components/admin/sermons/SermonListPage/dropdown.module.scss
@@ -21,11 +21,18 @@
   transition:
     border-color 0.15s $transition-easing-default,
     background 0.15s $transition-easing-default,
-    color 0.15s $transition-easing-default;
+    color 0.15s $transition-easing-default,
+    box-shadow 0.15s $transition-easing-default;
 
   &:hover {
     border-color: $border-primary;
     color: $txt-primary;
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-color: $primary-soft;
+    box-shadow: 0 0 0 3px $primary-soft-subtle;
   }
 }
 
@@ -129,6 +136,12 @@
   &:hover {
     background: $bg-secondary;
     color: $txt-primary;
+  }
+
+  &:focus-visible {
+    outline: none;
+    background: $bg-secondary;
+    box-shadow: inset 0 0 0 1.5px $primary-soft;
   }
 
   @include respond-up($breakpoint-pc-sm) {
@@ -255,6 +268,12 @@
 
   &:hover {
     text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid $primary-soft;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 
   @include respond-up($breakpoint-pc-sm) {

--- a/src/components/admin/sermons/SermonListPage/dropdown.module.scss
+++ b/src/components/admin/sermons/SermonListPage/dropdown.module.scss
@@ -232,8 +232,8 @@
 
   &:focus {
     outline: none;
-    border-color: $primary;
-    box-shadow: 0 0 0 3px $primary-subtle;
+    border-color: $primary-soft;
+    box-shadow: 0 0 0 3px $primary-soft-subtle;
   }
 
   @include respond-up($breakpoint-pc-sm) {

--- a/src/components/form/FormField.module.scss
+++ b/src/components/form/FormField.module.scss
@@ -35,7 +35,7 @@
     transition: border 0.1s ease-in-out;
 
     &:focus {
-      border: 1px solid $border-focus;
+      border-color: $border-focus;
     }
   }
 }

--- a/src/components/form/FormField.module.scss
+++ b/src/components/form/FormField.module.scss
@@ -35,7 +35,7 @@
     transition: border 0.1s ease-in-out;
 
     &:focus {
-      border: 1px solid $border-focus !important;
+      border: 1px solid $border-focus;
     }
   }
 }

--- a/src/components/ui/Select/Select.module.scss
+++ b/src/components/ui/Select/Select.module.scss
@@ -21,12 +21,9 @@ $chevron-stroke: '%23' + string.slice('#{$txt-tertiary}', 2);
   background-repeat: no-repeat;
   background-position: right $spacing-10 center;
 
-  // border-color는 emphasized와 같은 $primary로 묻히므로, border와 분리된 offset
-  // outline으로 포커스를 표시한다 (일반·emphasized 상태 모두에서 보이게).
-  &:focus-visible {
-    outline: 2px solid $border-focus;
-    outline-offset: 2px;
-  }
+  // border-color는 emphasized와 같은 $primary로 묻히므로, border와 분리된 outline 링으로
+  // 포커스를 표시한다 (일반·emphasized 모두에서 보이게). focus-ring 토큰을 공통으로 쓴다.
+  @include focus-ring();
 
   &:disabled {
     cursor: not-allowed;


### PR DESCRIPTION
<!-- 🔁 Refactor 템플릿 — 기능 변경 없는 코드 구조 개선. -->

## 📋 개요 (Summary)

**목적**: 흩어진 `:focus` 표시를 공통 토큰·믹스인 한 벌로 모은다.

**범위**:

- `ui/Select`의 수동 outline 링을 공통 `focus-ring()` 믹스인으로 교체
- admin focus(`dropdown`·`primitives`·`AdminHeader`)를 admin accent `$primary-soft` border + `$primary-soft-subtle` glow 한 recipe로 통일
- `form/FormField`의 `:focus` `!important` 제거, admin 하드코딩 rgba를 토큰으로 교체

---

## 🔗 개발 컨텍스트

- **Task ID**: `focus-ring-unify`
- **Exec Plan**: `docs/exec-plans/active/2026-06-15-focus-ring-unify.md`
- **관련 ADR**: 해당 없음 — 기존 토큰·믹스인 적용이라 구조 결정 없음
- **관련 tech debt**: `docs/tech-debt/resolved.md` (focus-ring 항목에 후속 note 추가) / `docs/design-system/context.md` (활성 부채 발췌의 stale focus-ring 줄을 해소로 정정)
- **작업 범위**: `ui/Select`·`form/FormField`·admin focus 3곳(`dropdown`·`primitives`·`AdminHeader`)의 focus 표시
- **제외한 범위**: content/ui 입력 4개(TextField·SearchField·Textarea·FormField)의 border 메커니즘 구조 변경(이미 `border-color: $border-focus`로 일관), admin glow를 outline 링으로 교체, focus 외 admin 토큰 정리

---

## 💡 리팩토링 배경 (Motivation)

**개선하려는 문제:**

- [x] 기술 부채 해소
- [x] 가독성 저하 (네이밍 불명확 등)

PR #108이 focus-ring 믹스인·`$focus-ring-*` 토큰을 도입하고 11곳을 교체했지만, 범위 밖으로 둔 두 곳이 남았다. `ui/Select`는 `outline: 2px solid $border-focus`를 직접 선언해 다른 모든 링이 쓰는 공통 토큰을 따르지 않았다. admin focus는 색이 제각각이었다 — dropdown 트리거는 navy(`$primary`), primitives는 peri(`$primary-soft`)에 하드코딩 rgba, AdminHeader는 focus와 hover를 같은 규칙으로 묶어 키보드 포커스가 hover와 구분되지 않았다.

**관련 이슈:**

- Issue: 해당 없음

---

## 🔧 주요 변경점 (Key Changes)

- `src/components/ui/Select/Select.module.scss` — 수동 `outline: 2px solid $border-focus`를 `@include focus-ring()`으로 교체. 고정 2px 링이 사이트 공통 토큰 링(`$spacing-2`)을 따른다.
- `src/components/admin/sermons/SermonListPage/dropdown.module.scss` — 트리거 focus 색을 navy(`$primary`/`$primary-subtle`)에서 peri(`$primary-soft`/`$primary-soft-subtle`)로 교체. admin의 지배적 accent와 일치시킨다.
- `src/components/admin/layout/AdminHeader/index.module.scss` — `:focus-visible`를 `:hover`와 분리. 키보드 포커스에서 `$primary-soft` border가 hover의 gray border와 다르게 보이고, glow는 보조다.
- `src/components/admin/sermons/SermonForm/primitives/primitives.module.scss` — 하드코딩 `rgba(91,107,165,0.08)` 2곳을 `$primary-soft-subtle` 토큰으로 교체.
- `src/components/form/FormField.module.scss` — `:focus`의 `!important` 제거(특이도로 안전).

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| admin focus accent | peri(`$primary-soft`)로 통일 | admin accent가 active·selected·badge 15곳+에서 이미 peri다. navy로 가면 focus 하나만 admin accent에서 튄다. 바꿀 사이트도 더 적다(primitives는 토큰화만, dropdown·AdminHeader만 색 변경). | navy(`$primary`) — admin 지배 색과 어긋나 focus 하나만 도드라진다 |
| admin focus 시각 언어 | glow border recipe 유지 | admin 폼 컨트롤의 의도된 시각 언어라 content의 outline 링으로 바꾸면 변화가 크다. | content와 같은 outline 링 — 변화 폭이 커 이번 범위 밖으로 미룸 |

> ⚠️ **주의사항:** dropdown item active(`dropdown:142-149`)는 여전히 navy다. 이번 변경은 트리거 focus 색만 peri로 모았고, item active 색 통일은 범위 밖이다.

**변경 전 구조:**

focus 표시가 `ui/Select`는 수동 outline px, admin은 navy·peri·하드코딩 rgba가 섞여 컴포넌트마다 달랐다.

**변경 후 구조:**

`ui/Select`는 공통 `focus-ring()` 믹스인 링을, admin 3곳은 `$primary-soft` border + `$primary-soft-subtle` glow 한 recipe를 쓴다.

---

## 📊 개선 지표 (Improvement Metrics)

| 항목 | Before | After |
| ---- | ------ | ----- |
| 수동 outline px 선언(`ui/Select`) | 1곳 | 0 |
| `:focus` `!important`(`FormField`) | 1곳 | 0 |
| admin focus 하드코딩 rgba(`primitives`) | 2곳 | 0 |
| admin focus 색 갈래 | 3종(navy·peri·tertiary) | 1종(peri recipe) |
| SCSS 변경 | 5개 파일, +15 / -13줄 | — |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs focus-ring-unify` — PASS, RUN_ID=`20260615-181611`, lint·styles·build 통과, knip 신규 0(기존 부채 warning만 비차단) |
| `harness-gate` | 머지 직전 `node scripts/harness-gate.mjs focus-ring-unify` 실행 |
| Codex 계획 검증 | CHANGE_REQUEST(반영) — 블로커 2건 수정: (1) Select 변경을 '무변화'가 아니라 '고정 2px → 공통 토큰 링 정렬(rem 기반 스케일)'로 고침, (2) AdminHeader 포커스 표시 주체를 glow 단독에서 `$primary-soft` border + 보조 glow로 고침. 상세는 exec-plan `## Codex 계획 검증`. |
| Codex 1차 검증 | N/A — 저위험 SCSS 줄 치환(토큰·믹스인 1:1, 신규 로직 0)이라 1차 검증 트리거(큰 diff·고위험 파일·레이어 변경·검증 실패) 어디에도 안 해당. Claude 자체 교차 확인으로 대신함. |
| Claude 2차 검증 | 완료 — build가 5개 SCSS를 컴파일해 토큰·믹스인 해석을 실증. Chrome 3개 라우트(`/news/notices`·`/admin/sermons`·`/admin/sermons/new`) 실측: `ui/Select`는 공통 링(`outline: rgb(44,62,80) solid 0.2rem`), admin 4곳은 `border rgb(91,107,165)` + `box-shadow rgba(91,107,165,0.08)` 한 recipe로 일치. 키보드 Tab으로 `matchesFocusVisible=true` 확인. |
| ADR 판단 | 불필요 — 기존 토큰·믹스인 적용, docs/decisions·skills 변경 없음 |
| 남은 warning | 기존 부채 (변경 파일 stylelint 경고 4건은 안 건드린 줄의 hex·primitive 부채 / Knip) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**리팩토링 완성도**

- [x] 외부 동작 변경: admin focus 표시가 미세하게 바뀐다(navy → peri glow, hover와 분리). 의도된 focus 표시 통일이다.
- [x] 불필요한 기능 변경 미포함 확인 (focus 표시 외 토큰 정리는 범위에서 빼고 발견 사실만 기록)

**코드 품질**

- [x] 토큰·믹스인 네이밍의 의도 명확성(`$primary-soft`·`$primary-soft-subtle`·`focus-ring()`)
- [x] 불필요한 코드·디버그 로그 없음 확인

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: admin 폼·dropdown·헤더 검색버튼의 키보드 focus 표시가 navy·제각각에서 peri glow 한 가지로 바뀐다. `ui/Select`의 focus 링은 고정 2px에서 사이트 공통 토큰 링으로 바뀌어 뷰포트에 따라 스케일한다. 의도된 focus 표시 통일이다.
- **운영 리스크**: 없음 (SCSS 토큰·믹스인 치환만, 배포·설정 영향 없음)
- **QA 후속**: 머지 후 admin 폼 입력·dropdown·헤더 검색버튼·`ui/Select`를 키보드로 포커스해 peri glow / 공통 링 표시 재확인
- **롤백 시 영향**: 없음 (focus 표시가 이전 색·폭으로 되돌아갈 뿐, 동작 영향 없음)
- **먼저 볼 화면 / 흐름**: `/admin/sermons`(dropdown·헤더)·`/admin/sermons/new`(폼 입력)를 키보드 Tab으로 순회

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

admin과 content의 focus 시각을 완전히 한 가지로 합치는 건 미뤘다. admin glow는 폼 컨트롤의 의도된 시각 언어라 content outline 링으로 바꾸면 변화가 크다. admin/content focus를 하나로 통일하기로 결정될 때 후속으로 다룬다. dropdown item active의 navy 색도 이번 범위 밖이라 남아 있다.
