### PR TITLE
[Feat] 홈에 교회 식별·위치 JSON-LD 추가 — 검색엔진 지역 노출 근거

### DIFF
--- a/.claude/skills/supabase/SKILL.md
+++ b/.claude/skills/supabase/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: supabase
-description: Supabase 클라이언트 생성/선택, 데이터 페칭, 캐싱 전략(revalidateTag/ISR), Server Action 작성, 인증 흐름 작업 시 사용
+description: Supabase 클라이언트 생성/선택, 데이터 페칭, 캐싱 전략(updateTag/ISR), Server Action 작성, 인증 흐름 작업 시 사용
 ---
 
 # Supabase 클라이언트 · 캐싱 · 인증
@@ -35,33 +35,33 @@ const supabase = createStaticClient({ tags: ['bulletin-list'], revalidate: 86400
 
 **3. On-demand ISR** — 관리자 액션으로만 변경되는 데이터 (주보 상세 등)
 ```ts
-const supabase = createStaticClient({ tags: ['bulletin-detail', 'bulletin-detail-42'] });
-// 뮤테이션 시: revalidateTag('bulletin-detail-42')
+const supabase = createStaticClient({ tags: ['bulletin', 'bulletin-detail', 'bulletin-detail-42'] });
+// 뮤테이션 시: updateTag('bulletin') — 모든 키가 ROOT 'bulletin'을 포함해 한 번에 무효화 (ADR 0016)
 ```
 
 **4. 영구 캐시** — 거의 변경되지 않는 데이터 (사역자 정보 등)
 ```ts
 const supabase = createStaticClient({ tags: ['staff'], cache: 'force-cache' });
-// 관리자 수정 시: revalidateTag('staff')
+// 관리자 수정 시: updateTag('staff')
 ```
 
 ### 레이어별 역할
 
-**`src/apis/`** — 단일 테이블 단순 쿼리. 캐시 전략을 함께 결정하고, 쿼리 결과를 가공 없이 반환.
+**`src/apis/`** — 인증·설정·스태프 등 횡단(cross-cutting) 단순 쿼리. 도메인(sermon·bulletin 등) 파일은 없다. 캐시 전략을 함께 결정하고, 쿼리 결과를 가공 없이 반환.
 
-**`src/services/`** — 여러 쿼리 조합(`Promise.all`), 결과 가공 등 비즈니스 로직. 캐시 전략은 `*-cache.ts`로 분리하고 클라이언트를 주입받아 사용(`bulletinService(supabase)`).
+**`src/services/`** — 도메인 읽기·쓰기를 모두 가진다. 여러 쿼리 조합(`Promise.all`)·결과 가공 같은 읽기 로직과 RPC 뮤테이션(`createSermon`·`updateSermon` 등)이 한 팩토리에 함께 있다. 캐시 전략은 `*-cache.ts`로 분리하고 클라이언트를 주입받아 사용(`bulletinService(supabase)`).
 
-**`src/actions/`** — 폼 제출·뮤테이션 전담. `createServerSideClient()`(캐시 없음) 고정. 성공 후 `revalidateTag`로 관련 캐시 무효화.
+**`src/actions/`** — 폼 제출·뮤테이션의 서버 진입점. `'use server'` + 검증·인증을 입혀 `services/` 뮤테이션을 호출한다. `createServerSideClient()`(캐시 없음) 고정. 성공 후 `updateTag`로 관련 캐시 무효화.
 
-### revalidateTag 무효화 책임
+### updateTag 무효화 책임
 
-뮤테이션이 발생한 Server Action에서 직접 호출. 태그 체계는 `src/services/*/`의 `*-cache.ts`에서 관리.
+뮤테이션이 발생한 Server Action에서 직접 호출. 태그 체계는 `src/services/*/`의 `*-cache.ts`에서 관리. 모든 도메인 캐시 키가 ROOT 태그를 포함하므로 ROOT 하나로 목록·요약·상세·nav를 한 번에 갱신한다 (ADR 0016).
 
 ```ts
+import { updateTag } from 'next/cache';
+
 // 예시: 주보 수정 후
-revalidatePath('/news/bulletins');
-revalidateTag('bulletin-detail');      // 전체 상세 무효화
-revalidateTag(`bulletin-detail-${id}`); // 특정 건만 무효화
+updateTag('bulletin'); // ROOT 태그 — 주보 관련 캐시 전체 무효화
 ```
 
 ## 인증 (Auth)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 
 - **Stack**: Next.js (App Router), Supabase, SCSS Modules, Cloudinary, TypeScript
 - **Route Groups**: `(content)/` — HeroSection + Breadcrumb 포함 (about, news, fellowship, sermons, community, next-gen, notifications, search)
-- **Data Flow**: `apis/` (DB 쿼리) → `services/` (비즈니스 로직) → `actions/` (뮤테이션) → `app/` (페이지)
+- **레이어 서열** (ESLint 강제): `apis → services → actions → app`. 각 층은 왼쪽(하위)만 import하고 오른쪽(상위)은 참조하지 못한다. 순차 데이터 파이프라인이 아니다 — `services/`가 도메인 읽기·쓰기(RPC 뮤테이션 포함)를 함께 갖고, `actions/`는 검증·인증·캐시 갱신을 입힌 서버 뮤테이션 진입점, `apis/`는 인증·설정 등 횡단 쿼리다.
 
 ## 행동 가드레일 (LLM 공통 실수 방지)
 
@@ -86,6 +86,7 @@
 | 2026-05-28 | writing-style SKILL 신설 (작성용 단일 SSOT) | .claude/skills/writing-style/, harness-workflow SKILL reference 1줄 | 작성 시점 표현 가이드 부재 해소 — 사후 점검만으로는 같은 위반 반복(본 task dogfood에서 plan 자체에 5건 위반 발견). description 트리거로 작성 시점 자동 로딩 |
 | 2026-05-29 | PR 생성 시점 commit-pr-author 호출 의무화 + PreToolUse hook 신설 | .claude/hooks/check-pr-before-create.mjs, .claude/settings.json PreToolUse 블록, claude-code.md, harness-workflow SKILL | gh pr create 시점은 PostToolUse hook 사각지대 — 결정적 reminder + 워크플로우 의무 + COMMIT 단계 명시 3 계층 방어 |
 | 2026-06-15 | PR 리뷰 대응을 표준 절차로 명문화 (`### 8. PR_REVIEW` 조건부 단계) | harness-workflow SKILL (§ 8 + `## PR 리뷰 명령`), CLAUDE.md (Workflow 포인터 + 본 표) | PR #118·#119 수동 대응에서 봇 오탐 2건을 코드 미확인 중계로 놓칠 뻔함 — 코드 확인 근거·중계 금지 hard rule로 검증 규율 고정 (hook·스크립트·ADR 없이 문서만) |
+| 2026-06-18 | 레이어 설명을 import 서열 + `services` 읽기·쓰기 공존으로 정정, `revalidateTag`→`updateTag` 드리프트 정정, 스킬 표에 `complete-task` 반영, audit 마커 갱신 | CLAUDE.md, docs/ARCHITECTURE.md, .claude/skills/supabase/SKILL.md, README.md | 포트폴리오 점검 중 `services`를 읽기 전용처럼 읽히게 한 표현·코드와 안 맞는 API 이름·표 누락 발견 (Codex 계획 검증 PASS_WITH_DECISION_LOG) |
 
 ## HOW (검증 루프)
 
@@ -153,19 +154,20 @@ pre-commit 훅은 lint-staged로 변경 파일만 자동 검사 — error는 차
 | Codex 컨텍스트 로더 | `.codex/skills/context-loader/` | 컨텍스트 라우팅 변경 시 |
 | Claude Hook 자동 제안 | `.claude/hooks/` + `.claude/settings.json` | 협업 타이밍 변경 시 |
 | 워크플로우 자동화 스크립트 | `scripts/` | 스크립트 추가/변경 시 |
-| 작업별 how-to (자동 로딩) | `.claude/skills/{supabase,styles,file-structure,ui-components,writing-style}/` | 트리거 시 자동 |
+| 작업별 how-to (자동 로딩) | `.claude/skills/{supabase,styles,file-structure,ui-components,writing-style,complete-task}/` | 트리거 시 자동 |
 | **작성용 SSOT** (한국어 표현·커밋·PR·exec-plan·ADR·tech-debt 템플릿) | `.claude/skills/writing-style/SKILL.md` | 모든 문서·메시지 작성 시 자동 로딩 |
 
 스킬 트리거:
 
 | 트리거                                         | 스킬                             |
 | ---------------------------------------------- | -------------------------------- |
-| Supabase 클라이언트, 캐싱, revalidateTag, 인증 | `.claude/skills/supabase/`       |
+| Supabase 클라이언트, 캐싱, updateTag, 인증 | `.claude/skills/supabase/`       |
 | SCSS 토큰, 믹스인, 시맨틱 토큰 매핑            | `.claude/skills/styles/`         |
 | 새 파일 위치, 디렉토리 구조, barrel export     | `.claude/skills/file-structure/` |
 | Button·TextField·Modal·BottomSheet·Tabs 등 공용 UI 사용·확장·신규 추가 | `.claude/skills/ui-components/` |
 | 하네스 워크플로우, PLAN Mode, task-id, exec-plan, Codex 검증, harness-gate | `.claude/skills/harness-workflow/` |
 | 문서·메시지 작성 (exec-plan, ADR, tech-debt, 검증 기록, commit, PR, Codex 인용) | `.claude/skills/writing-style/` |
+| 작업 완료, PR 머지 후, exec-plan completed 이관, 회고, tech-debt 등록 | `.claude/skills/complete-task/` |
 
-<!-- last-audit: 2026-05-01 -->
+<!-- last-audit: 2026-06-18 -->
 

--- a/README.md
+++ b/README.md
@@ -160,8 +160,8 @@ dnchurch/
 ├── scripts/                # 워크플로우 자동화 (.mjs)
 ├── supabase/               # 마이그레이션, seed, config.toml
 └── src/
-    ├── actions/            # Server Action (mutation)
-    ├── apis/               # Supabase 쿼리 (read)
+    ├── actions/            # Server Action 진입점 (mutation)
+    ├── apis/               # 횡단 쿼리 (인증·설정·스태프)
     ├── app/                # App Router 라우트
     │   ├── (admin)/        # 관리자 그룹 (.shell scope)
     │   ├── (content)/      # 일반 사용자 그룹 (Hero + Breadcrumb)
@@ -173,7 +173,7 @@ dnchurch/
     ├── hooks/              # 12개 커스텀 훅
     ├── lib/                # supabase 클라이언트 4종 + 도메인 유틸
     ├── proxy.ts            # Next 16 미들웨어 (구 middleware.ts)
-    ├── services/           # 비즈니스 로직 (bulletin/notice/sermon/worship)
+    ├── services/           # 도메인 읽기·쓰기 (bulletin/notice/sermon/worship)
     ├── store/              # zustand (toast)
     ├── styles/             # 토큰·믹스인·globals
     ├── types/              # database.types(자동) + 도메인 타입
@@ -194,15 +194,13 @@ dnchurch/
 
 ## 데이터 레이어
 
-### 흐름
+### 의존 서열
 
 ```
-apis/  →  services/  →  actions/  →  app/
-  ↑           ↑           ↑           ↑
-Supabase    비즈니스    Server      페이지/
-쿼리(read)  로직·RPC   Action      레이아웃
-                       (write)
+apis  →  services  →  actions  →  app
 ```
+
+화살표는 의존 서열이다 (왼쪽=하위, 오른쪽=상위). 순차 데이터 흐름이 아니다 — `services/`가 도메인 읽기·쓰기(쿼리 조합 + RPC 뮤테이션)를 함께 갖고, `actions/`는 검증·인증·캐시 갱신을 입힌 서버 뮤테이션 진입점이다.
 
 레이어 의존 방향은 ESLint로 강제됩니다 (`eslint.config.mjs`):
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -18,13 +18,12 @@ src/app/
 
 ## 데이터 흐름
 
+레이어 의존 서열이다 (위가 하위 레이어). 각 층은 자신보다 위(하위)만 import하고 아래(상위)는 참조하지 못한다 — 순차 데이터 파이프라인이 아니다.
+
 ```
-apis/         ← Supabase 쿼리 (read 중심)
-  ↓
-services/     ← 비즈니스 로직 / 트랜스폼 / 정렬·필터
-  ↓
-actions/      ← Server Action (write·뮤테이션, "use server")
-  ↓
+apis/         ← 횡단 쿼리 (인증·설정·스태프). 도메인 파일 없음
+services/     ← 도메인 읽기·쓰기 (쿼리 조합·정렬·필터 + RPC 뮤테이션)
+actions/      ← Server Action 진입점 ("use server" + 검증·인증·캐시 갱신)
 app/          ← 페이지·레이아웃 (RSC 기본)
 ```
 
@@ -58,4 +57,4 @@ app/          ← 페이지·레이아웃 (RSC 기본)
 
 상세는 `.claude/skills/file-structure/`.
 
-<!-- last-audit: 2026-05-01 -->
+<!-- last-audit: 2026-06-18 -->

--- a/docs/exec-plans/active/2026-06-18-church-jsonld.md
+++ b/docs/exec-plans/active/2026-06-18-church-jsonld.md
@@ -124,6 +124,21 @@
   - 다음 기준: Vercel 배포 + `NEXT_PUBLIC_SITE_URL` 설정 후.
   - 기록 위치: 없음.
 
+## PR 리뷰 대응 (#128)
+
+봇 2개(gemini-code-assist·chatgpt-codex-connector)·Codex 독립 리뷰(foreground)·Claude 직접 검토에서 같은 4건이 겹쳤고, 처리 방향도 일치했다. 처리 결과는 아래와 같다.
+
+| 지적 | 출처 | 처리 |
+| --- | --- | --- |
+| `<script>`에 `JSON.stringify` 값을 직접 삽입 → 값에 `</script>`가 섞이면 스크립트 태그가 일찍 닫혀 코드가 주입되는 XSS | Gemini(security-high) | 적용. 출력 문자열의 `<`를 유니코드 이스케이프(`\\u003c`)로 치환 |
+| `cleanValue` 인자 타입이 `string \| undefined` (DB value는 런타임 null 가능) | Gemini(medium) | 적용. `string \| null \| undefined`로 넓혀 형제 util(`displaySettingValue`)과 맞춤 |
+| fetch(I/O)와 JSON 빌드가 한 함수에 섞임 + `SITE_URL` 끝 슬래시 | Gemini(high) | 적용. 순수 `generateChurchJsonLd(settings, siteUrl)` 분리(sermons `buildJsonLd` 패턴), `siteUrl.replace(/\/$/, '')`로 `//images` 이중 슬래시 제거 |
+| JSON-LD 주소가 항상 상수라 admin이 `church_address`를 바꿔도 검색엔진엔 옛 주소 | Codex-connector(P2) | 상수 유지로 결정(사용자 선택 A). `PostalAddress`는 streetAddress·locality·region 구조 분해가 필요한데 DB는 자유형 문자열 1개라 분해 불가. 교회 주소는 안 바뀌는 값이고, 바뀌면 `CHURCH_INFO.address` 상수를 갱신한다 |
+
+- XSS 이스케이프 근거: `site_settings`는 admin이 편집하는 값이라, 같은 텍스트가 `<script>`에 들어가면 위 주입 경로가 열린다. 공개 사용자 입력은 아니지만 이스케이프로 막는다.
+- Codex foreground 재시도 verdict: **CHANGE_REQUEST (high)**, 4건 동의·추가 발견 없음. `@type ['Church','Organization']` 배열 유효·Suspense 중복 없음·좌표 dedup 안전 재확인.
+- 재검증: `verify-task church-jsonld`(run `20260618-202620`) ESLint·stylelint·Build 통과, 신규 knip 0.
+
 ## 의사결정 로그
 
 - **D1 — 교회 정보 출처는 DB `site_settings` + 상수 fallback**

--- a/docs/exec-plans/active/2026-06-18-church-jsonld.md
+++ b/docs/exec-plans/active/2026-06-18-church-jsonld.md
@@ -1,0 +1,148 @@
+# church-jsonld
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-18
+- **브랜치**: feat/church-jsonld
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+홈페이지에 교회 식별·위치 구조화 데이터(JSON-LD)를 넣는다. 검색엔진이 대구동남교회를 "대구 달서구에 있는 교회"로 읽고 지식 패널·지역 결과에 쓸 근거를 갖게 한다. 비신자가 검색으로 닿는 첫 관문을 넓히는 SEO 1순위 작업.
+
+## 검증된 Assumptions
+
+- 기존 JSON-LD 패턴 존재: `sermons/[id]/page.tsx`의 `buildJsonLd` + `<script type="application/ld+json" dangerouslySetInnerHTML>` — Read 확인.
+- 교회 정보는 `site_settings` 테이블 키로 관리: `church_address`·`church_lat`·`church_lng`·`church_phone`·`church_email`·`church_zipcode` — `services/about/index.ts` LOCATION_SETTING_KEYS Read 확인.
+- 실좌표가 location 페이지 fallback에 박힘: `35.85262832577055, 128.53467835707838` — `about/location/page.tsx:23-24` Read 확인.
+- 주소 `대구 달서구 달구벌대로307길 58`(`Footer.tsx:126`), 예배 주일 11시·수요 19시(`NewHere.tsx:19`) — Grep 확인.
+- `getSiteSettings`는 `createStaticClient` `force-cache` `tags:['site-settings']` — 홈 재호출도 같은 캐시라 저렴. `apis/site-settings.ts` Read 확인.
+- 미시드 값은 `'TODO'`/빈 문자열 — `parseFiniteFloat`/`displaySettingValue`로 안전 처리. `utils/site-settings.ts` Read 확인.
+- `SNS_LINKS` href가 전부 `'#'` placeholder → `sameAs` 소스 없음. `Footer.tsx:55-58` Grep 확인.
+- 홈 `/`는 자동 Hero 없음(`resolveHeroMeta('/')→null`) → script 주입 충돌 없음. `hero.config.ts` Read 확인.
+
+## Success Criteria
+
+- 홈 SSR HTML에 `<script type="application/ld+json">` 1개가 `["Church","Organization"]` 노드로 출력된다.
+- JSON에 `name`·`address`(PostalAddress)·`geo`(GeoCoordinates)가 항상 포함된다.
+- DB 미시드 상태에서 `telephone`·`email`이 빠지고 `'준비 중'` 같은 깨진 값이 안 들어간다.
+- `NEXT_PUBLIC_SITE_URL` 미설정 빌드에서 `url`·`@id`·`image` 절대경로가 빠지고 나머지는 유효하다.
+- DB 시드 후 phone/email/zipcode가 자동 반영된다(site-settings 캐시 태그).
+- `yarn lint` 통과, `yarn knip` 신규 0.
+
+## 영향받는 파일
+
+- `src/config/seo.ts` — `CHURCH_INFO` 상수 추가(이름·교단·주소 분해·좌표 fallback·국가).
+- `src/services/about/index.ts` — `getChurchIdentityData` 추가(JSON-LD용 최소 키 fetch). app→apis 직접 호출 금지 레이어 규칙 때문에 신규.
+- `src/app/_component/home/ChurchJsonLd.tsx` — 신규 서버 컴포넌트(service fetch → JSON-LD 빌드 → script).
+- `src/app/_component/home/index.ts` — barrel export 추가.
+- `src/app/(content)/page.tsx` — `<Suspense fallback={null}><ChurchJsonLd/></Suspense>` 주입.
+- (선택) `src/app/(content)/about/location/page.tsx` — 좌표 fallback을 `CHURCH_INFO` 한 곳으로 모아 location 페이지 중복 제거.
+
+## 단계별 체크리스트
+
+- [x] 1. `seo.ts`에 `CHURCH_INFO` 상수 정의(좌표·주소·교단·국가). 로고 파일이 실제로 어디 쓰이는지 확인 안 돼 v1에서 뺀다 — `image`만 OG 배너 URL로 쓴다.
+- [x] 2. `ChurchJsonLd.tsx` 작성 — `getChurchIdentityData()`(service 경유) → `buildChurchJsonLd`. app→apis 직접 호출 금지로 service 신설.
+- [x] 3. `buildChurchJsonLd`: name/address/geo 항상, telephone/email 조건부(TODO 제외), url/@id/image는 SITE_URL 있을 때만.
+- [x] 4. barrel export + `page.tsx` 주입.
+- [x] 5. `location/page.tsx` 좌표를 `CHURCH_INFO.geo`로 합침.
+- [x] 6. 검증 — lint → build → `verify-task`(run `20260618-183437`) 통과.
+
+## Non-goals
+
+- `openingHoursSpecification` — 예배 종료시각 미확정이라 제외(후속).
+- `sameAs` — SNS href가 전부 `'#'` placeholder라 제외(후속).
+- 루트 레이아웃·다른 페이지 주입 — 홈 1곳이 Organization/LocalBusiness 표준.
+- GBP·네이버 연동, sitemap 제출, analytics — 별도 Wave.
+
+## Verification
+
+- `node scripts/verify-task.mjs church-jsonld`
+
+---
+
+## Codex 계획 검증
+
+- **결론**: PASS
+- **현재 판단**: Codex CLI가 이 Windows 환경에서 작동하지 않아(메모리 `project-codex-windows-unavailable`) Claude가 직접 계획을 비판 검토했다.
+  - 출처: 기존 `site_settings` 파이프라인을 재사용해 새 SSOT를 안 만든다(D1).
+  - 표준 부합: 주입 위치(D2)·`@type`(D3)·Suspense(D4)가 sermons JSON-LD 패턴과 SEO 표준에 맞는다.
+  - 안전: 미시드·`NEXT_PUBLIC_SITE_URL` 미설정 양쪽을 조건부 필드로 막아 깨진 구조화 데이터를 안 내보낸다.
+  - ADR 불요: 트리거 파일 변경 0건.
+- **다음 행동**: 사용자 승인 후 WORK 진입, 구현 diff 생성 시 Codex 1차(대체: Claude) 검증.
+
+## Codex 1차 검증
+
+- **결론**: CHANGE_REQUEST — Claude 직접 검증으로 기각(거짓 양성). `high`는 Codex가 매긴 confidence.
+- **Codex 결과 인용**:
+
+  ```
+  CHANGE_REQUEST high
+  이유: cleanValue가 '준비 중' 같은 한국어 플레이스홀더를 걸러내지 못해
+  structured data에 오염 값이 노출될 위험이 있다. 이 프로젝트에서 DB 미설정
+  값이 'TODO' 계열 외에 다른 패턴으로도 들어올 수 있는지 확인하고, 필요하면
+  cleanValue 조건을 보완해야 한다.
+  (TYPE·CORRECTNESS·SURGICAL 항목은 문제 없음. SCHEMA.ORG 멀티타입은 유효하나
+  Rich Results Test 수용은 배포 후 확인 필요.)
+  ```
+
+  평이 풀이: SAFETY 항목 하나 때문에 변경 요청이 떴고, 나머지 검사 4개는 통과했다.
+- **현재 판단(Claude 직접 검증으로 기각)**:
+  - `'준비 중'`은 DB 저장값이 아니라 `displaySettingValue`의 표시용 fallback이다. `utils/site-settings.ts` 주석(ADR 0006)이 unset sentinel을 `'TODO'`/`'TODO:'` prefix·빈값·undefined로 못박는다.
+  - 시드 확인: `supabase/migrations/20260509000000_create_site_collections.sql:61-63`이 `church_phone`/`church_email`/`church_zipcode`에 `'TODO'`를 넣는다. `'준비 중'`을 저장값으로 쓰는 SQL은 0건(grep 확인).
+  - `cleanValue`는 문서화된 sentinel 4종(`!value`로 빈값·undefined, `'TODO'`·`'TODO:'` prefix)을 모두 거른다 — 계약 완전 충족.
+  - 임의 한국어 문자열 blocklist는 admin 오타를 못 막고(어떤 문자열이든 입력 가능) sentinel 계약을 흐린다. 코드 미변경이 정답.
+- **다음 행동**: cleanValue 유지. verify-task로 build·lint 마무리 후 Claude 2차 기록.
+
+## ADR 판단
+
+- **결론**: 불필요
+- **사유**: `src/services/about/index.ts`에 `getChurchIdentityData`를 더했지만 기존 `getHubPageData`·`getLocationPageData`와 같은 페이지별 fetch 패턴을 그대로 따른다. 새 레이어 경계·라이브러리·검증 정책을 만들지 않는다. site_settings 일부 키를 읽어 `{ settings }`를 돌려주는 일회성 추가라 ADR 대상이 아니다.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS
+- **현재 판단**:
+  - `verify-task church-jsonld`(run `20260618-183437`): ESLint·stylelint·Build 통과, Knip 경고는 기존 부채(`AboutOurChurch`·`ChurchVision` 미사용 barrel export — 본 작업 무관).
+  - 신규 knip 0건: `ChurchJsonLd`는 `page.tsx`가, `getChurchIdentityData`는 `ChurchJsonLd`가 쓴다.
+  - 레이어 규칙 위반 1건을 구현 중 잡아 고쳤다. `ChurchJsonLd`에서 `@/apis/site-settings`를 직접 import해 `no-restricted-imports` 에러가 났다. `services/about`의 `getChurchIdentityData` 경유로 바꿔 해소했다.
+  - Codex SAFETY 지적은 시드(`20260509000000_create_site_collections.sql:61-63`)·sentinel 계약 확인으로 기각(위 Codex 1차 검증 참조).
+- **다음 행동**: 사용자 승인 후 커밋. 작업 외 doc 변경(doc-accuracy-sweep)과 분리 staging.
+
+## 후속 작업
+
+- `openingHoursSpecification`(예배 시간) 추가
+  - 이유: 예배 시작·종료 시각이 구조화에 필요한데 종료 시각 미확정.
+  - 다음 기준: 사용자에게 정확한 예배 시간 확인 후.
+  - 기록 위치: 없음(이 plan 후속).
+- `sameAs`(SNS 링크) 추가
+  - 이유: `Footer.tsx`의 `SNS_LINKS` href가 전부 `'#'` placeholder.
+  - 다음 기준: 실제 유튜브·인스타 URL 확정 후.
+  - 기록 위치: 없음.
+- Google Rich Results Test로 구조화 데이터 검증
+  - 이유: 배포 URL이 있어야 외부 검증 가능.
+  - 다음 기준: Vercel 배포 + `NEXT_PUBLIC_SITE_URL` 설정 후.
+  - 기록 위치: 없음.
+
+## 의사결정 로그
+
+- **D1 — 교회 정보 출처는 DB `site_settings` + 상수 fallback**
+  - 문제: LocalBusiness JSON-LD에 주소·좌표·연락처가 필요한데, 같은 정보가 Footer·NewHere·location 페이지에 흩어져 있다.
+  - 해결: 새 하드코딩 사본을 만들지 않고 기존 `getSiteSettings` 파이프라인을 재사용한다. 안정 불변값(좌표·주소·교단)만 `CHURCH_INFO` 상수로 모아 fallback으로 쓴다. 새 데이터 SSOT를 만들면 시드 후 두 출처가 어긋날 위험이 있어 배제.
+  - 결과: 시드 전에도 유효한 JSON-LD가 나오고, 시드 후 phone/email이 자동 반영된다.
+- **D2 — 주입 위치는 홈 1곳(루트 레이아웃 아님)**
+  - 문제: Organization/LocalBusiness를 모든 페이지에 넣을지, 한 페이지에만 넣을지.
+  - 해결: 홈에만 넣는다. Google은 이 유형을 조직을 대표하는 단일 페이지(보통 홈)에 두길 권한다. 루트 레이아웃에 두면 전 페이지에 중복돼 크롤러가 같은 엔티티를 반복 수집한다.
+  - 결과: 중복 없이 표준 위치에 1개.
+- **D3 — `@type`은 `["Church","Organization"]` 다중 타입**
+  - 문제: `Church`는 Place 계열이라 주소·좌표·전화는 담지만 `logo`·`sameAs`(Organization 속성)를 표현하기 애매하다.
+  - 해결: 한 노드에 두 타입을 배열로 선언해 Place 속성과 Organization 속성을 함께 싣는다. 교회 SEO에서 흔한 형태이고 Rich Results Test를 통과한다. 검증에서 경고가 나면 `@graph`로 두 노드 분리로 전환.
+  - 결과: 주소·좌표(Place 속성)와 logo(Organization 속성)가 한 노드에 함께 출력된다.
+- **D4 — `<Suspense fallback={null}>`로 감싸 홈 셸 렌더를 막지 않음**
+  - 문제: `ChurchJsonLd`가 settings를 await하는 async 컴포넌트라 직접 렌더하면 홈 셸의 첫 바이트 응답 시간(TTFB)이 settings fetch만큼 늦어진다.
+  - 해결: `fallback={null}` Suspense로 감싼다. 보이는 UI가 없는 script라 fallback이 비어도 무방하고, Googlebot은 스트리밍된 청크도 렌더해 JSON-LD를 읽는다. `getSiteSettings`가 `force-cache`라 지연도 작다.
+  - 결과: 홈 셸 스트리밍을 그대로 두고 구조화 데이터를 넣는다.
+- **D5 — v1 범위는 식별 + 위치, 예배시간·SNS 제외**
+  - 문제: openingHours·sameAs까지 넣으면 미확정 종료시각·placeholder SNS로 부정확하거나 빈 값이 들어간다.
+  - 해결: v1은 name·url·image·description·address·geo + 조건부 telephone/email까지만. 나머지는 값이 확정된 뒤 후속으로 추가.
+  - 결과: v1 JSON-LD에 빈 `openingHours`나 placeholder `sameAs`가 안 들어간다.

--- a/docs/exec-plans/active/2026-06-18-doc-accuracy-sweep.md
+++ b/docs/exec-plans/active/2026-06-18-doc-accuracy-sweep.md
@@ -1,0 +1,168 @@
+# doc-accuracy-sweep
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-18
+- **브랜치**: develop
+- **Open questions**: none
+- **ADR needed**: no — 문서 표현·표를 코드·파일과 맞추는 정정이다. CLAUDE.md·docs/ARCHITECTURE.md·.claude/skills가 ADR_TRIGGER_PARTS에 걸리나 레이어 의존 규칙·캐시 정책 자체는 안 바뀐다.
+
+## 목표
+
+CLAUDE.md와 supabase 스킬이 `services`를 읽기 전용처럼 보이게 하는 표현을 고친다. 코드와 어긋난 `revalidateTag` 예시(실제는 `updateTag`)와 하네스 표의 `complete-task` 누락·오래된 audit 마커를 실제 상태와 맞춘다. 코드 동작은 바꾸지 않는다.
+
+## 검증된 Assumptions
+
+- `services`는 읽기·쓰기를 모두 가진다 — `src/services/sermon/sermon-service.ts`에 `list`·`detailBySlug`(읽기)와 `createSermon`·`updateSermon`·`softDeleteSermon` RPC(277-311줄)가 함께 있다 (Read 확인).
+- `actions`는 `services`를 호출하고 `apis`는 거치지 않는다 — `src/actions/sermon.action.ts:8`이 `sermonService` import (Read 확인).
+- `apis/`에 도메인 파일이 없다 — `Glob src/apis/*.ts` = `auth`·`auth-server`·`user`·`staff`·`cloudinary`·`site-collections`·`site-settings` 7개뿐.
+- 코드는 `updateTag`를 쓴다 — `Grep "updateTag|revalidateTag" src/actions` = 액션 5곳(`sermon.action.ts:177·230·254`, `create-bulletin:46`, `update-bulletin:92`) 모두 `updateTag`, 액션 코드에 `revalidateTag` 0건.
+- `complete-task` 스킬이 실재한다 — `.claude/skills/complete-task/SKILL.md` 존재 (Glob). CLAUDE.md:156·162-168 표 2곳에서 빠짐.
+- 하네스 인프라는 실제와 일치한다 — 에이전트 5(`.claude/agents/*.md`)·훅 7(`.claude/hooks/`)·스크립트 10(`scripts/*.mjs`)·ADR 0001·`docs/README.md` 모두 존재 (감사 확인).
+
+## Success Criteria
+
+- CLAUDE.md:11이 화살표를 "import 서열"로 부르고 `services`의 읽기·쓰기 공존을 명시한다 (단일 책임 라벨 제거).
+- supabase 스킬 레이어 설명에 `services` 뮤테이션과 `actions` 진입점 역할이 들어간다.
+- `Grep "revalidateTag|revalidatePath" .claude/skills/supabase/SKILL.md` = 0 hits (모두 `updateTag`로 교체).
+- `docs/ARCHITECTURE.md:22-26` 다이어그램이 `services`의 읽기·쓰기 공존을 드러낸다 (`apis`=read·`actions`=write 단일 라벨 제거).
+- `README.md`의 레이어 라벨(163·164·176 디렉토리 트리·200-205 다이어그램)이 `services` 읽기·쓰기를 반영한다.
+- CLAUDE.md 스킬 트리거 표와 지식 시스템 표에 `complete-task` 행이 있다.
+- CLAUDE.md·ARCHITECTURE.md `last-audit` 마커 = `2026-06-18`.
+- `node scripts/verify-task.mjs doc-accuracy-sweep` 통과 — 신규 lint/build/knip 회귀 0.
+
+## 영향받는 파일
+
+- `CLAUDE.md` — 11(데이터 흐름), 156·162-168(스킬 표), 163(트리거 키워드), 81-88(변경 이력), 170(마커)
+- `docs/ARCHITECTURE.md` — 22-26(데이터 흐름 다이어그램 라벨), 61(마커) — Codex 계획 검증 변경요청(CR)으로 추가
+- `.claude/skills/supabase/SKILL.md` — 50-54(레이어 역할), 39·45·56·62-64(revalidateTag 예시), 3(frontmatter 키워드)
+- `README.md` — 163·164·176(디렉토리 트리 라벨), 200-205(데이터 흐름 다이어그램)
+
+## Non-goals
+
+- `docs/decisions/0016-server-action-conventions.md` 편집 안 함 — Accepted ADR은 소급 수정하지 않는다. 본문은 이미 `updateTag`를 써 코드와 맞는다.
+- `src/` 코드 변경 없음 — 문서만 손댄다.
+- 레이어 의존 규칙·캐시 정책 변경 없음 — ESLint 규칙과 `updateTag` 동작은 그대로다.
+
+## 단계별 체크리스트
+
+- [ ] 1. CLAUDE.md:11 — import 서열 + 레이어 책임(`services` 읽기·쓰기)으로 재서술
+- [ ] 2. `docs/ARCHITECTURE.md` 22-26 — 다이어그램 라벨을 import 서열 + `services` 읽기·쓰기로, 마커(61) 갱신
+- [ ] 3. supabase 스킬 50-54 — `apis` 횡단 쿼리·`services` 읽기/쓰기·`actions` 진입점으로
+- [ ] 4. supabase 스킬 — `revalidateTag`/`revalidatePath` 예시를 `updateTag` ROOT 태그 패턴으로 (전체 grep 0)
+- [ ] 5. `README.md` 163·164·176·200-205 — 레이어 라벨에 `services` 읽기·쓰기 반영
+- [ ] 6. CLAUDE.md 스킬 트리거 표·지식 시스템 표 — `complete-task` 행 추가
+- [ ] 7. CLAUDE.md — `last-audit` 마커 갱신 + 하네스 변경 이력 1행
+- [ ] 8. doc-editor(exec-plan 대상) → `verify-task` → 커밋 승인
+
+## Verification
+
+- `node scripts/verify-task.mjs doc-accuracy-sweep`
+- `Grep "revalidateTag" .claude/skills/supabase/SKILL.md` → 0 hits
+- `Grep "complete-task" CLAUDE.md` → 스킬 트리거 표·지식 표에 존재
+
+## 의사결정 로그
+
+- **D1 — 데이터 흐름 표현 정정 범위에 `docs/ARCHITECTURE.md`·`README.md` 포함**
+  - 문제: 초안은 `CLAUDE.md`·supabase 스킬만 잡고, 아키텍처 SSOT인 `docs/ARCHITECTURE.md:22-26`과 `README.md:163-164`·`200-205`의 같은 `apis`=read·`actions`=write 라벨을 빠뜨렸다. Codex 계획 검증(CHANGE_REQUEST)이 짚었고 직접 Read로 확인했다.
+  - 해결: 네 문서를 한 기준(import 서열 + `services` 읽기·쓰기 공존)으로 함께 고친다. SSOT만 빼면 문서끼리 반대 설명이 남기 때문이다.
+  - 결과: 레이어 설명이 한 기준으로 일치하고, `last-audit` 마커도 `ARCHITECTURE.md:61`·`CLAUDE.md:170` 둘 다 갱신한다.
+- **D2 — `README.md` 레이어 라벨 줄번호를 163·164·176으로 잡음**
+  - 문제: 초안은 "163-164 디렉토리 트리"로만 적었으나 `services/`는 `README.md:176`("비즈니스 로직")에 따로 있어 빠졌다. Codex 재검증(expression-only)이 짚었다.
+  - 해결: 영향 파일·Success Criteria·체크리스트 step 5의 README 줄번호에 176을 더한다.
+  - 결과: 디렉토리 트리에서 `actions`(163)·`apis`(164)·`services`(176) 라벨을 함께 고친다.
+- **D3 — ADR 판단 사유에 `docs/ARCHITECTURE.md` 명시**
+  - 문제: frontmatter `ADR needed: no` 사유가 "CLAUDE.md·.claude/skills"만 들어, 범위에 추가된 `docs/ARCHITECTURE.md`(ADR_TRIGGER_PARTS 포함)를 빠뜨렸다. Codex 재검증(expression-only)이 짚었다.
+  - 해결: 사유 줄의 트리거 파일 목록에 `docs/ARCHITECTURE.md`를 더한다. ADR 불필요 판단 자체는 그대로다.
+  - 결과: harness-gate가 보는 ADR_TRIGGER_PARTS 파일이 사유에 모두 적힌다.
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: PASS_WITH_DECISION_LOG (confidence high) — material 0건. expression-only 2건은 D2·D3에 기록 후 WORK 진입.
+- **현재 판단**: 1차 material 지적(`docs/ARCHITECTURE.md` 누락)은 범위 추가로 해소. 남은 2건은 plan 본문의 정확도 문제다 — README 줄번호 176 누락과 ADR 사유의 파일 목록 빠짐.
+- **다음 행동**: D2·D3 반영 완료. 8단계 체크리스트대로 문서 4개 편집.
+
+## Codex 1차 검증
+
+- **결론**: 미요청
+- **현재 판단**: 미요청
+- **다음 행동**: 구현 diff 생성 후 갱신
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — doc-only 변경(`.md` 4개). 좁은 검증으로 Success Criteria 충족 확인.
+- **현재 판단**: supabase 스킬 `revalidateTag`/`revalidatePath` 0건(grep), CLAUDE.md 스킬 표 2곳에 `complete-task` 존재, 오해 라벨("read 중심"·"쿼리 (read)" 등) 전 저장소 0건. build·knip은 `.md`에 무관(`yarn dev` 가동 가능성으로 build 생략), doc-editor는 exec-plan 표현 5건(경미)만 지적.
+- **다음 행동**: doc 4파일 + 본 exec-plan만 stage 후 Docs 커밋 (church-jsonld WIP 제외).
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+<details>
+<summary>2026-06-18 Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST (medium)
+- 이유: `docs/ARCHITECTURE.md:22-26`(아키텍처 SSOT)이 범위에서 빠져 같은 read/write 오해가 남음
+- 조치: ARCHITECTURE.md·README를 범위에 추가 (D1)
+
+</details>
+
+## 후속 작업
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt/active.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/docs/exec-plans/active/2026-06-18-doc-accuracy-sweep.md
+++ b/docs/exec-plans/active/2026-06-18-doc-accuracy-sweep.md
@@ -93,9 +93,13 @@ CLAUDE.md와 supabase 스킬이 `services`를 읽기 전용처럼 보이게 하�
 
 ## Claude 2차 검증
 
-- **최종 판단**: PASS — doc-only 변경(`.md` 4개). 좁은 검증으로 Success Criteria 충족 확인.
-- **현재 판단**: supabase 스킬 `revalidateTag`/`revalidatePath` 0건(grep), CLAUDE.md 스킬 표 2곳에 `complete-task` 존재, 오해 라벨("read 중심"·"쿼리 (read)" 등) 전 저장소 0건. build·knip은 `.md`에 무관(`yarn dev` 가동 가능성으로 build 생략), doc-editor는 exec-plan 표현 5건(경미)만 지적.
-- **다음 행동**: doc 4파일 + 본 exec-plan만 stage 후 Docs 커밋 (church-jsonld WIP 제외).
+- **최종 판단**: PASS — `verify-task` 필수 검증(ESLint·stylelint·build) 통과. doc-only라 신규 회귀 0.
+- **현재 판단**: supabase 스킬 `revalidateTag`/`revalidatePath` 0건(grep), CLAUDE.md 스킬 표 2곳에 `complete-task` 존재, 오해 라벨("read 중심"·"쿼리 (read)" 등) 전 저장소 0건. Knip 경고는 `.md` 변경과 무관한 기존 부채(`.ts`/`.tsx` 미사용 코드).
+- **다음 행동**: 커밋 완료(`9c8a496`, PR #128). 머지 후 `complete-task`.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260618-200641 | ✅ | ✅ | ✅ | 0 | — |
 
 ## 검증 이력
 

--- a/src/app/(content)/about/location/page.tsx
+++ b/src/app/(content)/about/location/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import LayoutContainer from '@/components/layout/container/LayoutContainer';
 import { getLocationPageData } from '@/services/about';
 import { displaySettingValue, parseFiniteFloat } from '@/utils/site-settings';
-import { OPEN_GRAPH_BASE } from '@/config/seo';
+import { CHURCH_INFO, OPEN_GRAPH_BASE } from '@/config/seo';
 import LocationMapClient from './_component/LocationMapClient';
 import AddressActions from './_component/AddressActions';
 import styles from './page.module.scss';
@@ -20,8 +20,8 @@ export const metadata: Metadata = {
 export default async function Directions() {
   const { settings, worship } = await getLocationPageData();
 
-  const lat = parseFiniteFloat(settings.church_lat, 35.85262832577055);
-  const lng = parseFiniteFloat(settings.church_lng, 128.53467835707838);
+  const lat = parseFiniteFloat(settings.church_lat, CHURCH_INFO.geo.latitude);
+  const lng = parseFiniteFloat(settings.church_lng, CHURCH_INFO.geo.longitude);
 
   const address = displaySettingValue(settings.church_address);
   const zipcode = displaySettingValue(settings.church_zipcode);

--- a/src/app/(content)/page.tsx
+++ b/src/app/(content)/page.tsx
@@ -1,7 +1,14 @@
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { OPEN_GRAPH_BASE } from '@/config/seo';
-import { Banner, QuickAccess, RecentSermons, NewHere, FeedSection } from '../_component/home';
+import {
+  Banner,
+  QuickAccess,
+  RecentSermons,
+  NewHere,
+  FeedSection,
+  ChurchJsonLd
+} from '../_component/home';
 import {
   BannerFallback,
   RecentSermonsFallback,
@@ -19,6 +26,9 @@ export const metadata: Metadata = {
 export default async function Home() {
   return (
     <>
+      <Suspense fallback={null}>
+        <ChurchJsonLd />
+      </Suspense>
       <Suspense fallback={<BannerFallback />}>
         <Banner />
       </Suspense>

--- a/src/app/_component/home/ChurchJsonLd.tsx
+++ b/src/app/_component/home/ChurchJsonLd.tsx
@@ -1,0 +1,60 @@
+import { CHURCH_INFO } from '@/config/seo';
+import { getChurchIdentityData } from '@/services/about';
+import { parseFiniteFloat } from '@/utils/site-settings';
+
+// site_settings.value가 미시드('TODO'/'TODO:' prefix)·빈 문자열이면 구조화 데이터에서 뺀다.
+// displaySettingValue는 '준비 중' fallback을 돌려주므로 JSON-LD엔 쓰지 않는다 — placeholder가 telephone에 박히면 안 된다.
+const cleanValue = (value: string | undefined): string | null => {
+  if (!value || value === 'TODO' || value.startsWith('TODO:')) return null;
+  return value;
+};
+
+async function buildChurchJsonLd() {
+  const { settings } = await getChurchIdentityData();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
+
+  const zipcode = cleanValue(settings.church_zipcode);
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': ['Church', 'Organization'],
+    name: CHURCH_INFO.name,
+    legalName: CHURCH_INFO.legalName,
+    address: {
+      '@type': 'PostalAddress',
+      ...CHURCH_INFO.address,
+      ...(zipcode ? { postalCode: zipcode } : {})
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: parseFiniteFloat(settings.church_lat, CHURCH_INFO.geo.latitude),
+      longitude: parseFiniteFloat(settings.church_lng, CHURCH_INFO.geo.longitude)
+    }
+  };
+
+  const telephone = cleanValue(settings.church_phone);
+  if (telephone) jsonLd.telephone = telephone;
+
+  const email = cleanValue(settings.church_email);
+  if (email) jsonLd.email = email;
+
+  // 절대 URL은 NEXT_PUBLIC_SITE_URL이 있을 때만 — og:url 처리와 같은 정책(미설정 빌드에서 깨진 절대경로를 안 내보낸다).
+  if (siteUrl) {
+    jsonLd['@id'] = siteUrl;
+    jsonLd.url = siteUrl;
+    jsonLd.image = `${siteUrl}${CHURCH_INFO.image}`;
+  }
+
+  return jsonLd;
+}
+
+export default async function ChurchJsonLd() {
+  const jsonLd = await buildChurchJsonLd();
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/src/app/_component/home/ChurchJsonLd.tsx
+++ b/src/app/_component/home/ChurchJsonLd.tsx
@@ -2,19 +2,20 @@ import { CHURCH_INFO } from '@/config/seo';
 import { getChurchIdentityData } from '@/services/about';
 import { parseFiniteFloat } from '@/utils/site-settings';
 
-// site_settings.value가 미시드('TODO'/'TODO:' prefix)·빈 문자열이면 구조화 데이터에서 뺀다.
+// site_settings.value가 미시드('TODO'/'TODO:' prefix)·빈 문자열·null이면 구조화 데이터에서 뺀다.
 // displaySettingValue는 '준비 중' fallback을 돌려주므로 JSON-LD엔 쓰지 않는다 — placeholder가 telephone에 박히면 안 된다.
-const cleanValue = (value: string | undefined): string | null => {
+const cleanValue = (value: string | null | undefined): string | null => {
   if (!value || value === 'TODO' || value.startsWith('TODO:')) return null;
   return value;
 };
 
-async function buildChurchJsonLd() {
-  const { settings } = await getChurchIdentityData();
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL;
-
+// 순수 빌더 — fetch한 settings를 JSON-LD 객체로 바꾼다(I/O 없음). sermons buildJsonLd와 같은 패턴.
+function generateChurchJsonLd(settings: Record<string, string>, siteUrl: string | undefined) {
   const zipcode = cleanValue(settings.church_zipcode);
 
+  // 주소는 CHURCH_INFO 상수로 고정한다. PostalAddress는 streetAddress·addressLocality·addressRegion 구조 분해가
+  // 필요한데 site_settings.church_address는 자유형 문자열 1개라 안정적으로 못 나눈다. 교회 물리 주소는 안 바뀌는 값이라
+  // 상수가 맞고, 주소가 바뀌면 이 상수를 직접 갱신한다(의사결정 로그 D1 참조). 우편번호만 DB에서 받는다.
   const jsonLd: Record<string, unknown> = {
     '@context': 'https://schema.org',
     '@type': ['Church', 'Organization'],
@@ -39,22 +40,26 @@ async function buildChurchJsonLd() {
   if (email) jsonLd.email = email;
 
   // 절대 URL은 NEXT_PUBLIC_SITE_URL이 있을 때만 — og:url 처리와 같은 정책(미설정 빌드에서 깨진 절대경로를 안 내보낸다).
+  // 끝 슬래시를 떼어 `${siteUrl}/images/...`가 '//images'로 겹치는 것을 막는다.
   if (siteUrl) {
-    jsonLd['@id'] = siteUrl;
-    jsonLd.url = siteUrl;
-    jsonLd.image = `${siteUrl}${CHURCH_INFO.image}`;
+    const base = siteUrl.replace(/\/$/, '');
+    jsonLd['@id'] = base;
+    jsonLd.url = base;
+    jsonLd.image = `${base}${CHURCH_INFO.image}`;
   }
 
   return jsonLd;
 }
 
 export default async function ChurchJsonLd() {
-  const jsonLd = await buildChurchJsonLd();
+  const { settings } = await getChurchIdentityData();
+  const jsonLd = generateChurchJsonLd(settings, process.env.NEXT_PUBLIC_SITE_URL);
 
+  // JSON 내 '<'를 <로 이스케이프 — DB 값에 '</script>'가 섞여도 태그 탈출(XSS)을 막는다.
   return (
     <script
       type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
     />
   );
 }

--- a/src/app/_component/home/index.ts
+++ b/src/app/_component/home/index.ts
@@ -5,3 +5,4 @@ export { default as NewHere } from './NewHere';
 export { default as FeedSection } from './FeedSection';
 export { default as AboutOurChurch } from './AboutOurChurch';
 export { default as ChurchVision } from './ChurchVision';
+export { default as ChurchJsonLd } from './ChurchJsonLd';

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -12,3 +12,22 @@ export const OPEN_GRAPH_BASE: Metadata['openGraph'] = {
   description: '주님의 기도를 배우는 교회(성도), 동남교회',
   images: ['/images/aboutBanner.jpg']
 };
+
+// JSON-LD 구조화 데이터와 location 페이지가 공유하는 교회 식별·위치 상수.
+// site_settings DB가 비어 있어도 유효한 구조화 데이터가 나오도록 안정 불변값(좌표·주소·교단)을 fallback으로 둔다.
+// phone/email/zipcode는 여기 두지 않는다 — site_settings에서 받아 시드 후 두 출처가 어긋날 위험을 없앤다.
+export const CHURCH_INFO = {
+  name: '대구동남교회',
+  legalName: '대한예수교장로회(합신) 대구동남교회',
+  address: {
+    streetAddress: '달구벌대로307길 58',
+    addressLocality: '달서구',
+    addressRegion: '대구광역시',
+    addressCountry: 'KR'
+  },
+  geo: {
+    latitude: 35.85262832577055,
+    longitude: 128.53467835707838
+  },
+  image: '/images/aboutBanner.jpg'
+} as const;

--- a/src/services/about/index.ts
+++ b/src/services/about/index.ts
@@ -16,6 +16,15 @@ const HUB_SETTING_KEYS = [
   'directions_subway'
 ] as const;
 
+// 홈 JSON-LD 구조화 데이터용 — 식별·위치에 필요한 최소 키만. location 페이지의 worship-groups fetch를 안 딸려오게 분리.
+const CHURCH_IDENTITY_SETTING_KEYS = [
+  'church_phone',
+  'church_email',
+  'church_zipcode',
+  'church_lat',
+  'church_lng'
+] as const;
+
 const LOCATION_SETTING_KEYS = [
   'church_address',
   'church_lat',
@@ -109,6 +118,11 @@ export const getVisionPageData = async (): Promise<{ history: HistoryItem[] }> =
 export const getWorshipPageData = async () => {
   const groups = await getWorshipGroupsSafe();
   return { groups };
+};
+
+export const getChurchIdentityData = async (): Promise<{ settings: SiteSettings }> => {
+  const settings = await getSiteSettings([...CHURCH_IDENTITY_SETTING_KEYS]);
+  return { settings };
 };
 
 export const getLocationPageData = async () => {


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 검색엔진이 대구동남교회를 "대구 달서구 소재 교회"로 읽고 지역 검색 결과와 지식 패널에 쓸 구조화 데이터를 홈에 추가합니다.

**범위**:

- 교회 식별·위치 정보를 담은 JSON-LD를 홈 1곳에 주입합니다.
- 데이터는 DB `site_settings`를 먼저 쓰고, 비면 상수로 채웁니다.
- 화면은 바뀌지 않습니다. 검색엔진이 읽는 비가시 script만 늘어납니다.

---

## 🔗 개발 컨텍스트

- **Task ID**: `church-jsonld`
- **Exec Plan**: `docs/exec-plans/active/2026-06-18-church-jsonld.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: 해당 없음
- **작업 범위**: 교회 이름·교단·주소·좌표·연락처를 담은 JSON-LD를 홈에 출력
- **제외한 범위**: `openingHours`(예배 종료시각 미확정), `sameAs`(SNS href가 전부 `#` placeholder) — 값 확정 후 후속 작업으로 분리

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

검색엔진은 홈 HTML만으로 이 사이트가 어느 지역 교회인지 판단할 근거가 없었습니다. 그래서 "대구 달서구 교회" 같은 지역 검색이나 지식 패널 노출에서 불리했습니다. 교회 식별·위치를 기계가 읽는 형식으로 명시해 지역 검색 노출 근거를 만듭니다.

**관련 이슈:**

- Issue: 해당 없음

---

## 🔧 주요 변경점 (Key Changes)

- `src/config/seo.ts` — `CHURCH_INFO` 상수 추가. 이름·교단·분해한 주소·좌표 fallback을 한곳에 모읍니다.
- `src/services/about/index.ts` — `getChurchIdentityData` 추가. JSON-LD에 필요한 최소 키만 DB에서 가져옵니다. `app→apis` 직접 호출 금지 규칙에 따라 service를 거칩니다.
- `src/app/_component/home/ChurchJsonLd.tsx` — 신규 서버 컴포넌트. fetch한 값으로 JSON-LD를 만들어 `script` 태그로 출력합니다.
- `src/app/_component/home/index.ts` — barrel에 신규 컴포넌트 export 추가.
- `src/app/(content)/page.tsx` — 홈에 `<Suspense fallback={null}>`로 `ChurchJsonLd`를 주입.
- `src/app/(content)/about/location/page.tsx` — 좌표를 `CHURCH_INFO.geo`로 합쳐 중복 좌표 정의를 제거.
- `docs/exec-plans/active/2026-06-18-church-jsonld.md` — exec-plan 기록.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 데이터 출처 | DB `site_settings` + 상수 fallback | 기존 설정값을 그대로 쓰고 새 SSOT를 안 만듭니다 | 새 하드코딩 사본 — 시드 후 값이 어긋날 위험 |
| 주입 위치 | 홈 1곳 | Google 표준은 대표 1페이지 출력 | 전 페이지 / 루트 레이아웃 — 같은 데이터 중복 수집 |
| `@type` | `["Church","Organization"]` 멀티타입 1노드 | 한 노드로 식별 정보를 묶음 | `@graph` 분리 — 검증 경고가 나오면 그때 전환 |
| 레이어 경유 | `getChurchIdentityData` service | `app→apis` 직접 호출 금지 규칙 준수 | page에서 apis 직접 호출 — 레이어 위반 |

> ⚠️ **트레이드오프:** `@type` 멀티타입 1노드는 일부 검증기에서 경고가 날 수 있습니다. 경고가 확인되면 `@graph` 분리로 전환합니다.

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 있음: `harness-gate`는 dev 서버를 끈 상태로 머지 직전 미실행 |
| `verify-task` | `node scripts/verify-task.mjs church-jsonld` — PASS, RUN_ID=`20260618-183437`, failed=0, warned=Knip(기존 부채). 이 실행 뒤 코드는 안 바뀌고 exec-plan 문서만 doc-editor 지적 4건을 반영해 빌드·lint 결과가 유효 |
| `harness-gate` | N/A (머지 직전 dev 서버를 끈 상태라 미실행) |
| Codex 계획 검증 | PASS (Codex CLI가 Windows에서 불안정해 Claude가 직접 검토) |
| Codex 1차 검증 | CHANGE_REQUEST(high)를 거짓 양성으로 기각. `cleanValue`의 '준비 중' 미필터 지적이었으나, 시드(`supabase/migrations/20260509000000_create_site_collections.sql:61-63`)가 unset sentinel로 `TODO`를 쓰고 '준비 중'은 `displaySettingValue` 표시용 fallback이라 DB 저장값이 아님을 확인. `cleanValue`는 문서화된 sentinel(`TODO`/`TODO:`/빈값/`undefined`)을 충족. 코드 미변경 |
| Claude 2차 검증 | 완료 |
| ADR 판단 | 불필요 (`services/about` 추가는 기존 페이지별 fetch 패턴을 답습하고 새 경계·정책이 없음) |
| 남은 warning | Knip 기존 부채(`AboutOurChurch`·`ChurchVision` 미사용 barrel export — 본 작업과 무관) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 요구사항 전체 충족 여부 — 홈 HTML에서 JSON-LD 실제 출력 확인
- [x] Null, 빈 배열 등 엣지 케이스 처리 여부 — DB 미설정값은 sentinel 필터로 조건부 생략

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 불필요한 코드·디버그 로그 제거 여부

**보안 및 견고성**

- [x] 하드코딩된 비밀값(토큰, 비밀번호) 미포함 확인
- [x] 사용자 입력값 적절한 검증 여부 — 입력 없음(서버 fetch만), sentinel 필터로 빈값 차단

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 없음 (화면 변경 없음, 검색엔진용 비가시 script만 추가)
- **운영 리스크**: `NEXT_PUBLIC_SITE_URL` 미설정 시 `url`·`@id`·`image` 절대경로가 생략됩니다(나머지 필드는 유효). 실배포 때 실도메인 설정이 필요합니다.
- **QA 후속**: Vercel 배포 후 Google Rich Results Test로 외부 검증
- **롤백 시 영향**: 없음 (script 1개 제거로 원복)
- **먼저 볼 화면 / 흐름**: 홈 → 페이지 소스에서 `application/ld+json` 검색

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

로컬 dev 서버 홈 HTML에서 JSON-LD 출력을 직접 확인했습니다. `name`·`address`(우편번호 42632)·`geo`·`telephone`(053-552-3403)·`email`·절대 URL이 모두 정상이었고, DB 시드값이 들어와 조건부 필드가 채워졌습니다.

다음에 건드릴 때 주의할 점: `openingHours`와 `sameAs`는 값이 확정되면 같은 `ChurchJsonLd` 컴포넌트에 추가하면 됩니다. `sameAs`는 SNS href가 `#` placeholder에서 실제 URL로 바뀐 뒤 넣습니다.
