### PR TITLE
[Fix] 하위 페이지 공유 시 og:image 소실 복구

### DIFF
--- a/docs/exec-plans/active/2026-06-18-subpage-og-image.md
+++ b/docs/exec-plans/active/2026-06-18-subpage-og-image.md
@@ -82,6 +82,12 @@ sermons·news 하위 페이지가 SNS·검색 공유 시 미리보기 이미지(
   - 이미지 없는 상세의 `[OG_FALLBACK_IMAGE]` 분기는 build로 검증된 한 줄 상수 치환(표본에 이미지 없는 항목이 없어 런타임 미관측).
 - **다음 행동**: 사용자 승인 후 커밋.
 
+## PR 리뷰 대응 (#129)
+
+- **Gemini 지적**: 상세 3개(`sermons/[id]`·`sermons/series/[id]`·`news/bulletins/[id]`)에서 삼항 `x ? [{ url: x }] : [OG_FALLBACK_IMAGE]`를 `[{ url: x || OG_FALLBACK_IMAGE }]`로 바꾸면 배열 원소 타입이 항상 `{ url: string }`로 일관된다 (medium, 3건 동일).
+- **처리**: 3건 모두 수용. `getOgImageUrl`이 `string | null`을 반환하므로 `x || OG_FALLBACK_IMAGE`는 삼항과 결과 og:image URL이 같고, 배열이 항상 `[{ url: string }]`이라 혼합 타입(`{ url: string }[] | string[]`)이 사라진다. 프로젝트 `.gemini/styleguide.md §7`(삼항보다 `||` 선호)과도 맞는다.
+- **재검증**: `verify-task subpage-og-image`(run `20260619-143446`) ESLint·stylelint·Build 통과.
+
 ## 검증 이력
 
 <!--

--- a/docs/exec-plans/active/2026-06-18-subpage-og-image.md
+++ b/docs/exec-plans/active/2026-06-18-subpage-og-image.md
@@ -1,0 +1,144 @@
+# subpage-og-image
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-06-18
+- **브랜치**: feat/subpage-og-image
+- **Open questions**: none
+- **ADR needed**: no
+
+## 목표
+
+sermons·news 하위 페이지가 SNS·검색 공유 시 미리보기 이미지(og:image)를 항상 갖게 한다. 지금은 일부 페이지가 `openGraph`를 부분 선언해 root의 기본 배너를 잃거나, 콘텐츠 이미지가 없으면 `images: []`로 빈 미리보기가 된다.
+
+## 검증된 Assumptions
+
+- about/*·home은 이미 `...OPEN_GRAPH_BASE`를 펼쳐 정상 — `grep OPEN_GRAPH_BASE` 8파일 확인.
+- 정적 목록 4개(`sermons`·`sermons/all`·`sermons/series`·`news/bulletins`)는 `openGraph`에 title/description(/url)만 두고 base를 안 펼친다 — 각 파일 metadata Read 확인.
+- 동적 상세 3개(`sermons/[id]`·`sermons/series/[id]`·`news/bulletins/[id]`)는 콘텐츠 이미지를 쓰되 없으면 `images: []` fallback — 각 파일 `images:` 줄 Read 확인.
+- `OPEN_GRAPH_BASE.images = ['/images/aboutBanner.jpg']`, Next는 `metadataBase`로 절대화 — `src/config/seo.ts`·`layout.tsx` Read 확인.
+- Next.js openGraph는 shallow merge라 부분 선언 시 root images가 사라짐 — `page.tsx:11-13` 주석·tech-debt(PR #110) 확인.
+
+## Success Criteria
+
+- 정적 목록 4개의 SSR `<head>`에 `og:image`(기본 배너 절대 URL)가 출력된다.
+- 동적 상세 3개에서 콘텐츠 이미지가 없을 때 `og:image`가 빈 값이 아니라 기본 배너로 채워진다.
+- 콘텐츠 이미지가 있는 상세는 기존 콘텐츠 이미지를 그대로 쓴다(회귀 없음).
+- 기본 배너 경로가 한 상수(`OG_FALLBACK_IMAGE`)로 모이고, 목록은 `type/locale/siteName`도 base에서 받는다.
+- `yarn lint`·`yarn build` 통과, 신규 knip 0.
+
+## 영향받는 파일
+
+- `src/config/seo.ts` — `OG_FALLBACK_IMAGE` 상수 추가, `OPEN_GRAPH_BASE.images`가 그 상수를 쓰게(단일 출처).
+- `src/app/(content)/sermons/page.tsx`·`sermons/all/page.tsx`·`sermons/series/page.tsx`·`news/bulletins/page.tsx` — `openGraph`에 `...OPEN_GRAPH_BASE` 펼치고 title/description(/url) 유지.
+- `src/app/(content)/sermons/[id]/page.tsx`·`sermons/series/[id]/page.tsx`·`news/bulletins/[id]/page.tsx` — 이미지 없을 때 og/twitter `images` fallback을 `[]` → `[OG_FALLBACK_IMAGE]`.
+
+## 단계별 체크리스트
+
+- [x] 1. `seo.ts`에 `OG_FALLBACK_IMAGE` 상수 + `OPEN_GRAPH_BASE.images`·`CHURCH_INFO.image` 참조 전환.
+- [x] 2. 정적 목록 4개에 `...OPEN_GRAPH_BASE` 펼침(기존 title/description/url override 유지).
+- [x] 3. 동적 상세 3개의 og·twitter `images` fallback을 `OG_FALLBACK_IMAGE`로.
+- [x] 4. 검증 — `verify-task 20260618-211658`로 lint·build 통과. prod 런타임에서 목록 4개의 og:image가 배너 절대 URL로 출력됨을 확인.
+
+## Non-goals
+
+- about/*·home — 이미 정상이라 건드리지 않음.
+- 페이지별 전용 공유 이미지 제작 — 기본 배너로 통일. 전용 이미지는 후속.
+- `next-gen`·`community`·`news/gallery` stub — sitemap에서도 제외된 미구현이라 범위 밖.
+
+## Verification
+
+- `node scripts/verify-task.mjs subpage-og-image`
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: PASS (Claude 직접 — Codex CLI Windows 불안정 + 저위험 반복 변경)
+- **현재 판단**:
+  - 목록 4개는 about 페이지가 이미 쓰는 `...OPEN_GRAPH_BASE` + override 패턴을 그대로 따른다. 검증된 선례라 회귀 위험이 낮다.
+  - 상세 3개는 `type: 'article'`·url을 유지하려 base를 안 펼치고 `images` fallback만 바꾼다. 외과적.
+  - 상대경로 `OG_FALLBACK_IMAGE`가 절대 Cloudinary URL과 섞이지만 Next는 둘 다 `metadataBase`로 동일 처리한다. `NEXT_PUBLIC_SITE_URL` 미설정 시 og:image가 상대경로로 남는 건 기존 base 동작과 같다.
+  - ADR 트리거 파일 0건(`src/config/`·`src/app/`만). ADR 불요.
+- **다음 행동**: 사용자 승인 후 WORK. 구현 diff 후 1차 검증.
+
+## Codex 1차 검증
+
+- **결론**: PASS (Claude 직접 — Codex CLI Windows 불안정 + 저위험 반복 변경)
+- **현재 판단**:
+  - 목록 4개는 about 페이지가 쓰는 `...OPEN_GRAPH_BASE` + override 패턴을 그대로 따른다. prod 런타임에서 4개 모두 `og:image = .../images/aboutBanner.jpg`(절대 URL) 출력 확인.
+  - 상세 3개는 `images: x ? [...] : [OG_FALLBACK_IMAGE]` 한 줄 치환. 콘텐츠 이미지가 있으면 그대로(`/sermons/3`이 Cloudinary 썸네일 출력 — 회귀 없음), 없으면 배너로 채운다. `type: 'article'`·url은 그대로.
+  - 혼합 image 배열 타입(`{ url: string }[] | string[]`)은 build(tsc) 통과 — verify-task `20260618-211658`.
+  - `OG_FALLBACK_IMAGE` 한 상수를 `OPEN_GRAPH_BASE`·`CHURCH_INFO.image`·상세 fallback 세 곳이 모두 참조해 같은 배너를 가리킨다. knip 신규 0.
+- **다음 행동**: Claude 2차 기록 후 커밋.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS
+- **현재 판단**:
+  - `verify-task subpage-og-image`(run `20260618-211658`): ESLint·stylelint·Build 통과, Knip 경고는 기존 부채.
+  - prod 서버(빌드 산출물) 실측: 목록 `/sermons`·`/sermons/all`·`/sermons/series`·`/news/bulletins` 4개가 `og:image`로 배너 절대 URL을 출력. 상세 `/sermons/3`은 콘텐츠 썸네일 유지.
+  - 이미지 없는 상세의 `[OG_FALLBACK_IMAGE]` 분기는 build로 검증된 한 줄 상수 치환(표본에 이미지 없는 항목이 없어 런타임 미관측).
+- **다음 행동**: 사용자 승인 후 커밋.
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 후속 작업
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt/active.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/src/app/(content)/news/bulletins/[id]/page.tsx
+++ b/src/app/(content)/news/bulletins/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getOgImageUrl, getKakaoShareUrl } from '@/utils/cloudinary';
 import { generateFileDownloadList } from '@/utils/file';
 import { isNumeric } from '@/utils/validator';
 import { getAllBulletinIds, getBulletinById, getAdjacentBulletins } from '@/services/bulletin';
+import { OG_FALLBACK_IMAGE } from '@/config/seo';
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
@@ -25,7 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     openGraph: {
       title,
       description,
-      images: ogImage ? [{ url: ogImage }] : []
+      images: ogImage ? [{ url: ogImage }] : [OG_FALLBACK_IMAGE]
     }
   };
 }

--- a/src/app/(content)/news/bulletins/[id]/page.tsx
+++ b/src/app/(content)/news/bulletins/[id]/page.tsx
@@ -26,7 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<{ id: strin
     openGraph: {
       title,
       description,
-      images: ogImage ? [{ url: ogImage }] : [OG_FALLBACK_IMAGE]
+      images: [{ url: ogImage || OG_FALLBACK_IMAGE }]
     }
   };
 }

--- a/src/app/(content)/news/bulletins/page.tsx
+++ b/src/app/(content)/news/bulletins/page.tsx
@@ -5,6 +5,7 @@ import LatestBulletin from '@/app/(content)/news/bulletins/_component/LatestBull
 import BulletinTableSection from '@/app/(content)/news/bulletins/_component/BulletinTableSection';
 import { getBulletinSummary } from '@/services/bulletin';
 import { validateSearchParams, validate } from '@/utils/common';
+import { OPEN_GRAPH_BASE } from '@/config/seo';
 import styles from './page.module.scss';
 
 type Props = {
@@ -15,6 +16,7 @@ export const metadata: Metadata = {
   title: '주보',
   description: '이번 주 교회 주보에서 예배 일정과 소식을 살펴보세요.',
   openGraph: {
+    ...OPEN_GRAPH_BASE,
     title: '주보',
     description: '이번 주 교회 주보에서 예배 일정과 소식을 살펴보세요.'
   }

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/services/sermon';
 import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
 import { getOgImageUrl } from '@/utils/cloudinary';
+import { OG_FALLBACK_IMAGE } from '@/config/seo';
 import type { SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
 
@@ -35,14 +36,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       title,
       description,
       url: canonical,
-      images: ogImage ? [{ url: ogImage }] : [],
+      images: ogImage ? [{ url: ogImage }] : [OG_FALLBACK_IMAGE],
       type: 'article'
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: ogImage ? [ogImage] : []
+      images: ogImage ? [ogImage] : [OG_FALLBACK_IMAGE]
     }
   };
 }

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -36,14 +36,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       title,
       description,
       url: canonical,
-      images: ogImage ? [{ url: ogImage }] : [OG_FALLBACK_IMAGE],
+      images: [{ url: ogImage || OG_FALLBACK_IMAGE }],
       type: 'article'
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: ogImage ? [ogImage] : [OG_FALLBACK_IMAGE]
+      images: [ogImage || OG_FALLBACK_IMAGE]
     }
   };
 }

--- a/src/app/(content)/sermons/all/page.tsx
+++ b/src/app/(content)/sermons/all/page.tsx
@@ -21,6 +21,7 @@ import {
   resolveSeriesSlug
 } from '@/utils/sermon';
 import { getTotalPages } from '@/utils/pagination';
+import { OPEN_GRAPH_BASE } from '@/config/seo';
 import styles from '../_component/SermonListPage/SermonListPage.module.scss';
 
 const PAGE_DESCRIPTION = '대구동남교회의 모든 설교를 검색·필터로 찾아보세요';
@@ -31,10 +32,10 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: { canonical: PAGE_CANONICAL },
   openGraph: {
+    ...OPEN_GRAPH_BASE,
     title: '전체 설교',
     description: PAGE_DESCRIPTION,
-    url: PAGE_CANONICAL,
-    type: 'website'
+    url: PAGE_CANONICAL
   },
   twitter: { card: 'summary', title: '전체 설교', description: PAGE_DESCRIPTION }
 };

--- a/src/app/(content)/sermons/page.tsx
+++ b/src/app/(content)/sermons/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { LayoutContainer } from '@/components/layout';
+import { OPEN_GRAPH_BASE } from '@/config/seo';
 import { getAllSeries, getFeaturedSermon, getSermons } from '@/services/sermon';
 import SermonFeatured from './_component/SermonFeatured/SermonFeatured';
 import SermonRecentCarousel from './_component/SermonRecentCarousel/SermonRecentCarousel';
@@ -17,10 +18,10 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: { canonical: PAGE_CANONICAL },
   openGraph: {
+    ...OPEN_GRAPH_BASE,
     title: '설교',
     description: PAGE_DESCRIPTION,
-    url: PAGE_CANONICAL,
-    type: 'website'
+    url: PAGE_CANONICAL
   },
   twitter: { card: 'summary', title: '설교', description: PAGE_DESCRIPTION }
 };

--- a/src/app/(content)/sermons/series/[id]/page.tsx
+++ b/src/app/(content)/sermons/series/[id]/page.tsx
@@ -43,14 +43,14 @@ export async function generateMetadata({
       title,
       description,
       url: canonical,
-      images: image ? [{ url: image }] : [OG_FALLBACK_IMAGE],
+      images: [{ url: image || OG_FALLBACK_IMAGE }],
       type: 'website'
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: image ? [image] : [OG_FALLBACK_IMAGE]
+      images: [image || OG_FALLBACK_IMAGE]
     }
   };
 }

--- a/src/app/(content)/sermons/series/[id]/page.tsx
+++ b/src/app/(content)/sermons/series/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { LayoutContainer } from '@/components/layout';
 import { getSeriesDetail } from '@/services/sermon';
 import { getOgImageUrl } from '@/utils/cloudinary';
+import { OG_FALLBACK_IMAGE } from '@/config/seo';
 import SeriesDetailHero from '../../_component/SeriesDetailPage/SeriesDetailHero';
 import EpisodeGrid from '../../_component/SeriesDetailPage/EpisodeGrid';
 import styles from '../../_component/SeriesDetailPage/SeriesDetailPage.module.scss';
@@ -42,14 +43,14 @@ export async function generateMetadata({
       title,
       description,
       url: canonical,
-      images: image ? [{ url: image }] : [],
+      images: image ? [{ url: image }] : [OG_FALLBACK_IMAGE],
       type: 'website'
     },
     twitter: {
       card: 'summary_large_image',
       title,
       description,
-      images: image ? [image] : []
+      images: image ? [image] : [OG_FALLBACK_IMAGE]
     }
   };
 }

--- a/src/app/(content)/sermons/series/page.tsx
+++ b/src/app/(content)/sermons/series/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { LayoutContainer } from '@/components/layout';
 import { getAllSeries } from '@/services/sermon';
 import { filterSeries, parseSeriesParams } from '@/utils/sermon';
+import { OPEN_GRAPH_BASE } from '@/config/seo';
 import SeriesFilterSidebar from '../_component/SeriesListPage/SeriesFilterSidebar';
 import SeriesToolbar from '../_component/SeriesListPage/SeriesToolbar';
 import SeriesResultHeader from '../_component/SeriesListPage/SeriesResultHeader';
@@ -17,10 +18,10 @@ export const metadata: Metadata = {
   description: PAGE_DESCRIPTION,
   alternates: { canonical: PAGE_CANONICAL },
   openGraph: {
+    ...OPEN_GRAPH_BASE,
     title: '모든 시리즈',
     description: PAGE_DESCRIPTION,
-    url: PAGE_CANONICAL,
-    type: 'website'
+    url: PAGE_CANONICAL
   },
   twitter: { card: 'summary', title: '모든 시리즈', description: PAGE_DESCRIPTION }
 };

--- a/src/config/seo.ts
+++ b/src/config/seo.ts
@@ -1,5 +1,9 @@
 import type { Metadata } from 'next';
 
+// 공유 미리보기(og:image)·JSON-LD의 기본 이미지. 페이지·콘텐츠 전용 이미지가 없을 때 fallback으로 쓴다.
+// 한 곳에 모아 OPEN_GRAPH_BASE와 CHURCH_INFO가 같은 배너를 가리키게 한다(경로 드리프트 방지).
+export const OG_FALLBACK_IMAGE = '/images/aboutBanner.jpg';
+
 // root layout과 홈이 공유하는 OpenGraph 기본값.
 // 홈은 여기에 url만 더해 전체를 선언한다 — Next.js는 openGraph를 shallow merge하므로,
 // 부분만 선언하면 여기 없는 필드(og:image 등)가 사라진다.
@@ -10,7 +14,7 @@ export const OPEN_GRAPH_BASE: Metadata['openGraph'] = {
   locale: 'ko_KR',
   siteName: '대구동남교회',
   description: '주님의 기도를 배우는 교회(성도), 동남교회',
-  images: ['/images/aboutBanner.jpg']
+  images: [OG_FALLBACK_IMAGE]
 };
 
 // JSON-LD 구조화 데이터와 location 페이지가 공유하는 교회 식별·위치 상수.
@@ -29,5 +33,5 @@ export const CHURCH_INFO = {
     latitude: 35.85262832577055,
     longitude: 128.53467835707838
   },
-  image: '/images/aboutBanner.jpg'
+  image: OG_FALLBACK_IMAGE
 } as const;


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: sermons·news 하위 페이지를 외부 공유하거나 검색엔진이 읽을 때 빠지던 미리보기 이미지(og:image)를 복구한다.

**범위**:

- 정적 목록 4개에서 `openGraph`에 root 기본 배너(images)를 다시 펼쳐 채운다.
- 동적 상세 3개에서 콘텐츠 이미지가 없을 때 기본 배너로 fallback한다.
- 배너 경로를 `OG_FALLBACK_IMAGE` 상수 한 곳으로 모아 드리프트를 막는다.

---

## 🔗 개발 컨텍스트

- **Task ID**: `subpage-og-image`
- **Exec Plan**: `docs/exec-plans/active/2026-06-18-subpage-og-image.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: `docs/tech-debt/active.md` (PR #110 og:image 항목 — 이 PR로 해소)
- **작업 범위**: `src/config/seo.ts` + sermons·news 계열 페이지 7개의 `generateMetadata`/`metadata`
- **제외한 범위**: 페이지별 전용 공유 이미지 (후속 — 현재는 기본 배너로 통일)

---

## 🐛 버그 리포트 (Bug Report)

**재현 조건:**

- 환경: prod 빌드 산출물 (`yarn build` 후 서버 실행)
- 재현 절차:
  1. `/sermons`, `/sermons/all`, `/sermons/series`, `/news/bulletins` 중 한 페이지를 연다.
  2. 해당 URL을 curl 하거나 카카오톡·페이스북에 공유한다.
  3. 응답 HTML의 `og:image` 메타 태그를 확인한다.
- 기대 동작: root layout 기본 배너가 `og:image`로 노출된다.
- 실제 동작: `og:image` 태그가 아예 없어 미리보기 이미지가 빈 상태로 공유된다.

**근본 원인 (Root Cause):**

- Next.js Metadata는 `openGraph`를 shallow merge 한다 — 페이지가 `title`/`description`/`url`만 부분 선언하면 root의 누락 필드(`images` 등)는 채워지지 않고 사라진다. about/*·home은 이미 `...OPEN_GRAPH_BASE`를 펼쳐 이 문제를 피했으나 sermons·news 계열에는 적용되지 않았다.
- 동적 상세 3개는 콘텐츠 이미지(설교 썸네일·시리즈 커버·주보 첫장)가 없을 때 `images: []`로 빈 미리보기를 그대로 내보냈다.

**관련 이슈:**

- Issue: 해당 없음

---

## 🔧 수정 내용 (Fix Details)

- `src/config/seo.ts` — `OG_FALLBACK_IMAGE` 상수(`/images/aboutBanner.jpg`)를 신설하고, `OPEN_GRAPH_BASE.images`와 `CHURCH_INFO.image`가 이 상수를 참조하도록 바꿔 배너 경로를 한 곳에 모았다.
- 정적 목록 4개(`sermons`·`sermons/all`·`sermons/series`·`news/bulletins`) — `openGraph`에 `...OPEN_GRAPH_BASE`를 펼치고(about 페이지와 같은 패턴) 기존 `title`/`description`/`url` override는 유지했다. base가 제공하는 `type: 'website'` 중복은 제거했다.
- 동적 상세 3개(`sermons/[id]`·`sermons/series/[id]`·`news/bulletins/[id]`) — og·twitter `images` fallback을 `[]`에서 `[OG_FALLBACK_IMAGE]`로 바꿨다. 콘텐츠 이미지가 있으면 그대로 쓴다.

---

## ⚠️ 영향 범위 (Impact)

**변경된 동작:**

- 정적 목록 4개는 콘텐츠 이미지가 없어도 기본 배너를 `og:image`로 노출한다.
- 동적 상세 3개는 콘텐츠 이미지가 없을 때 빈 미리보기 대신 기본 배너로 fallback한다.

**영향받는 컴포넌트·모듈:**

- `src/config/seo.ts`
- sermons·news 계열 페이지 7개의 메타데이터 생성부

**사이드 이펙트 가능성:**

> 없음. 콘텐츠 이미지가 있는 경로(예: `/sermons/3`의 Cloudinary 썸네일)는 기존 이미지를 그대로 유지하므로 회귀가 없다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 목록 페이지 og:image 복구 방식 | `...OPEN_GRAPH_BASE` 펼침 | about/home에서 검증된 패턴과 일치, 한 줄로 root 기본값 상속 | `images`만 개별 재선언 — 같은 누락이 다른 필드에서 재발할 여지 |
| fallback 배너 경로 관리 | `OG_FALLBACK_IMAGE` 상수로 단일화 | 배너 경로가 여러 파일에 흩어져 드리프트 나는 것을 막음 | 각 페이지에 경로 문자열 직접 기입 — 변경 시 누락 위험 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 있음: harness-gate (머지 직전 dev 끈 상태에서 실행) |
| `verify-task` | `node scripts/verify-task.mjs subpage-og-image` — PASS, RUN_ID=`20260618-211658`, HEAD=`d037179`, failed=0, warned=Knip |
| `harness-gate` | N/A |
| Codex 계획 검증 | PASS (Claude 직접 — Codex Windows 불안정 + 저위험 반복 변경) |
| Codex 1차 검증 | PASS (Claude 직접) |
| Claude 2차 검증 | 완료 |
| ADR 판단 | 불필요 (`src/config/`·`src/app/`만 변경 — ADR 트리거 파일 없음) |
| 남은 warning | 기존 부채 (Knip) |

**수동 확인:**

| Before (버그 상태) | After (수정 후) |
| ------------------ | --------------- |
| `/sermons` 등 목록 4개의 응답에 `og:image` 메타 태그 없음 | 목록 4개 모두 `og:image = http://localhost:3000/images/aboutBanner.jpg` (배너 절대 URL) 출력 |
| 콘텐츠 이미지 없는 상세는 빈 미리보기 | `/sermons/3`은 Cloudinary 콘텐츠 썸네일 유지 (회귀 없음) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**버그 수정 완성도**

- [x] 근본 원인(Root Cause) 해결 여부 (증상만 억제한 것은 아닌지 확인)
- [x] 동일 패턴의 잠재적 버그 추가 점검 여부 — about/home은 이미 base 펼침 적용, sermons·news 계열 7개로 동일 패턴 마무리. openGraph 미선언 페이지는 root 기본값을 상속해 정상
- [x] 수정 범위가 버그와 무관한 코드를 포함하지 않는지 확인

**코드 품질**

- [x] 불필요한 코드·디버그 로그 제거 여부

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: sermons·news 하위 페이지를 공유하면 빈 미리보기 대신 교회 기본 배너가 보인다.
- **운영 리스크**: 없음. 콘텐츠 이미지가 있는 경로는 기존 이미지를 그대로 노출한다.
- **QA 후속**: 이미지 없는 상세 페이지의 fallback 분기는 build로만 검증됐다 (표본에 이미지 없는 항목이 없어 런타임 미관측) — 그런 항목이 생기면 실측 확인. 실서비스 공유 미리보기는 배포 + 실도메인 설정 후 Facebook·Kakao 디버거로 최종 확인.
- **롤백 시 영향**: 없음. og:image가 다시 빠지는 수정 전 상태로 되돌아갈 뿐 다른 동작에는 영향 없음.
- **먼저 볼 화면 / 흐름**: 빌드 후 `/sermons` 등 목록 4개를 curl 해 `og:image` 메타 태그 노출을 확인.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- Next.js Metadata의 `openGraph`는 shallow merge다. 새 페이지에서 `openGraph`를 선언할 때 `...OPEN_GRAPH_BASE`를 먼저 펼치지 않으면 root 기본 배너(images)가 통째로 사라진다 — 이번 버그의 핵심.
- 배너 경로는 `OG_FALLBACK_IMAGE` 한 곳에서 바꾼다. 페이지마다 직접 적지 말 것.
- og:image tech-debt(`active.md`, PR #110 항목)는 이 PR로 해소된다. 머지 후 `complete-task`에서 `resolved.md`로 이관 예정.
