### PR TITLE
[Style] 홈을 교회 소개 레퍼런스 톤으로 다시 맞추고 골드 accent 전역 통일·padding 토큰 표준화

### DIFF
--- a/.claude/skills/styles/SKILL.md
+++ b/.claude/skills/styles/SKILL.md
@@ -171,13 +171,16 @@ admin은 정보 밀도가 높은 cool 표면이라 콘텐츠 warm 톤과 다른 
 |---|---|---|---|
 | input, button | `$padding-control` | `$radius-xs` | |
 | 큰 CTA 버튼 | `$padding-control-wide` | `$radius-xs` | |
-| card, 패널 | `$padding-card` | `$radius-s` | `$shadow-sm` |
-| 소형 카드, 리스트 아이템 | `$padding-card-compact` | `$radius-s` | `$content-gap-s` |
+| 대형·피처 카드 (히어로 등) | `$padding-card-lg` | `$radius-l` | `$shadow-sm` |
+| 표준 카드·패널 | `$padding-card` | `$radius-s` | `$shadow-sm` |
+| 컴팩트 카드·타일·콜아웃·리스트 행 | `$padding-card-compact` | `$radius-s` | `$content-gap-s` |
 | 모달, 바텀시트 | `$padding-card` | `$radius-m` | `$overlay-scrim` |
 | 태그, 뱃지 | `$padding-inline-xs` | `$radius-circle` | |
 | 섹션 컨테이너 | `$container-padding` / `$section-gap-*` | — | `$container-max` |
 | 이미지 오버레이 | — | — | `$overlay-scrim`, `$txt-image-subtle` |
 | `:focus-visible` outline | `$focus-ring-width` / `$focus-ring-offset` | — | `$focus-ring-color` |
+
+**카드 padding은 대칭만 쓴다** — 대형 `$padding-card-lg`(20/24px), 표준 `$padding-card`(16/20px), 컴팩트 `$padding-card-compact`(12/16px). 모두 가로=세로다. 면 종류마다 토큰 하나로 고정한다. 컨트롤·배지는 가로형이라 예외다. 근거: ADR 0018.
 
 **Content Gap** (XL→XS): `$content-gap-xl`(32px) > `$content-gap-l`(24px) > `$content-gap-m`(16px) > `$content-gap-s`(12px) > `$content-gap-xs`(8px)
 

--- a/docs/decisions/0018-padding-token-standardization.md
+++ b/docs/decisions/0018-padding-token-standardization.md
@@ -1,0 +1,85 @@
+# 0018 — 카드·면 padding을 대칭 시맨틱 토큰 3단계로 고정
+
+- **Status**: Accepted
+- **Date**: 2026-06-27
+- **Deciders**: 프로젝트 오너
+- **Tags**: frontend, design-system, scss, tokens, spacing
+
+## Context
+
+홈을 모바일 앱 UI로 개편하면서 카드·면 padding이 작성자 감각대로 경우마다 제각각 쌓였다. 세 가지 결함이 있다.
+
+1. **같은 "카드"에 값이 제각각** — `$spacing-16`·`$spacing-20`·`$spacing-24`가 규칙 없이 섞였다. 어떤 카드가 어떤 값을 쓸지 근거가 없다.
+2. **시맨틱 토큰이 있는데 거의 안 쓴다** — `_semantic.scss`에 `$padding-card`·`$padding-card-compact`가 정의돼 있는데도 대부분 raw `$spacing-*`로 작성됐다. 게다가 `$padding-card`는 비대칭(`$spacing-16 $spacing-20`, 가로>세로)이라 카드마다 padding 방향마저 뒤섞였다(TodayVerse는 세로>가로).
+3. **토큰명 = 데스크톱 px 함정** — `$spacing-N`은 이름의 N이 데스크톱 px이고 모바일은 약 0.75N로 작아진다(`$spacing-16` = 모바일 12px / 데스크톱 16px). 작성자가 "이름=px"로 오인해 모바일 카드가 의도보다 답답해지는 혼란이 반복됐다.
+
+이를 미루면 신규 작업마다 padding 결정 비용이 들고, 페이지별 변종이 계속 늘어 시각 일관성이 무너진다. 실제로 개편 한 세션에서 padding 수정이 10여 회 발생했다.
+
+## Decision
+
+### 1. 카드 padding은 대칭만 쓴다 (가로 = 세로)
+비대칭 카드 padding을 금지한다. 방향(가로>세로 또는 세로>가로) 고민을 제거하고, 토큰 한 값으로 표현한다. 컨트롤·배지처럼 본질이 가로형인 면은 예외(기존 비대칭 유지).
+
+### 2. 면 종류 → 토큰 1:1 매핑
+면 종류마다 토큰을 하나로 고정한다. 카드는 3단계 스케일을 둔다.
+
+| 토큰 | 값 | 모바일 / 데스크톱 | 면 종류 |
+| --- | --- | --- | --- |
+| `$padding-card-lg` | `$spacing-24` | 20 / 24px | 대형·피처 카드 (히어로 등) |
+| `$padding-card` | `$spacing-20` | 16 / 20px | 표준 카드·패널 ★ 기본 |
+| `$padding-card-compact` | `$spacing-16` | 12 / 16px | 컴팩트 카드·카드 내부 타일·콜아웃·리스트 행 |
+| `$padding-control` | `$spacing-8 $spacing-12` | (유지) | 버튼·인풋 |
+| `$padding-control-wide` | `$spacing-12 $spacing-24` | (유지) | 큰 CTA 링크 |
+| `$padding-inline-xs` / `-sm` | (유지) | (유지) | 인라인 배지·칩 |
+
+고정 크기 그래픽 박스(원형/정사각 아이콘 박스)와 섹션 간 리듬(`$content-gap-*`·`$section-gap-*`)은 이 표준 대상이 아니다.
+
+### 3. 기존 시맨틱 토큰을 대칭으로 재정의한다
+- `$padding-card`: `$spacing-16 $spacing-20` → `$spacing-20`
+- `$padding-card-compact`: `$spacing-12 $spacing-16` → `$spacing-16`
+- `$padding-card-lg`: 신규(`$spacing-24`)
+
+두 재정의는 **가로는 그대로, 세로만 +2~4px** 늘어나는 방향이라 기존 소비처가 받는 영향이 작다. 토큰명을 유지해 소비처 코드를 건드리지 않고 값만 바꾼다.
+
+### 4. 점진 마이그레이션
+홈을 먼저 raw `$spacing-*` → 토큰으로 옮긴다(phase 1, 본 작업). 이후 sermons·about 등은 실제 손볼 때 페이지별로 raw → 토큰으로 옮긴다. 한 번에 전 페이지를 강제 치환하지 않는다.
+
+## Consequences
+
+### 긍정적
+- 면 종류만 정하면 padding 토큰이 자동으로 결정돼 작성·리뷰 비용이 줄어든다.
+- 카드 대칭 규칙으로 방향 고민이 사라진다.
+- 모바일에서도 표준 카드가 16px 이상을 확보해 답답함이 준다.
+- raw `$spacing-*` 카드 padding이 토큰으로 수렴해 페이지별 변종 누적을 막는다.
+
+### 부정적 / 트레이드오프
+- `$padding-card` 재정의가 홈 밖 소비처 sermons 4곳(`SermonSeriesSidebar`·`SermonListPage` 2곳·`SeriesListPage`)에도 세로 padding +4px로 적용된다. `$padding-card-compact`는 홈 밖 소비처가 없다. 위험은 작지만, sermons 4곳을 시각으로 확인해야 한다.
+- 오늘의 말씀(금색) 카드는 `$padding-card-lg`로 옮기며 데스크톱 세로 padding이 32→24px로 준다(옛 `respond-up` 커스텀 값을 거둠). 모바일은 가로가 +4px 늘어 방향이 반대다 — 시각 확인 대상.
+- 점진 마이그레이션이라 raw 값과 토큰이 한동안 섞여 있다.
+
+### 영향 범위
+- **코드**:
+  - `_semantic.scss` — 토큰 재정의 + `$padding-card-lg` 신규
+  - `app/_component/home/*.module.scss` — 홈 마이그레이션
+  - `$padding-card` 소비처 sermons 4곳(`SermonSeriesSidebar`·`SermonListPage`·`SeriesListPage`) — 값만 변경. `$padding-card-compact`는 홈 밖 소비처 없음
+- **운영**: 시각 회귀 확인은 홈 + sermons 4곳에 한정. 모바일/데스크톱.
+- **문서**: 본 ADR. `.claude/skills/styles/SKILL.md`의 Semantic Token 매핑 표에 카드 3단계·대칭 규칙 반영(후속).
+
+## Alternatives Considered
+
+### A안: 기존 비대칭 `$padding-card`(`$spacing-16 $spacing-20`) 유지, 매핑 규칙만 신설
+- 장점: 토큰값 무변경이라 소비처 영향 0.
+- 사유로 기각: 모바일 카드 세로 12px가 답답하다는 사용자 판단. 비대칭이라 방향 혼란도 그대로.
+
+### B안: 기존 토큰은 두고 새 대칭 토큰만 추가
+- 장점: 기존 소비처 무영향.
+- 사유로 기각: 비대칭·대칭 두 체계가 영구 공존해 일관성 목표에 미달. 어느 쪽을 쓸지 결정 비용이 오히려 늘어난다.
+
+### C안: 카드도 비대칭(가로>세로) 표준으로 통일
+- 장점: 텍스트 카드의 가로 여백 확보에 유리.
+- 사유로 기각: 사용자가 대칭을 명시 선택("`$padding-card`는 `$spacing-20`으로, 16/20 안 씀"). 방향 규칙이 하나뿐이라 대칭이 더 단순.
+
+## References
+
+- 관련 ADR: [0003 — design-system-v3 typography hierarchy](0003-design-system-v3-token-unification.md), [0014 — card component strategy](0014-card-component-strategy.md)
+- 관련 스킬: `.claude/skills/styles/SKILL.md` (Semantic Token 매핑)

--- a/src/app/(content)/layout.module.scss
+++ b/src/app/(content)/layout.module.scss
@@ -1,6 +1,10 @@
 // 모바일 고정 BottomNav에 콘텐츠 최하단이 가리지 않도록, 콘텐츠 셸이 그 높이만큼 바닥 여백을 둔다.
 // 클리어런스를 개별 컴포넌트(Footer 등)가 아니라 레이아웃이 책임진다 — 최하단 컴포넌트가 바뀌거나 추가돼도 안전하다.
 .content_shell {
+  // #root(flex column)의 in-flow 자식으로 높이를 채워, 내부 #main의 flex:1(스티키 푸터)을 유지한다
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   padding-bottom: calc(#{$tab-bar-height} + env(safe-area-inset-bottom, 0rem));
 
   // BottomNav가 사라지는 뷰포트(태블릿+)에서는 여백이 필요 없다

--- a/src/app/(content)/layout.module.scss
+++ b/src/app/(content)/layout.module.scss
@@ -1,0 +1,10 @@
+// 모바일 고정 BottomNav에 콘텐츠 최하단이 가리지 않도록, 콘텐츠 셸이 그 높이만큼 바닥 여백을 둔다.
+// 클리어런스를 개별 컴포넌트(Footer 등)가 아니라 레이아웃이 책임진다 — 최하단 컴포넌트가 바뀌거나 추가돼도 안전하다.
+.content_shell {
+  padding-bottom: calc(#{$tab-bar-height} + env(safe-area-inset-bottom, 0rem));
+
+  // BottomNav가 사라지는 뷰포트(태블릿+)에서는 여백이 필요 없다
+  @include respond-up($header-breakpoint) {
+    padding-bottom: 0;
+  }
+}

--- a/src/app/(content)/layout.tsx
+++ b/src/app/(content)/layout.tsx
@@ -4,6 +4,7 @@ import { Header, Hero, Footer, BottomNav } from '@/components/layout';
 import KakaoScript from '@/components/lib/KakaoScript';
 import { getWorshipScheduleGroups } from '@/services/worship';
 import { SCROLL_THRESHOLD } from '@/constants';
+import styles from './layout.module.scss';
 
 const API_KEY = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
 
@@ -21,12 +22,14 @@ export default async function ContentLayout({ children }: PropsWithChildren) {
           __html: `if(window.scrollY>${SCROLL_THRESHOLD})document.documentElement.setAttribute('data-scrolled','');`
         }}
       />
-      <Header />
-      <main id="main">
-        <Hero />
-        {children}
-      </main>
-      <Footer worshipLine={worshipLine} />
+      <div className={styles.content_shell}>
+        <Header />
+        <main id="main">
+          <Hero />
+          {children}
+        </main>
+        <Footer worshipLine={worshipLine} />
+      </div>
       <BottomNav />
       <Script
         id="scroll-reveal-observer"

--- a/src/app/(content)/page.module.scss
+++ b/src/app/(content)/page.module.scss
@@ -1,6 +1,6 @@
-// 홈 전용 웜 크림 배경 — 목업의 radial 크림 톤. 다른 (content) 페이지는 이 wrapper를 쓰지 않는다.
+// [실험] 홈 전용 크림·glow 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
 .home {
-  background: radial-gradient(110rem 70rem at 80% -10%, $home-bg-glow, transparent 60%), $home-bg;
+  background: $bg-primary;
 }
 
 // 시각적으로 숨긴 홈 단일 h1 — 문서 구조·SEO용 메인 제목(슬라이드 제목은 h2)

--- a/src/app/(content)/page.module.scss
+++ b/src/app/(content)/page.module.scss
@@ -1,6 +1,6 @@
-// [실험] 홈 전용 크림·glow 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
+// 홈 전용 웜 크림 배경 — 목업의 radial 크림 톤. 다른 (content) 페이지는 이 wrapper를 쓰지 않는다.
 .home {
-  background: $bg-primary;
+  background: radial-gradient(110rem 70rem at 80% -10%, $home-bg-glow, transparent 60%), $home-bg;
 }
 
 // 시각적으로 숨긴 홈 단일 h1 — 문서 구조·SEO용 메인 제목(슬라이드 제목은 h2)

--- a/src/app/(content)/page.module.scss
+++ b/src/app/(content)/page.module.scss
@@ -1,8 +1,6 @@
 // 홈 전용 웜 크림 배경 — 목업의 radial 크림 톤. 다른 (content) 페이지는 이 wrapper를 쓰지 않는다.
 .home {
-  background:
-    radial-gradient(110rem 70rem at 80% -10%, $home-bg-glow, transparent 60%),
-    $home-bg;
+  background: radial-gradient(110rem 70rem at 80% -10%, $home-bg-glow, transparent 60%), $home-bg;
 }
 
 // 시각적으로 숨긴 홈 단일 h1 — 문서 구조·SEO용 메인 제목(슬라이드 제목은 h2)

--- a/src/app/(content)/page.tsx
+++ b/src/app/(content)/page.tsx
@@ -8,7 +8,7 @@ import {
   RecentSermons,
   NewHere,
   PhotoGallery,
-  FeedSection,
+  // FeedSection, // 교회 소식 — 목업에 없어 임시 숨김
   LoginPrompt,
   ChurchJsonLd
 } from '../_component/home';
@@ -36,7 +36,7 @@ export default async function Home() {
       <NewHere />
       <PhotoGallery />
       <RecentSermons />
-      <FeedSection />
+      {/* <FeedSection /> 교회 소식 — 목업에 없어 임시 숨김 */}
       <LoginPrompt />
     </div>
   );

--- a/src/app/_component/home/FeedSection.module.scss
+++ b/src/app/_component/home/FeedSection.module.scss
@@ -1,3 +1,3 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -63,7 +63,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
 
 .eyebrow {
   font-size: $font-size-12;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-wider;
   color: $home-eyebrow;
 }
@@ -103,7 +103,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
   height: 4.6rem;
   border-radius: $radius-s;
   font-size: $font-size-14;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
 }
 
 .primary {

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -57,7 +57,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
 
 .content {
   position: relative;
-  padding: $spacing-24;
+  padding: $padding-card-lg;
   color: $home-cream-text;
 }
 

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -6,7 +6,7 @@ $slide-visit: linear-gradient(180deg, #3a4a2c 0%, #6e5a32 100%);
 $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15, 0.86) 100%);
 
 .section {
-  padding: $content-gap-l $container-padding 0;
+  padding: $spacing-8 $content-gap-l 0;
 }
 
 .viewport {

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -150,6 +150,6 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
   max-width: 64rem;
   margin: 0 auto;
   min-height: 30rem;
-  border-radius: $radius-l;
+  border-radius: $radius-xl;
   background: $home-surface;
 }

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -18,7 +18,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
 // Embla viewport — overflow hidden + 카드 외형(라운드·그림자). embla가 container transform을 제어.
 .embla {
   overflow: hidden;
-  border-radius: $radius-l;
+  border-radius: $radius-xl;
   box-shadow: $shadow-lg;
 }
 
@@ -100,7 +100,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: 4.6rem;
+  height: 4.4rem;
   border-radius: $radius-s;
   font-size: $font-size-14;
   font-weight: $font-weight-semibold;

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -31,7 +31,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
   position: relative;
   flex: 0 0 100%;
   min-width: 0;
-  min-height: 32rem;
+  min-height: 30rem;
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
@@ -74,7 +74,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
   font-size: $font-size-32;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-heading;
-  color: $home-cream-text;
+  color: $txt-inverse;
 }
 
 .subtitle {
@@ -149,7 +149,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
 .skeleton {
   max-width: 64rem;
   margin: 0 auto;
-  min-height: 32rem;
+  min-height: 30rem;
   border-radius: $radius-l;
   background: $home-surface;
 }

--- a/src/app/_component/home/HeroCarousel.module.scss
+++ b/src/app/_component/home/HeroCarousel.module.scss
@@ -90,7 +90,7 @@ $slide-scrim: linear-gradient(180deg, rgba(20, 30, 18, 0.05) 0%, rgba(16, 26, 15
 .ctas {
   display: flex;
   width: 100%;
-  gap: $spacing-8;
+  gap: $spacing-12;
   margin-top: $content-gap-m;
 }
 

--- a/src/app/_component/home/LoginPrompt.module.scss
+++ b/src/app/_component/home/LoginPrompt.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $content-gap-l 0 $section-gap-40;
+  padding: $spacing-20 0 $section-gap-40;
 }
 
 .card {
@@ -58,7 +58,7 @@
   background-color: $home-gold;
   color: $home-cream-text;
   font-size: $font-size-13;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   white-space: nowrap;
 
   @include hover-bg-shift($home-gold-hover);

--- a/src/app/_component/home/LoginPrompt.module.scss
+++ b/src/app/_component/home/LoginPrompt.module.scss
@@ -10,7 +10,7 @@
   margin: 0 auto;
   padding: $padding-card;
   border-radius: $radius-l;
-  background: linear-gradient(135deg, $home-card-soft, $home-tint);
+  background: $home-tint-card;
   border: 1px solid $home-border-gold;
 
   // 좁은 폰에서 텍스트가 버튼을 압박해 깨지는 것 방지 — 버튼을 아래 줄 전체폭으로 내린다

--- a/src/app/_component/home/LoginPrompt.module.scss
+++ b/src/app/_component/home/LoginPrompt.module.scss
@@ -9,7 +9,7 @@
   max-width: 64rem;
   margin: 0 auto;
   padding: $padding-card;
-  border-radius: $radius-m;
+  border-radius: $radius-l;
   background: linear-gradient(135deg, $home-card-soft, $home-tint);
   border: 1px solid $home-border-gold;
 }

--- a/src/app/_component/home/LoginPrompt.module.scss
+++ b/src/app/_component/home/LoginPrompt.module.scss
@@ -12,6 +12,11 @@
   border-radius: $radius-l;
   background: linear-gradient(135deg, $home-card-soft, $home-tint);
   border: 1px solid $home-border-gold;
+
+  // 좁은 폰에서 텍스트가 버튼을 압박해 깨지는 것 방지 — 버튼을 아래 줄 전체폭으로 내린다
+  @include respond($breakpoint-mobile) {
+    flex-wrap: wrap;
+  }
 }
 
 .icon_box {
@@ -62,4 +67,10 @@
   white-space: nowrap;
 
   @include hover-bg-shift($home-gold-hover);
+
+  // 좁은 폰에서 줄바꿈 시 버튼을 전체폭으로 — 텍스트 압박/깨짐 방지
+  @include respond($breakpoint-mobile) {
+    flex-basis: 100%;
+    text-align: center;
+  }
 }

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -5,15 +5,11 @@
 .card {
   max-width: 64rem;
   margin: 0 auto;
-  padding: $spacing-20;
+  padding: $padding-card-lg;
   border-radius: $radius-xl;
   background: $home-card;
   border: 1px solid $home-border;
   box-shadow: $shadow-sm;
-
-  @include respond-up($breakpoint-tablet) {
-    padding: $spacing-24;
-  }
 }
 
 .title {
@@ -41,7 +37,7 @@
   display: flex;
   flex-direction: column;
   gap: $spacing-4;
-  padding: $spacing-12 $spacing-16;
+  padding: $padding-card-compact;
   border-radius: $radius-s;
   background: $home-card-soft;
   border: 1px solid $home-border;
@@ -62,7 +58,7 @@
 
 .notice {
   margin-top: $content-gap-s;
-  padding: $spacing-12 $spacing-16;
+  padding: $padding-card-compact;
   border-radius: $radius-s;
   background: $home-tint;
   font-size: $font-size-13;

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -6,7 +6,7 @@
   max-width: 64rem;
   margin: 0 auto;
   padding: $spacing-20;
-  border-radius: $radius-l;
+  border-radius: $radius-xl;
   background: $home-card;
   border: 1px solid $home-border;
   box-shadow: $shadow-sm;

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }
 
 .card {
@@ -49,13 +49,13 @@
 
 .tile_label {
   font-size: $font-size-11;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   color: $home-text-muted;
 }
 
 .tile_value {
   font-size: $font-size-14;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-body;
   color: $home-text;
 }
@@ -70,6 +70,6 @@
   color: $home-gold-strong;
 
   strong {
-    font-weight: $font-weight-bold;
+    font-weight: $font-weight-semibold;
   }
 }

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -13,7 +13,7 @@
 }
 
 .title {
-  font-size: $font-size-18;
+  font-size: $font-size-16;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-body;
   color: $home-text;
@@ -44,13 +44,13 @@
 }
 
 .tile_label {
-  font-size: $font-size-11;
+  font-size: $font-size-12;
   font-weight: $font-weight-semibold;
   color: $home-gold-strong;
 }
 
 .tile_value {
-  font-size: $font-size-14;
+  font-size: $font-size-13;
   font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-body;
   color: $home-text;

--- a/src/app/_component/home/NewHere.module.scss
+++ b/src/app/_component/home/NewHere.module.scss
@@ -46,7 +46,7 @@
 .tile_label {
   font-size: $font-size-11;
   font-weight: $font-weight-semibold;
-  color: $home-text-muted;
+  color: $home-gold-strong;
 }
 
 .tile_value {

--- a/src/app/_component/home/PhotoGallery.module.scss
+++ b/src/app/_component/home/PhotoGallery.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $spacing-20 0 0;
+  padding: $spacing-24 0 0;
 }
 
 .scroller {

--- a/src/app/_component/home/PhotoGallery.module.scss
+++ b/src/app/_component/home/PhotoGallery.module.scss
@@ -23,7 +23,7 @@
   display: block;
   position: relative;
   width: 15.2rem;
-  border-radius: $radius-m;
+  border-radius: $radius-l;
   overflow: hidden;
   border: 1px solid $home-border;
   box-shadow: $shadow-sm;

--- a/src/app/_component/home/PhotoGallery.module.scss
+++ b/src/app/_component/home/PhotoGallery.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }
 
 .scroller {
@@ -56,7 +56,7 @@
   bottom: 0;
   padding: $spacing-20 $spacing-12 $spacing-10;
   font-size: $font-size-13;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   color: $home-cream-text;
   background: linear-gradient(transparent, rgba(0, 0, 0, 0.62));
 }

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -22,8 +22,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: $spacing-10;
-  padding: $spacing-16 $spacing-4;
+  gap: $spacing-8;
+  padding: $spacing-20 $spacing-4;
   text-align: center;
 
   @include hover-bg-shift($home-card-soft);

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -45,7 +45,7 @@
 }
 
 .label {
-  font-size: $font-size-13;
+  font-size: $font-size-11;
   font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-body;
   color: $home-text;

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -4,34 +4,30 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
+  grid-template-columns: repeat(2, 1fr);
+  gap: $spacing-10;
   max-width: 64rem;
   margin: 0 auto;
-  background: $home-card;
-  border: 1px solid $home-border;
-  border-radius: $radius-l;
-  overflow: hidden;
-  box-shadow: $shadow-sm;
-}
-
-.grid li:not(:first-child) .item {
-  border-left: 1px solid $home-border-divider;
 }
 
 .item {
   display: flex;
-  flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: $spacing-8;
-  padding: $spacing-20 $spacing-4;
-  text-align: center;
+  padding: $padding-card-compact;
+  background: $home-card;
+  border: 1px solid $home-border;
+  border-radius: $radius-m;
+  box-shadow: $shadow-sm;
 
-  @include hover-bg-shift($home-card-soft);
+  @include hover-lift;
 }
 
 .icon_box {
-  width: 4.6rem;
-  height: 4.6rem;
+  flex-shrink: 0;
+  width: 3.4rem;
+  height: 3.4rem;
   display: grid;
   place-items: center;
   border-radius: $radius-circle;
@@ -39,13 +35,13 @@
   color: $home-gold-strong;
 
   svg {
-    width: 2.2rem;
-    height: 2.2rem;
+    width: 1.8rem;
+    height: 1.8rem;
   }
 }
 
 .label {
-  font-size: $font-size-11;
+  font-size: $font-size-13;
   font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-body;
   color: $home-text;

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }
 
 .grid {

--- a/src/app/_component/home/QuickAccess.module.scss
+++ b/src/app/_component/home/QuickAccess.module.scss
@@ -9,7 +9,7 @@
   margin: 0 auto;
   background: $home-card;
   border: 1px solid $home-border;
-  border-radius: $radius-m;
+  border-radius: $radius-l;
   overflow: hidden;
   box-shadow: $shadow-sm;
 }

--- a/src/app/_component/home/RecentSermons.module.scss
+++ b/src/app/_component/home/RecentSermons.module.scss
@@ -1,3 +1,3 @@
 .section {
-  padding: $spacing-20 0 0;
+  padding: $spacing-24 0 0;
 }

--- a/src/app/_component/home/RecentSermons.module.scss
+++ b/src/app/_component/home/RecentSermons.module.scss
@@ -1,3 +1,3 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }

--- a/src/app/_component/home/SectionHeader.module.scss
+++ b/src/app/_component/home/SectionHeader.module.scss
@@ -8,6 +8,8 @@
 }
 
 .title {
+  // 아래 카드의 border-radius만큼 타이틀을 안쪽으로 — 카드 콘텐츠와 좌측 시각 정렬
+  padding-left: $spacing-4;
   font-size: $font-size-18;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-body;

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -2,7 +2,7 @@
   display: block;
   max-width: 64rem;
   margin: 0 auto;
-  border-radius: $radius-l;
+  border-radius: $radius-xl;
   overflow: hidden;
   background: $home-card;
   border: 1px solid $home-border;

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -61,7 +61,7 @@
 .info {
   display: flex;
   flex-direction: column;
-  padding: $spacing-16;
+  padding: $padding-card;
   background: $home-card;
 }
 

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -66,7 +66,7 @@
 }
 
 .eyebrow {
-  font-size: $font-size-12;
+  font-size: $font-size-11;
   font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-body;
   color: $home-gold-strong;
@@ -74,7 +74,7 @@
 
 .title {
   margin: $spacing-4 0;
-  font-size: $font-size-18;
+  font-size: $font-size-16;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-body;
   color: $home-text;

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -34,7 +34,7 @@
   padding: $spacing-4 $spacing-10;
   border-radius: $radius-circle;
   font-size: $font-size-11;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   color: $home-cream-text;
   background: rgba(0, 0, 0, 0.33);
 }
@@ -67,7 +67,7 @@
 
 .eyebrow {
   font-size: $font-size-12;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-body;
   color: $home-gold-strong;
 }

--- a/src/app/_component/home/SermonCard.module.scss
+++ b/src/app/_component/home/SermonCard.module.scss
@@ -61,7 +61,7 @@
 .info {
   display: flex;
   flex-direction: column;
-  padding: $padding-card;
+  padding: $padding-card-lg;
   background: $home-card;
 }
 

--- a/src/app/_component/home/TodayVerse.module.scss
+++ b/src/app/_component/home/TodayVerse.module.scss
@@ -6,7 +6,7 @@
   max-width: 64rem;
   margin: 0 auto;
   padding: $spacing-24 $spacing-20;
-  border-radius: $radius-m;
+  border-radius: $radius-l;
   background: linear-gradient(135deg, $home-gold, $home-gold-deep);
   box-shadow: 0 1rem 2.4rem rgba($home-gold-strong, 0.22);
   text-align: center;
@@ -32,6 +32,14 @@
   line-height: $line-height-loose;
   letter-spacing: $letter-spacing-body;
   color: $home-cream-text;
+
+  &::before {
+    content: '\201C';
+  }
+
+  &::after {
+    content: '\201D';
+  }
 }
 
 .reference {

--- a/src/app/_component/home/TodayVerse.module.scss
+++ b/src/app/_component/home/TodayVerse.module.scss
@@ -14,7 +14,7 @@
 
 .eyebrow {
   margin: 0 0 $spacing-12;
-  font-size: $font-size-12;
+  font-size: $font-size-11;
   font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-wider;
   color: $home-eyebrow;

--- a/src/app/_component/home/TodayVerse.module.scss
+++ b/src/app/_component/home/TodayVerse.module.scss
@@ -5,15 +5,11 @@
 .card {
   max-width: 64rem;
   margin: 0 auto;
-  padding: $spacing-24 $spacing-20;
+  padding: $padding-card-lg;
   border-radius: $radius-l;
   background: linear-gradient(135deg, $home-gold, $home-gold-deep);
   box-shadow: 0 1rem 2.4rem rgba($home-gold-strong, 0.22);
   text-align: center;
-
-  @include respond-up($breakpoint-tablet) {
-    padding: $spacing-32 $spacing-24;
-  }
 }
 
 .eyebrow {

--- a/src/app/_component/home/TodayVerse.module.scss
+++ b/src/app/_component/home/TodayVerse.module.scss
@@ -23,11 +23,11 @@
 .quote {
   margin: 0;
   font-family: $font-family-home-serif;
-  font-size: $font-size-18;
+  font-size: $font-size-16;
   font-weight: $font-weight-regular;
-  line-height: $line-height-loose;
+  line-height: $line-height-relaxed;
   letter-spacing: $letter-spacing-body;
-  color: $home-cream-text;
+  color: $txt-inverse;
 
   &::before {
     content: '\201C';

--- a/src/app/_component/home/TodayVerse.module.scss
+++ b/src/app/_component/home/TodayVerse.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }
 
 .card {
@@ -19,7 +19,7 @@
 .eyebrow {
   margin: 0 0 $spacing-12;
   font-size: $font-size-12;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-wider;
   color: $home-eyebrow;
 }
@@ -39,7 +39,7 @@
   margin-top: $spacing-12;
   font-size: $font-size-13;
   font-style: normal;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   letter-spacing: $letter-spacing-wide;
   color: $home-eyebrow-ref;
 }

--- a/src/app/_component/home/WeeklyBulletin.module.scss
+++ b/src/app/_component/home/WeeklyBulletin.module.scss
@@ -8,7 +8,7 @@
   gap: $content-gap-s;
   max-width: 64rem;
   margin: 0 auto;
-  padding: $padding-card-compact;
+  padding: $padding-card;
   border-radius: $radius-l;
   background: $home-tint-card;
   border: 1px solid $home-border-gold;

--- a/src/app/_component/home/WeeklyBulletin.module.scss
+++ b/src/app/_component/home/WeeklyBulletin.module.scss
@@ -56,7 +56,7 @@
 }
 
 .desc {
-  font-size: $font-size-13;
+  font-size: $font-size-12;
 
   @include ellipsis-multi(1);
 }

--- a/src/app/_component/home/WeeklyBulletin.module.scss
+++ b/src/app/_component/home/WeeklyBulletin.module.scss
@@ -1,5 +1,5 @@
 .section {
-  padding: $content-gap-l 0 0;
+  padding: $spacing-20 0 0;
 }
 
 .card {
@@ -31,14 +31,14 @@
 
 .day {
   font-size: $font-size-18;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   line-height: $line-height-reset;
 }
 
 .month {
   margin-top: $spacing-2;
   font-size: $font-size-11;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
 }
 
 .text {

--- a/src/app/_component/home/WeeklyBulletin.module.scss
+++ b/src/app/_component/home/WeeklyBulletin.module.scss
@@ -9,7 +9,7 @@
   max-width: 64rem;
   margin: 0 auto;
   padding: $padding-card-compact;
-  border-radius: $radius-m;
+  border-radius: $radius-l;
   background: $home-tint-card;
   border: 1px solid $home-border-gold;
 

--- a/src/app/_component/home/WeeklyBulletin.module.scss
+++ b/src/app/_component/home/WeeklyBulletin.module.scss
@@ -18,8 +18,8 @@
 
 .date {
   flex-shrink: 0;
-  width: 5rem;
-  height: 5rem;
+  width: 4.8rem;
+  height: 4.8rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -46,7 +46,6 @@
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: $spacing-2;
 }
 
 .title {
@@ -58,7 +57,6 @@
 
 .desc {
   font-size: $font-size-13;
-  color: $home-text-sub;
 
   @include ellipsis-multi(1);
 }

--- a/src/components/layout/BottomNav/BottomNav.module.scss
+++ b/src/components/layout/BottomNav/BottomNav.module.scss
@@ -24,7 +24,7 @@
 .tab_list {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
-  height: 5.8rem;
+  height: $tab-bar-height;
 }
 
 .tab_item {

--- a/src/components/layout/BottomNav/BottomNav.module.scss
+++ b/src/components/layout/BottomNav/BottomNav.module.scss
@@ -10,8 +10,7 @@
   left: 0;
   right: 0;
   z-index: $z-bottom-nav;
-  // 홈 크림 배경과 톤 일치 (목업: 바텀나비가 콘텐츠 크림에 녹아듦). 공용이라 콘텐츠 페이지에도 적용됨.
-  background-color: $home-bg;
+  // [실험] 크림 배경 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
   border-top: 0.1rem solid $border-warm;
   // iOS 홈 인디케이터 영역만큼 배경을 확장
   padding-bottom: env(safe-area-inset-bottom, 0);

--- a/src/components/layout/BottomNav/BottomNav.module.scss
+++ b/src/components/layout/BottomNav/BottomNav.module.scss
@@ -10,7 +10,8 @@
   left: 0;
   right: 0;
   z-index: $z-bottom-nav;
-  // [실험] 크림 배경 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
+  // 홈 크림 배경과 톤 일치 (목업: 바텀나비가 콘텐츠 크림에 녹아듦). 공용이라 콘텐츠 페이지에도 적용됨.
+  background-color: $home-bg;
   border-top: 0.1rem solid $border-warm;
   // iOS 홈 인디케이터 영역만큼 배경을 확장
   padding-bottom: env(safe-area-inset-bottom, 0);

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -3,12 +3,6 @@
 .footer {
   background-color: $home-bg;
   border-top: 0.1rem solid $border-warm;
-  // 모바일 고정 BottomNav(높이 + iOS 홈인디케이터 safe-area)에 가리지 않도록 그만큼 아래로 띄운다
-  padding-bottom: calc(#{$tab-bar-height} + env(safe-area-inset-bottom, 0rem));
-
-  @include respond-up($header-breakpoint) {
-    padding-bottom: 0;
-  }
 }
 
 .top {

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -3,8 +3,8 @@
 .footer {
   background-color: $home-bg;
   border-top: 0.1rem solid $border-warm;
-  // 모바일 고정 BottomNav에 가리지 않도록 그만큼 아래로 띄운다
-  padding-bottom: $tab-bar-height;
+  // 모바일 고정 BottomNav(높이 + iOS 홈인디케이터 safe-area)에 가리지 않도록 그만큼 아래로 띄운다
+  padding-bottom: calc(#{$tab-bar-height} + env(safe-area-inset-bottom, 0rem));
 
   @include respond-up($header-breakpoint) {
     padding-bottom: 0;
@@ -65,7 +65,7 @@
   padding-top: 0.2rem;
   font-size: $font-size-12;
   font-weight: $font-weight-bold;
-  color: $home-text-muted;
+  color: $home-gold-strong;
 }
 
 .value {

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -58,7 +58,7 @@
   margin: 0;
   padding-top: 0.2rem;
   font-size: $font-size-12;
-  font-weight: $font-weight-bold;
+  font-weight: $font-weight-semibold;
   color: $home-gold-strong;
 }
 

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -1,7 +1,7 @@
 // 교회 푸터 — claude.ai/design "교회 푸터" 목업 기반. 로고+교회명·예배안내·오시는곳·법적 링크.
 // 홈 크림 톤과 맞춰 공용 레이아웃에 적용한다(BottomNav·Header와 같은 스코프 — D9).
 .footer {
-  background-color: $home-bg;
+  // [실험] 크림 배경 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
   border-top: 0.1rem solid $border-warm;
   // 모바일 고정 BottomNav(높이 + iOS 홈인디케이터 safe-area)에 가리지 않도록 그만큼 아래로 띄운다
   padding-bottom: calc(#{$tab-bar-height} + env(safe-area-inset-bottom, 0rem));

--- a/src/components/layout/Footer/Footer.module.scss
+++ b/src/components/layout/Footer/Footer.module.scss
@@ -1,7 +1,7 @@
 // 교회 푸터 — claude.ai/design "교회 푸터" 목업 기반. 로고+교회명·예배안내·오시는곳·법적 링크.
 // 홈 크림 톤과 맞춰 공용 레이아웃에 적용한다(BottomNav·Header와 같은 스코프 — D9).
 .footer {
-  // [실험] 크림 배경 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
+  background-color: $home-bg;
   border-top: 0.1rem solid $border-warm;
   // 모바일 고정 BottomNav(높이 + iOS 홈인디케이터 safe-area)에 가리지 않도록 그만큼 아래로 띄운다
   padding-bottom: calc(#{$tab-bar-height} + env(safe-area-inset-bottom, 0rem));

--- a/src/components/layout/Header/Header.module.scss
+++ b/src/components/layout/Header/Header.module.scss
@@ -15,7 +15,8 @@ $indicator-height: 0.2rem;
   position: sticky;
   top: 0;
   z-index: $z-header;
-  // [실험] 크림 배경 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
+  // 홈 크림 배경과 톤 일치 (목업: 헤더가 콘텐츠 크림에 녹아듦). 공용이라 콘텐츠 페이지에도 적용됨.
+  background-color: $home-bg;
 
   @include respond-up($header-breakpoint) {
     display: none;

--- a/src/components/layout/Header/Header.module.scss
+++ b/src/components/layout/Header/Header.module.scss
@@ -15,8 +15,7 @@ $indicator-height: 0.2rem;
   position: sticky;
   top: 0;
   z-index: $z-header;
-  // 홈 크림 배경과 톤 일치 (목업: 헤더가 콘텐츠 크림에 녹아듦). 공용이라 콘텐츠 페이지에도 적용됨.
-  background-color: $home-bg;
+  // [실험] 크림 배경 제거 — body $bg-primary 단일 톤 미리보기 (평가 후 복원/교체)
 
   @include respond-up($header-breakpoint) {
     display: none;

--- a/src/styles/tokens/_color.scss
+++ b/src/styles/tokens/_color.scss
@@ -25,9 +25,10 @@ $navy-800: #2c3e50;
 $navy-600: #3d5166;
 
 // ── Gold (Accent) ──
+// 홈/목업 골드(#93702e)로 통일 — 전역 accent를 콘텐츠 골드 톤에 맞춤.
 
-$gold-600: #c4924a;
-$gold-400: #d9a96a;
+$gold-600: #93702e;
+$gold-400: #a8823a; // 한 단계 옅은 골드 (accent hover)
 $gold-100: #f5ead6;
 
 // ── Beige (Neutral Surface) ──
@@ -84,7 +85,7 @@ $bg-secondary: $beige-150; // 섹션·카드 정적 면 (decorative neutral) ★
 $bg-secondary-deep: $beige-300; // $bg-secondary보다 진한 따뜻한 면 — QuickAccess 배경·영상 그라데이션 끝
 $bg-beige-subtle: $beige-100; // 가장 옅은 beige 섹션 면 (secondary보다 옅음)
 $bg-hover: rgba($navy-800, 0.06); // 인터랙티브 hover 피드백 (cool, 면 종류 무관) — v4
-$bg-accent-subtle: rgba(196, 146, 74, 0.12); // CTA 섹션·환영 배너 (Gold 12% tint)
+$bg-accent-subtle: rgba(147, 112, 46, 0.12); // CTA 섹션·환영 배너 (Gold 12% tint)
 $bg-dark: #0f1820; // 다크 섹션 (페이지당 최대 1회)
 $bg-dark-card: #1a2535; // 다크 섹션 내 카드
 $bg-dark-nav: $navy-950; // 헤더·푸터·사이드바 전용

--- a/src/styles/tokens/_home.scss
+++ b/src/styles/tokens/_home.scss
@@ -1,6 +1,7 @@
 // ════════════════════════════════════════════
 // HOME (warm mockup tone) — 홈 + 공용 레이아웃 톤 토큰
 // claude.ai/design 디자인 레퍼런스 목업의 따뜻한 골드/크림 톤.
+// 배경은 "한빛교회 - 교회 소개" 레퍼런스 톤(#f4f0e6 + glow #fcf9f2)에 맞춤.
 // globals 시스템(cool navy + 노란기 적은 중성 beige)과 별개.
 // 사용처: 홈 콘텐츠 모듈 + 공용 레이아웃 BottomNav·Header(D9 — 콘텐츠 전반에 크림 톤 적용).
 // 그 외 콘텐츠 페이지 본문에서는 쓰지 않는다.
@@ -8,8 +9,8 @@
 // ════════════════════════════════════════════
 
 // ── Surface ──
-$home-bg: #efebe2; // 홈 페이지 배경 (웜 크림)
-$home-bg-glow: #e9e1d2; // 배경 radial 하이라이트
+$home-bg: #f4f0e6; // 홈 페이지 배경 (웜 크림 — 교회 소개 톤)
+$home-bg-glow: #fcf9f2; // 배경 radial 하이라이트 (교회 소개 톤)
 $home-surface: #f6f3ec; // 큰 면
 $home-card: #fff; // 카드
 $home-card-soft: #faf8f2; // 옅은 정보 타일

--- a/src/styles/tokens/_layout.scss
+++ b/src/styles/tokens/_layout.scss
@@ -22,7 +22,7 @@ $screensize-h-min: var(--screensize-h-min);
 $top-bar-height: 3.6rem;
 $header-height: 7.2rem;
 $app-header-height: 5.2rem;
-$tab-bar-height: 5.4rem;
+$tab-bar-height: 5.8rem; // BottomNav .tab_list 높이 SSOT — Footer 하단 패딩이 이 값 + safe-area를 참조
 $lnb-min-height: 25rem;
 
 // Header (tablet compact)

--- a/src/styles/tokens/_semantic.scss
+++ b/src/styles/tokens/_semantic.scss
@@ -14,11 +14,15 @@ $padding-control: $spacing-8 $spacing-12;
 /// 1.2rem 2.4rem — CTA 링크 버튼 (가로:세로 ≈ 4:3)
 $padding-control-wide: $spacing-12 $spacing-24;
 
-/// 1.6rem 2rem — 카드, 패널 내부 여백
-$padding-card: $spacing-16 $spacing-20;
+// 카드 padding은 대칭만 사용한다(가로=세로). 카드 종류 → 토큰 1:1 매핑.
+/// 20/24px(모바일/데스크톱, 대칭) — 대형·피처 카드 (히어로 등)
+$padding-card-lg: $spacing-24;
 
-/// 1.2rem 1.6rem — 작은 카드, 리스트 아이템 내부 여백
-$padding-card-compact: $spacing-12 $spacing-16;
+/// 16/20px(모바일/데스크톱, 대칭) — 표준 카드·패널 ★ 기본
+$padding-card: $spacing-20;
+
+/// 12/16px(모바일/데스크톱, 대칭) — 컴팩트 카드·카드 내부 타일·콜아웃·리스트 행
+$padding-card-compact: $spacing-16;
 
 // ══════════════════════════════════════════
 // SPACING: Content Gap — 요소 간 간격


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 홈(`/`) 폴리시 작업이 진행되며 기준 레퍼런스가 "한빛교회 - 홈"에서 "한빛교회 - 교회 소개" 톤으로 옮겨갔다. 이에 맞춰 홈의 배경·폰트·간격을 다시 맞추고, 그 과정에서 드러난 골드 불일치를 전역에서 통일하며, 레이아웃 클리어런스와 카드 padding을 토큰으로 정리한다.

**범위**:

- 홈 배경 톤·폰트 크기·카드 톤·섹션 간격을 "교회 소개" 레퍼런스에 맞춤
- 골드 accent를 콘텐츠 골드(`#93702e`)로 전역 통일 — 헤더·CTA가 쓰던 밝은 골드를 콘텐츠 톤에 맞춤 (admin 포함 전 페이지 accent 영향)
- QuickAccess를 2×2 개별 카드로 바꾸고, 교회 소식(FeedSection)을 임시 숨김, LoginPrompt·SermonCard 마감
- BottomNav 클리어런스를 레이아웃 셸로 옮기고, 카드·면 padding을 대칭 시맨틱 토큰 3단계로 표준화 (ADR 0018)

> 이 PR은 PR #132(홈 골드·명조 개편)의 후속 폴리시로 시작했으나, 이번 세션에서 10개 커밋이 더해져 범위가 넓어졌다. 본문은 그 넓어진 범위를 반영한다.

---

## 🔗 개발 컨텍스트

- **Task ID**: `home-mockup-spacing-weight` · `home-mockup-radius-quote` · `padding-token-standard` (초기 3개). 이후 톤 재정렬·골드 통일·레이아웃 정리 커밋은 같은 브랜치에서 이어 작업 — 별도 task-id 미기재
- **Exec Plan**: 없음 — PR #132의 후속 폴리시. 상위 계획은 `docs/exec-plans/completed/2026-06-25-home-gold-redesign.md`
- **관련 ADR**: `docs/decisions/0018-padding-token-standardization.md` (이 PR에서 신규 채택)
- **관련 tech debt**: 해당 없음
- **작업 범위**: 홈 컴포넌트 스타일, 공유 토큰(`_color.scss`·`_home.scss`·`_semantic.scss`·`_layout.scss`), `(content)` 레이아웃 셸, `styles` SKILL 매핑 표 — develop 대비 23개 파일, `+221 / −115`
- **제외한 범위**: 홈 밖 페이지의 시각을 따로 손대지는 않았다. 다만 골드 전역 변경은 admin·sermons 등 모든 페이지 accent에 닿는다 — 이 영향은 미확인 (아래 리뷰어 확인 포인트 참조)

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제 / 목적:**

PR #132에서 홈을 골드·명조 톤으로 개편했지만, 폴리시를 이어가며 기준 목업이 "교회 소개" 톤으로 옮겨갔다. 그 톤과 나란히 두니 배경이 약간 어둡고(`#efebe2`), 폰트가 한 단계 크며, 섹션 간격이 넓었다. 이를 레퍼런스에 맞춘다.

작업 중 헤더 로고·CTA가 쓰던 밝은 골드(`#c4924a`)와 홈 콘텐츠 골드(`#93702e`)가 한 화면에서 서로 달라 보이는 문제가 드러났다. 두 톤을 콘텐츠 골드로 합쳐 한 화면 안에서 골드가 하나로 읽히게 한다.

더해서 카드마다 raw `$spacing-*` 값을 직접 적어 같은 "카드 안쪽 여백"이 컴포넌트마다 달랐고, Footer가 하단 내비에 가리는 클리어런스를 컴포넌트마다 따로 줬다. 전자는 대칭 토큰으로, 후자는 레이아웃 셸 한 곳으로 모은다.

**관련 이슈:**

- Issue: 없음 (PR #132 후속)

---

## 🔧 주요 변경점 (Key Changes)

- 홈 배경을 `$home-bg` `#efebe2`→`#f4f0e6`, glow `#e9e1d2`→`#fcf9f2`로 올려 "교회 소개" 레퍼런스 톤에 맞춤 (`_home.scss`). `.home` radial glow는 유지
- 골드 accent를 전역에서 콘텐츠 골드로 통일 — `_color.scss`의 `$gold-600` `#c4924a`→`#93702e`, `$gold-400` `#d9a96a`→`#a8823a`, `$bg-accent-subtle` rgb도 같은 톤으로. 헤더·CTA가 쓰던 밝은 골드가 콘텐츠 골드에 맞춰진다 — 전 페이지 accent에 닿는 변경
- 폰트 크기를 "교회 소개" 목업 기준으로 한 단계 축소 — eyebrow 12→11, 카드 제목 18→16, desc 13→12, QuickAccess 라벨 등
- QuickAccess를 4열 한 줄에서 2×2 개별 카드(가로 배치, 아이콘 축소)로 변경 (`QuickAccess.module.scss`)
- 교회 소식(FeedSection)을 `page.tsx`에서 **주석 처리**로 임시 숨김 — 목업에 없어 가렸으나 정식 제거는 아님 (현재 dead code 상태)
- BottomNav 클리어런스를 개별 컴포넌트(Footer 등)가 아니라 `(content)` 레이아웃 셸이 책임지도록 이전 — `.content_shell`이 콘텐츠 전체에 `$tab-bar-height` + safe-area-inset 만큼 바닥 여백을 줘 최하단 컴포넌트가 바뀌어도 안 가린다. Footer 개별 padding-bottom은 제거
- 카드·면 padding을 대칭 시맨틱 토큰 3단계로 고정 — `$padding-card-lg`(20/24px) · `$padding-card`(16/20px, 기본) · `$padding-card-compact`(12/16px). 홈 카드를 raw `$spacing-*`에서 이 토큰으로 옮기고 `styles` SKILL 매핑 표 갱신 (ADR 0018). LoginPrompt 배경 `#f2e8cf`, SermonCard 여백 `$padding-card-lg`
- 섹션 간격·비제목 굵기·카드 radius·CTA 높이·말씀 인용부호를 목업 수치에 맞춤 (섹션 top `$spacing-20`, 비제목 700→600, radius 한 단계↑, CTA 4.6→4.4rem, 인용구 `\201C`/`\201D` 복원)
- SectionHeader `.title`에 `padding-left $spacing-4`를 줘 라운드 카드와 좌측 정렬 (`SectionHeader.module.scss`)

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 골드 톤 불일치 해소 방식 | `_color.scss`의 골드 토큰을 콘텐츠 골드(`#93702e`)로 전역 통일 | 헤더·CTA의 밝은 골드와 콘텐츠 골드가 한 화면에서 서로 달라 보였다. 토큰 한 곳을 바꾸면 모든 accent가 한 톤으로 읽힌다 | 홈만 로컬 오버라이드하면 헤더·CTA 불일치가 그대로 남고, 페이지마다 골드가 둘이 된다 |
| FeedSection 처리 | `page.tsx`에서 import·JSX를 주석 처리(임시 숨김) | 목업에 교회 소식이 없어 가렸으나, 콘텐츠가 채워지면 되살릴 가능성이 있다 | 정식 삭제하면 되살릴 때 다시 붙여야 한다. 단 지금은 dead code 상태라 머지 전 제거 여부를 정해야 한다 |
| BottomNav 클리어런스 위치 | 개별 컴포넌트가 아니라 `(content)` 레이아웃 셸이 바닥 여백을 책임 | 최하단 컴포넌트가 바뀌거나 추가돼도 가림이 안 생긴다. 클리어런스 규칙이 한 곳에 모인다 | 컴포넌트마다 padding-bottom을 주면 최하단이 바뀔 때마다 다시 손봐야 하고 빠뜨리기 쉽다 |
| 카드 안쪽 여백 정의 방식 | 대칭 시맨틱 토큰 3단계(lg·기본·compact)로 고정 | 같은 "카드 여백"이 컴포넌트마다 raw 값이라 달랐다. 가로는 동일, 세로만 +2~4px로 시각 균형을 맞춘다 | raw `$spacing-*` 유지하면 다음에 또 어긋난다. 비대칭 자유값을 허용하면 목업 대비 기준이 사라진다 |
| 비제목 글자 굵기 | 700에서 600(semibold)으로, 타이틀·헤딩·카드 제목만 700 | 목업은 본문급 텍스트를 semibold로 둬 위계가 분명하다 | 전부 700 유지하면 목업과 어긋나고 강조가 평평해진다 |

> padding 토큰 결정의 맥락·대안·영향 범위는 ADR 0018에 더 자세히 적었다.

---

## ✅ 하네스 검증 (Harness Verification)

> ⚠️ 아래 verify-task PASS는 `d7c6b9c`(초기 폴리시)까지만 측정한 값이다. 이후 10개 커밋(골드 전역 통일·배경/폰트 재정렬·QuickAccess 2×2·레이아웃 셸·FeedSection 숨김 등)은 아직 검증하지 않았다. 현재 HEAD `b1bde5b` 기준 재실행이 머지 전 필수다.

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` | 미실행 (현재 HEAD `b1bde5b` 기준) — `d7c6b9c`까지는 작업별 PASS였으나 이후 10개 커밋 미검증. dev 서버 가동 중이라 이번 세션 빌드 보류. 머지 전 재실행 필수 |
| `harness-gate` | 미실행 — 머지 전 필수 |
| Codex 계획 검증 | 해당 없음 (단일 관심사로 시작한 폴리시) |
| Codex 1차 검증 | 초기 padding 토큰 범위만 FIX_APPLIED (소비처를 sermons 4곳으로 정정). 넓어진 범위는 미검증 |
| Claude 2차 검증 | 초기 범위만 완료 (브라우저 재측정). 넓어진 범위는 미검증 |
| ADR 판단 | `docs/decisions/0018-padding-token-standardization.md` |
| 남은 warning | 기존 부채 (Knip) |

---

## 👀 PM / 리뷰어 확인 포인트

- **머지 전 반드시 확인 (1) — 골드 전역 변경**: `_color.scss` 골드 토큰을 바꿔 admin·sermons 등 **홈 밖 모든 페이지의 accent**에 닿는다. 이 화면들은 아직 눈으로 안 봤다 — 머지 전 다른 페이지에서 골드가 어색하지 않은지 확인 필요
- **머지 전 반드시 확인 (2) — FeedSection dead code**: 교회 소식을 주석 처리만 했다(정식 제거 아님). 되살릴지 삭제할지 결정하고, 삭제로 정하면 import·JSX·관련 컴포넌트를 함께 정리해야 함
- **머지 전 반드시 확인 (3) — 검증 미실행**: 넓어진 범위에 대해 `verify-task`·`harness-gate`를 아직 안 돌렸다(dev 서버 가동 중이라 이번 세션 빌드 보류). 머지 전 현재 HEAD 기준으로 둘 다 PASS 확인 필수
- **사용자에게 달라지는 점**: 홈 배경·폰트·간격·골드 톤이 "교회 소개" 레퍼런스에 가까워지고, QuickAccess가 2×2 카드가 되며 교회 소식 섹션이 가려진다. 헤더·CTA 골드가 콘텐츠 골드와 같은 톤이 된다. 좁은 폰 로그인 버튼·하단 Footer 가림이 해결된다
- **운영 리스크**: 없음 (스타일·토큰만, 배포 순서·환경변수 영향 없음)
- **롤백 시 영향**: 없음 (스타일 되돌림만, 데이터·동작 영향 없음)
- **먼저 볼 화면 / 흐름**: `/` (홈) 모바일 뷰포트 → 골드 확인용으로 admin·`/sermons` 한 번씩

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 골드 accent 톤은 이제 `_color.scss`의 `$gold-*` 토큰이 단일 출처다. 홈 골드(`#93702e`)와 전역 골드가 같은 값이니, 다시 갈라지지 않게 토큰만 바꾼다
- FeedSection은 `page.tsx`에 주석으로 남아 있다 — dead code 상태. 되살릴 때 주석만 풀면 되지만, 오래 가려둘 거면 정식 제거를 검토
- BottomNav 클리어런스는 `(content)/layout.module.scss`의 `.content_shell`이 책임진다. 홈 최하단 컴포넌트를 바꿔도 바닥 여백은 셸이 처리하니 개별 padding-bottom을 다시 주지 말 것
- 카드 여백은 raw `$spacing-*` 대신 `$padding-card*` 토큰을 쓴다 (매핑은 `styles` SKILL 표). 토큰 재정의가 sermons 4곳에도 닿으니 그 화면을 만질 때 기억할 것
