### PR TITLE
[Fix] 설교 상세를 방문해도 조회수가 0에 머무는 결함 수정

### DIFF
--- a/docs/exec-plans/active/2026-07-02-sermon-view-count-fix.md
+++ b/docs/exec-plans/active/2026-07-02-sermon-view-count-fix.md
@@ -120,6 +120,12 @@
 
 ## 검증 이력
 
+## PR 리뷰 대응
+
+| 지적 | 출처 | 대조 | 판정 | 조치 |
+| --- | --- | --- | --- | --- |
+| 실패 로그에 sermonId 컨텍스트 누락 | PR #137 Gemini 인라인 (id 3510728337, `sermon-views.action.ts:13`) | 코드 확인 — console.error 메시지에 sermonId 없음 | 타당 | 템플릿 리터럴로 sermonId 포함, 커밋 8e2d800, verify run 20260702-145247, 답글 r3510784851 |
+
 ## 후속 작업
 
 - P2 DB 위생 마이그레이션 (RLS initplan 래핑·중복 permissive 정책 분리·sermon RPC search_path·중복 인덱스·FK 인덱스)

--- a/docs/exec-plans/active/2026-07-02-sermon-view-count-fix.md
+++ b/docs/exec-plans/active/2026-07-02-sermon-view-count-fix.md
@@ -1,0 +1,128 @@
+# sermon-view-count-fix
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-07-02
+- **브랜치**: develop (작업 브랜치 분리 예정: fix/sermon-view-count)
+- **Open questions**: none
+- **ADR needed**: no — 기존 레이어 패턴(서비스 RPC 호출 + Server Action 진입점) 안의 결함 수정. 새 구조·라이브러리·정책 없음
+
+## 목표
+
+설교 상세 방문 시 조회수가 실제로 +1 되게 한다. 지금은 dev DB 설교 9건 전부 `view_count = 0`이다 — RPC 오버로드 모호성, ISR 렌더 내 호출, 에러 무시 세 겹이 원인이다.
+
+## 검증된 Assumptions
+
+- 실 DB에 `increment_sermon_views`가 uuid·bigint 2개 오버로드로 존재. bigint 버전은 SECURITY INVOKER(DEFINER 아님), search_path 미고정 — `pg_get_functiondef` 조회 (2026-07-02)
+- 생성 타입에 오버로드 모호성 에러 문자열 존재 — `src/types/database.types.ts:638-649` "Could not choose the best candidate function"
+- `sermons` UPDATE RLS는 `sermons_update_admin`뿐 → INVOKER 함수로는 익명·일반 사용자 방문 시 UPDATE가 0행 무음 — advisor 정책 목록
+- 호출부는 ISR 페이지 렌더 안 — `src/app/(content)/sermons/[id]/page.tsx:96` `incrementSermonViewCount(sermon.id).catch(() => {})`, 같은 파일 `:51` `revalidate = 86400`
+- 서비스도 에러 미확인 — `src/services/sermon/sermon-service.ts:270-274` (rpc 결과 버림), 진입점 `src/services/sermon/index.ts:54-57`은 `createServerSideClient()` 사용(렌더 중 `cookies()` 접근)
+- `view_count` 소비처는 admin 목록 정렬뿐 — `src/components/admin/sermons/SermonListPage/hooks/list-filter-params.ts:13`. 공개 상세에는 미표시 → 캐시 즉시 무효화 불필요
+- dev DB 설교 9건 전부 `view_count = 0` — SQL 조회 (2026-07-02)
+
+## Success Criteria
+
+- [x] DB에 `increment_sermon_views` 오버로드가 bigint 1개만 존재 (`pg_proc` SQL 조회로 판정 — args `sermon_id bigint`, prosecdef true)
+- [x] `yarn generate:types` 후 `database.types.ts`에 "Could not choose" 문자열 0건 (grep 0건, diff +4/−13)
+- [x] dev에서 `/sermons/[id]` 방문 1회 → 해당 행 `view_count` +1 (id 5: 0→1, id 3: 0→1 — StrictMode에서도 정확히 +1)
+- [x] 렌더 중 `cookies()` 호출 제거 확인 — build 마커는 D2 참조 (ƒ 표시는 회귀 아님, 대조군 동일)
+- [x] `node scripts/verify-task.mjs sermon-view-count-fix` 통과 (run 20260702-141605)
+
+## 접근법
+
+1. **마이그레이션 1건** (dev 우선): uuid 오버로드 DROP + bigint 버전을 SECURITY DEFINER + `SET search_path = public, pg_temp`로 재생성. 대상을 `is_published = true AND deleted_at IS NULL`로 한정해 비공개 설교 조회수 조작을 막는다.
+2. **조회수 증가 경로를 렌더 밖으로**: 클라이언트 tracker 컴포넌트(`SermonViewTracker`, useEffect 1회 실행)가 Server Action을 fire-and-forget 호출. ISR 페이지는 정적으로 남고, 방문마다 카운트된다.
+3. **에러를 숨기지 않기**: 서비스는 rpc error를 throw, 액션은 catch 후 서버 로그(`console.error`) — 방문자 UX에는 영향 없음.
+4. `page.tsx:96` 렌더 중 호출 제거 (+ 안 쓰게 된 import 정리).
+
+## 영향받는 파일
+
+- `supabase/migrations/<timestamp>_fix_increment_sermon_views.sql` (신규)
+- `src/types/database.types.ts` (yarn generate:types 재생성)
+- `src/services/sermon/sermon-service.ts` — `incrementViewCount` 에러 확인 추가
+- `src/actions/sermon-views.action.ts` (신규) — 공개 액션 (admin CRUD인 `sermon.action.ts`와 분리)
+- `src/app/(content)/sermons/_component/SermonDetailPage/SermonViewTracker.tsx` (신규, 'use client')
+- `src/app/(content)/sermons/[id]/page.tsx` — 렌더 중 호출 제거 + tracker 렌더
+
+## Non-goals
+
+- 다른 sermon RPC(create/update/delete_sermon, handle_new_user)의 search_path 고정 — P2(DB 위생 마이그레이션)에서 일괄
+- 세션/쿠키 기반 중복 방문 dedup, rate-limit — 새로고침·반복 호출 재집계는 수용. 조회수는 admin 정렬용 근사치라 부풀리기 유인이 낮고, 방지 인프라 도입 비용이 더 크다
+- route handler + sendBeacon 방식 — unload 시점 전송이 필요 없고 mount 시 +1로 충분해 의식적으로 제외
+- notices의 view_count 증가 경로 — 별개 도메인
+- 조회수 변경에 대한 updateTag — 공개 상세에 미표시, admin은 no-store라 불필요
+
+## 단계별 체크리스트
+
+- [x] 1. 마이그레이션 작성 + dev 적용 (MCP apply_migration) + 파일 커밋용 저장
+- [x] 2. `yarn generate:types` → 오버로드 에러 문자열 소멸 확인
+- [x] 3. 서비스 에러 확인 추가 (`sermon-service.ts:270`)
+- [x] 4. `sermon-views.action.ts` + `SermonViewTracker.tsx` 작성, `page.tsx` 호출 이전 — dev StrictMode에서 Effect가 2회 실행되므로 tracker에 `useRef` 초기화 guard 포함 (Codex 1차 지적으로 boolean → sermonId 비교 ref로 교체)
+- [x] 5. dev에서 방문 → SQL 전후 대조 — 값이 정확히 +1인지 확인 (StrictMode 이중 실행 영향 없음 판정)
+- [x] 6. verify-task + build output 확인 (마커 해석은 D2)
+
+## 의사결정 로그
+
+- **D1 — Codex 계획 검증에서 나온 표현 지적 4건을 계획에 반영**
+  - 문제: 계획 본문에 tracker의 StrictMode 이중 실행 대책과 공개 액션의 조회수 부풀리기 허용 근거가 안 적혀 있었다.
+  - 해결: 구현 판단을 바꾸는 지적이 아니라서 수정 요청(CR) 없이 계획 문구만 갱신했다 — 체크리스트 4·5에 `useRef` 중복 실행 방지와 +1 정밀 확인을 명시하고, Non-goals에 rate-limit 미도입 근거와 sendBeacon 기각 사유를 추가했다.
+  - 결과: 계획 갱신으로 종료, 구현 변경 없음.
+
+- **D2 — SC4의 "build output ISR 표시" 기대를 정정**
+  - 문제: `next build` 라우트 표에서 `/sermons/[id]`가 `ƒ (Dynamic)`으로 나와 SC 문구("ISR로 표시")와 안 맞았다.
+  - 해결: 대조군으로 판단했다 — 같은 설정(revalidate 86400 + generateStaticParams 없음)이고 `cookies()` 호출이 원래 없던 `/sermons/series/[id]`도 똑같이 `ƒ`다. generateStaticParams가 없는 동적 세그먼트는 빌드 시점 프리렌더가 없어서 `ƒ`로 표시될 뿐이고, 첫 요청 후 revalidate 86400으로 캐시된다. 이번 변경의 목적인 "렌더 경로에서 동적 API 제거"는 코드로 확인했다(`page.tsx`에서 `incrementSermonViewCount` 제거, 남은 조회는 전부 static client).
+  - 결과: SC4를 "렌더 중 cookies() 호출 제거"로 판정하고 충족 처리. 빌드 마커는 변경 전후 동일해 회귀 아님.
+
+## Verification
+
+- `node scripts/verify-task.mjs sermon-view-count-fix`
+- SQL: `select id, view_count from sermons where id = <방문한 id>` 전후 대조
+- `next build` output에서 `/sermons/[id]` 렌더링 모드 확인 (사용자 dev 서버 중지 상태에서만)
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: PASS_WITH_DECISION_LOG (confidence: high)
+- **현재 판단**: material 지적 0건 — 5체크를 전부 충족한다고 봤다. 표현만 지적한 4건(useRef 방지 문구·조회수 부풀리기 허용 근거·StrictMode 검증 문구·sendBeacon 기각 기록)은 D1로 반영했다.
+- **다음 행동**: WORK 진입. 재검증 요청 안 함 (3차 자동 호출 금지 규칙).
+
+## Codex 1차 검증
+
+- **결론**: FIX_APPLIED (지적 1건 반영 완료)
+- **현재 판단**: boolean guard가 상세 간 이동(prop 교체) 시 두 번째 설교의 조회수를 막는다 → `trackedSermonId: useRef<number | null>` 비교로 교체했다 (`SermonViewTracker.tsx:13-19`).
+- **다음 행동**: Claude 2차 검증 (verify-task — dev 서버 중지 후)
+
+### Codex 1차 검증 결과 (verbatim)
+
+> `hasTracked`가 boolean `useRef`라, 같은 컴포넌트 인스턴스에서 `sermonId` prop이 바뀌어도 액션이 두 번째부터 실행되지 않습니다. App Router에서 설교 상세 → 다른 설교 상세로 client-side 내비게이션이 일어나면 컴포넌트가 unmount 없이 prop만 바뀔 수 있고, 두 번째 설교의 조회수가 누락됩니다.
+
+풀이: 상세 간 이동은 컴포넌트를 unmount하지 않을 수 있어 boolean guard가 두 번째 집계를 막는다.
+
+이상 없다고 본 항목:
+- (a) primitive prop만 받는 클라이언트 컴포넌트라 ISR이 유지된다
+- (b) 익명 컨텍스트 RPC는 SECURITY DEFINER + 기존 EXECUTE 권한 보존으로 동작한다
+- (c) fragment 내 배치는 hydration 문제가 없다
+- 마이그레이션의 파라미터 이름·search_path·공개 조건이 계획과 일치한다
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — Codex 수정분(tracker ref 교체)까지 diff 재확인, 실측 +1 확인, verify-task 통과.
+- **현재 판단**: Codex가 고친 범위는 `SermonViewTracker.tsx`의 guard 로직뿐이고 의도(상세 간 이동 재집계)와 일치한다. knip 경고는 기존 부채이며 이번 신규 파일 관련 경고는 0건 (`knip.log` grep).
+- **다음 행동**: 사용자 승인 후 커밋
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260702-141605 | ✅ | ✅ | ✅ | 0 | 실측 +1 (id 5·3, StrictMode 이중 집계 없음) |
+| 2차 (문서 갱신 후 재검증, harness-gate 통과) | 20260702-143454 | ✅ | ✅ | ✅ | 0 | — |
+
+## 검증 이력
+
+## 후속 작업
+
+- P2 DB 위생 마이그레이션 (RLS initplan 래핑·중복 permissive 정책 분리·sermon RPC search_path·중복 인덱스·FK 인덱스)
+  - 이유: 이번 범위는 조회수 결함만 — 위생 항목을 섞으면 diff가 비대해진다
+  - 다음 기준: 본 task 머지 후 우선순위 합의대로
+  - 기록 위치: `docs/research/2026-07-02-refactor-audit.md` P2 항목

--- a/src/actions/sermon-views.action.ts
+++ b/src/actions/sermon-views.action.ts
@@ -1,0 +1,15 @@
+'use server';
+
+import { incrementSermonViewCount } from '@/services/sermon';
+
+// 공개 액션 — 조회수는 admin 정렬용 근사치라 인증·dedup 없이 받는다 (exec-plan Non-goals).
+export async function incrementSermonViewsAction(sermonId: number): Promise<void> {
+  if (!Number.isInteger(sermonId) || sermonId <= 0) return;
+
+  try {
+    await incrementSermonViewCount(sermonId);
+  } catch (error) {
+    // 방문자 UX에 영향 없는 실패지만 숨기지 않는다 — 서버 로그로 남긴다.
+    console.error('[sermon-views] 조회수 증가 실패', error);
+  }
+}

--- a/src/actions/sermon-views.action.ts
+++ b/src/actions/sermon-views.action.ts
@@ -10,6 +10,6 @@ export async function incrementSermonViewsAction(sermonId: number): Promise<void
     await incrementSermonViewCount(sermonId);
   } catch (error) {
     // 방문자 UX에 영향 없는 실패지만 숨기지 않는다 — 서버 로그로 남긴다.
-    console.error('[sermon-views] 조회수 증가 실패', error);
+    console.error(`[sermon-views] 조회수 증가 실패 (sermonId: ${sermonId})`, error);
   }
 }

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -1,16 +1,12 @@
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
-import {
-  getSermonById,
-  getSermons,
-  getSermonsBySeries,
-  incrementSermonViewCount
-} from '@/services/sermon';
+import { getSermonById, getSermons, getSermonsBySeries } from '@/services/sermon';
 import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
 import { getOgImageUrl } from '@/utils/cloudinary';
 import { OG_FALLBACK_IMAGE } from '@/config/seo';
 import type { SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
+import SermonViewTracker from '../_component/SermonDetailPage/SermonViewTracker';
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -93,12 +89,11 @@ export default async function SermonDetail({ params }: PageProps) {
 
   const otherSermonsByPreacher = otherByPreacher.length === 3 ? otherByPreacher : [];
 
-  incrementSermonViewCount(sermon.id).catch(() => {});
-
   const jsonLd = buildJsonLd(sermon);
 
   return (
     <>
+      <SermonViewTracker sermonId={sermon.id} />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonViewTracker.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonViewTracker.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { incrementSermonViewsAction } from '@/actions/sermon-views.action';
+
+type SermonViewTrackerProps = {
+  sermonId: number;
+};
+
+/** 마운트 시 조회수 +1. ISR 페이지 렌더 밖에서 방문마다 실행되도록 분리한 tracker. */
+export default function SermonViewTracker({ sermonId }: SermonViewTrackerProps) {
+  // dev StrictMode의 Effect 2회 실행은 막되, 상세 간 이동으로 sermonId가 바뀌면 다시 보낸다.
+  const trackedSermonId = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (trackedSermonId.current === sermonId) return;
+    trackedSermonId.current = sermonId;
+    incrementSermonViewsAction(sermonId);
+  }, [sermonId]);
+
+  return null;
+}

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -268,9 +268,10 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
 
   /** 설교 조회수 +1 (RPC `increment_sermon_views` 호출) */
   incrementViewCount: async (sermonId: number) => {
-    await supabase.rpc('increment_sermon_views', {
+    const { error } = await supabase.rpc('increment_sermon_views', {
       sermon_id: sermonId
     });
+    if (error) throw error;
   },
 
   /** [어드민] 설교 생성 — RPC create_sermon으로 sermon + resources 원자 INSERT */

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -635,19 +635,10 @@ export type Database = {
           prev_title: string
         }[]
       }
-      increment_sermon_views:
-        | {
-            Args: { sermon_id: number }
-            Returns: {
-              error: true
-            } & "Could not choose the best candidate function between: public.increment_sermon_views(sermon_id => int8), public.increment_sermon_views(sermon_id => uuid). Try renaming the parameters or the function itself in the database so function overloading can be resolved"
-          }
-        | {
-            Args: { sermon_id: string }
-            Returns: {
-              error: true
-            } & "Could not choose the best candidate function between: public.increment_sermon_views(sermon_id => int8), public.increment_sermon_views(sermon_id => uuid). Try renaming the parameters or the function itself in the database so function overloading can be resolved"
-          }
+      increment_sermon_views: {
+        Args: { sermon_id: number }
+        Returns: undefined
+      }
       update_bulletin: {
         Args: {
           p_bulletin_id: number

--- a/supabase/migrations/20260702000000_fix_increment_sermon_views.sql
+++ b/supabase/migrations/20260702000000_fix_increment_sermon_views.sql
@@ -1,0 +1,26 @@
+-- increment_sermon_views 결함 수정
+--
+-- 배경 (2026-07-02 refactor-audit D1):
+-- 1) 실 DB에 uuid·bigint 오버로드 2개가 공존 — uuid 버전은 과거 스키마(sermons.id uuid) 잔재.
+--    PostgREST가 호출을 모호성(PGRST203)으로 거부할 수 있고, 생성 타입에도
+--    "Could not choose the best candidate function" 에러가 박혀 있었다.
+-- 2) bigint 버전이 SECURITY INVOKER라 익명 방문자의 UPDATE가 RLS(sermons_update_admin 전용)에
+--    막혀 0행 무음 — dev 설교 9건 전부 view_count = 0.
+--
+-- 조치: uuid 오버로드 제거 + bigint 버전을 SECURITY DEFINER로 재생성.
+-- 대상을 공개(is_published)·미삭제 설교로 한정해 비공개 설교 조회수 조작을 막는다.
+
+drop function if exists public.increment_sermon_views(uuid);
+
+create or replace function public.increment_sermon_views(sermon_id bigint)
+returns void
+language sql
+security definer
+set search_path = public, pg_temp
+as $$
+  update sermons
+  set view_count = view_count + 1
+  where id = sermon_id
+    and is_published = true
+    and deleted_at is null;
+$$;


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 설교 상세를 방문해도 view_count가 0에 머무는 결함을 고쳐, 방문마다 조회수가 실제로 오르게 한다.

**범위**:

- RPC `increment_sermon_views`의 uuid·bigint 오버로드 모호성 제거, bigint 버전을 SECURITY DEFINER·search_path 고정으로 재생성
- 조회수 증가 경로를 ISR 페이지 렌더 밖(클라이언트 tracker + 공개 Server Action)으로 이동
- 서비스가 rpc 실패를 삼키지 않고 throw하도록 정정

---

## 🔗 개발 컨텍스트

- **Task ID**: `sermon-view-count-fix`
- **Exec Plan**: `docs/exec-plans/active/2026-07-02-sermon-view-count-fix.md`
- **관련 ADR**: 해당 없음 — 기존 레이어 패턴 안의 결함 수정, 새 구조·라이브러리·정책 없음
- **관련 tech debt**: 2026-07-02 리팩토링 감사 P2 항목 (DB 위생 마이그레이션, 본 PR 범위 밖 — 로컬 research 문서)
- **작업 범위**: 조회수 집계 경로(DB RPC · 서비스 · 액션 · 클라이언트 tracker · 상세 page)
- **제외한 범위**: 다른 sermon RPC의 search_path 고정, 중복 방문 dedup·rate-limit, 조회수 updateTag

---

## 🐛 버그 리포트 (Bug Report)

**재현 조건:**

- 환경: dev(mficogrxekuahjqborxw), Next.js App Router
- 재현 절차:
  1. `/sermons/[id]` 상세를 방문한다
  2. `select id, view_count from sermons where id = <방문한 id>`로 값을 확인한다
  3. 여러 번 방문 후 다시 조회한다
- 기대 동작: 방문할 때마다 해당 설교의 view_count가 1씩 오른다
- 실제 동작: 값이 계속 0이다 — dev 설교 9건 전부 view_count 0

**근본 원인 (Root Cause):** 증상은 하나였지만 원인이 세 겹으로 겹쳐 있었다.

1. **RPC 오버로드 모호성** — 실 DB에 `increment_sermon_views`가 uuid·bigint 두 버전으로 존재했다. uuid 버전은 `sermons.id`가 uuid이던 과거 스키마의 잔재다. PostgREST가 두 후보 중 하나를 못 골라 호출을 PGRST203으로 거부했고, `yarn generate:types` 산출물(`database.types.ts`)에도 "Could not choose the best candidate function" 에러 문자열이 그대로 생성됐다.
2. **RLS에 막힌 무음 UPDATE** — bigint 버전이 SECURITY INVOKER였다. `sermons` UPDATE 정책은 `sermons_update_admin` 하나뿐이라, 익명·일반 방문자 컨텍스트에서는 UPDATE가 0행으로 조용히 끝났다.
3. **호출 위치와 에러 은폐** — 호출이 ISR(`revalidate = 86400`) 페이지 렌더 안(`page.tsx`)에 있어 정적 렌더 이후 방문마다 실행되지 않았고, `createServerSideClient()`가 렌더 중 `cookies()`에 접근했다. 게다가 `.catch(() => {})`와 서비스의 rpc 결과 미확인으로 실패가 겉으로 드러나지 않았다.

**관련 이슈:**

- Issue: N/A (2026-07-02 refactor-audit D1에서 발견)

---

## 🔧 수정 내용 (Fix Details)

증상→원인을 확인한 뒤, 세 겹을 각각 닫았다.

- **DB** — `supabase/migrations/20260702000000_fix_increment_sermon_views.sql` 신규: uuid 오버로드를 DROP하고, bigint 버전을 `security definer` · `set search_path = public, pg_temp`로 재생성했다. 대상 행을 `is_published = true and deleted_at is null`로 한정해 비공개·삭제 설교의 조회수 조작을 막았다.
- **타입·서비스** — `yarn generate:types`로 오버로드 에러 문자열을 제거하고(`database.types.ts` +4/−13), `sermon-service.ts`의 `incrementViewCount`가 rpc error를 확인 후 `throw`하도록 고쳤다.
- **렌더 밖 집계 경로** — 공개 Server Action `src/actions/sermon-views.action.ts`(admin CRUD인 `sermon.action.ts`와 분리)와 클라이언트 `SermonViewTracker.tsx`를 신설했다. tracker는 `useEffect`에서 마운트마다 액션을 fire-and-forget 호출하고, `trackedSermonId` ref로 상세 간 이동 시엔 다시 보내되 dev StrictMode의 Effect 2회 실행은 막는다.
- **호출부 정리** — `page.tsx`에서 렌더 중 `incrementSermonViewCount(...)` 호출과 안 쓰게 된 import를 제거하고, 대신 `<SermonViewTracker sermonId={sermon.id} />`를 렌더한다.

---

## ⚠️ 영향 범위 (Impact)

**변경된 동작:**

- 설교 상세를 방문하면 view_count가 1씩 오른다 (id 5: 0→1, id 3: 0→1 실측).

**영향받는 컴포넌트·모듈:**

- DB 함수 `increment_sermon_views`, `sermon-service.ts`, 신규 `sermon-views.action.ts`·`SermonViewTracker.tsx`, `sermons/[id]/page.tsx`

**사이드 이펙트 가능성:**

> 낮음. 공개 상세에는 조회수를 표시하지 않아 방문자 화면은 그대로다. view_count 소비처는 admin 목록 정렬뿐이라 정렬 결과만 정확해진다. RPC 시그니처는 bigint를 유지하고 기존 EXECUTE 권한을 보존해 호출 규약 변화가 없다. 새로고침·반복 방문에 따른 재집계는 수용 범위(조회수는 admin 정렬용 근사치)다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 조회수 증가 실행 위치 | 클라이언트 tracker + 공개 Server Action | ISR 페이지를 정적으로 유지하면서 방문마다 집계 | 렌더 중 호출 유지 — 방문마다 실행 안 되고 렌더 중 `cookies()` 접근 |
| RPC 권한 모델 | SECURITY DEFINER + 공개·미삭제 한정 | 익명 방문자도 RLS에 막히지 않고, 비공개 설교 조작은 차단 | SECURITY INVOKER 유지 — 익명 UPDATE가 0행 무음 |
| 중복 방문 방지 | 미도입 | 조회수는 정렬용 근사치라 부풀리기 유인이 낮고, dedup 인프라 비용이 더 큼 | 세션·쿠키 dedup, rate-limit, sendBeacon — 필요 대비 과함 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs sermon-view-count-fix` — PASS, RUN_ID=`20260702-143454`, failed=0, warned=Knip |
| `harness-gate` | PASS (`node scripts/harness-gate.mjs sermon-view-count-fix`, 2026-07-02) |
| Codex 계획 검증 | PASS_WITH_DECISION_LOG (표현 지적 4건은 exec-plan D1로 반영, 구현 변경 없음) |
| Codex 1차 검증 | FIX_APPLIED — boolean guard가 상세 간 이동 시 둘째 설교 집계를 막던 문제를 `sermonId` 비교 ref로 교체 |
| Claude 2차 검증 | PASS — 수정분 diff 재확인, 실측 +1, verify-task 통과 |
| ADR 판단 | 불필요 |
| 남은 warning | 기존 부채(Knip). 이번 신규 파일 관련 경고 0건 |

**수동 확인:**

| Before (버그 상태) | After (수정 후) |
| ------------------ | --------------- |
| dev 설교 9건 전부 view_count = 0 | id 5·3 방문 시 0→1, StrictMode에서도 정확히 +1 |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**버그 수정 완성도**

- [x] 근본 원인(Root Cause) 해결 여부 — 오버로드·RLS·호출위치·에러은폐 세 겹을 각각 닫음
- [x] 동일 패턴의 잠재적 버그 추가 점검 여부 — 다른 sermon RPC search_path는 P2로 분리 기록
- [x] 수정 범위가 버그와 무관한 코드를 포함하지 않는지 확인

**코드 품질**

- [x] 불필요한 코드·디버그 로그 제거 여부 — page.tsx 렌더 중 호출과 죽은 import 제거

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 방문자 화면은 그대로. admin 설교 목록의 조회수 정렬이 실제 방문을 반영한다.
- **운영 리스크**: 낮음. 실패 시 서버 로그(`[sermon-views] 조회수 증가 실패`)만 남고 방문 UX엔 영향 없음.
- **QA 후속**: prod 적용 시 동일 마이그레이션 필요(dev 우선 적용 완료). 실기기에서 상세→다른 상세 이동 시 둘째 설교도 +1 되는지 확인.
- **롤백 시 영향**: 코드 롤백만으론 DB 함수가 남는다. 롤백 시 마이그레이션도 함께 되돌릴지 판단 필요.
- **먼저 볼 화면 / 흐름**: `/sermons/[id]` 방문 → admin 설교 목록 조회수 정렬.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 조회수가 0에서 안 오르면 먼저 `increment_sermon_views` 오버로드 개수(`pg_proc`)와 SECURITY 속성, 그리고 호출이 렌더 안에 있는지부터 본다.
- StrictMode 이중 집계는 boolean ref로는 상세 간 이동을 막으니 `sermonId` 비교 ref를 쓴다(Codex 1차 지적).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
