### PR TITLE
[Chore] Supabase advisor 경고 4종을 마이그레이션 1건으로 정리

### DIFF
--- a/docs/exec-plans/active/2026-07-02-db-hygiene-migration.md
+++ b/docs/exec-plans/active/2026-07-02-db-hygiene-migration.md
@@ -1,0 +1,107 @@
+# db-hygiene-migration
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-07-02
+- **브랜치**: develop (작업 브랜치 분리 예정: chore/db-hygiene-migration)
+- **Open questions**: none
+- **ADR needed**: no — Supabase advisor 경고를 걷어내는 위생 마이그레이션 1건. 스키마 구조·데이터 흐름·인증 정책의 의미를 바꾸지 않는다(정책 식은 값을 그대로 두는 변환만). 상세 `## ADR 판단`
+
+## 목표
+
+Supabase advisor(dev) 경고 중 안전하고 값이 분명한 4가지를 마이그레이션 1건으로 정리한다: RLS(행 수준 보안) 정책 14건에서 `auth.uid()`를 감싸지 않은 것, SECURITY DEFINER 함수 search_path 미고정, 중복 인덱스, FK(외래키) 인덱스 부재.
+
+## 검증된 Assumptions (실 DB = SSOT, 마이그레이션 drift 있음)
+
+- **auth_rls_initplan 14정책** — `pg_policies` 직접 조회. admin 체크 식이 테이블마다 다름: bulletins·bulletin_images는 `role='admin' AND status='approved'`, sermons·sermon_resources·site_*·staff·worship는 `role='admin'`만, profiles_select_own은 `auth.uid() = id`. 각각 정확히 보존하고 `auth.uid()`만 래핑
+- **search_path 미고정 SECURITY DEFINER 5개** — `pg_proc.proconfig` 조회: `create_sermon`·`update_sermon`·`delete_sermon`·`get_adjacent_bulletins`·`handle_new_user`. (`increment_sermon_views`는 P1에서 고침, bulletin RPC 3종·`rls_auto_enable`은 이미 고정)
+- **함수 본문이 전부 public qualified 참조** — `pg_get_functiondef` 조회: `public.profiles`·`public.bulletins` 명시, 나머지는 public enum/table. `SET search_path = public, pg_temp`가 본문 재작성 없이 안전
+- **트리거 함수 2개** `handle_updated_at`·`set_updated_at`도 advisor `function_search_path_mutable` 대상 — SECURITY INVOKER, `NEW.updated_at = now()`만 실행. now()는 pg_catalog(암묵) 참조라 search_path 추가가 안전
+- **중복 인덱스** — `pg_indexes`: `idx_sermons_date`·`idx_sermons_date_desc` 둘 다 `(sermon_date DESC)` 동일. `idx_sermons_date_desc`를 남긴다(마이그레이션 `001`이 만드는 이름)
+- **FK 인덱스 부재 2개** — `sermon_resources.sermon_id`(마이그레이션엔 `idx_sermon_resources_sermon` 있으나 실 DB에 없음 — drift), `site_collections.updated_by`
+- **소비처 영향 없음** — 정책·함수·인덱스는 앱 코드가 이름으로 참조하지 않는다. RLS·search_path·인덱스는 런타임 결과를 바꾸지 않는다
+
+## Success Criteria
+
+- [x] `auth_rls_initplan` 14 → 0 (advisor performance 재실행)
+- [x] `function_search_path_mutable` (SECURITY DEFINER 5 + 트리거 2) → 0 (advisor security 재실행)
+- [x] `duplicate_index` 1 → 0
+- [x] `unindexed_foreign_keys` 2 → 0
+- [x] 정책 semantics 보존 확인 — `truly_unwrapped = 0`, admin 조건 그대로(bulletins `status='approved'`·sermons 미포함·profiles `= id`), `auth.uid()`만 `( SELECT auth.uid() AS uid)`로 바뀜
+- [x] `node scripts/verify-task.mjs db-hygiene-migration` 통과 (아래 검증 표)
+
+**부수 관찰(회귀 아님)**: `unused_index`가 2 → 4. 늘어난 2개는 이번에 만든 FK 인덱스(`idx_sermon_resources_sermon`·`idx_site_collections_updated_by`)로, 방금 생성돼 `idx_scan = 0`이라 뜬 것이다. 워크로드가 쌓이면 FK 조인·삭제 시 쓰인다. 기존 2개(`idx_sermons_deleted_at`·`idx_sermons_service_type`)는 이번 범위 밖.
+
+## 접근법
+
+마이그레이션 파일 1건 + MCP `apply_migration`으로 dev 적용. 전부 in-place 변경이라 앱 재시작·재빌드 불필요.
+
+1. **정책**: `ALTER POLICY`로 `auth.uid()`만 `(select auth.uid())`로. DROP/CREATE 아님 — 이름·roles·cmd·나머지 조건 보존. FOR ALL 정책은 USING만 바꾸면 WITH CHECK(미설정)가 새 USING을 계속 상속
+2. **함수**: `ALTER FUNCTION … SET search_path = public, pg_temp`. 본문 미변경 — `CREATE OR REPLACE`의 본문 전사 오류 위험 회피
+3. **인덱스**: `DROP INDEX IF EXISTS idx_sermons_date` + `CREATE INDEX IF NOT EXISTS` 2개
+
+**동작 보존 근거**: `(select auth.uid())`는 `auth.uid()`와 같은 값을 반환하되 쿼리당 1회 평가(InitPlan). ALTER FUNCTION search_path는 qualified 참조 함수의 결과를 바꾸지 않는다. 인덱스는 결과가 아니라 실행 계획만 바꾼다.
+
+## Non-goals
+
+- `multiple_permissive_policies` 정리 — "only admins can modify X" FOR ALL을 INSERT/UPDATE/DELETE로 분리하거나 sermons SELECT 2정책 병합하는 건 RLS 명령 커버리지 재구조화라 고위험이고, ≤39행 테이블에서 효과가 사실상 없다. tech-debt에 남긴다
+- `unused_index`(idx_sermons_deleted_at·idx_sermons_service_type) 제거는 미루기 — 미래 필터에서 다시 쓸지 확인해야 하고 advisor INFO 레벨이라 급하지 않다. 별도 tech-debt로 뺀다
+- `auth_leaked_password_protection` 등 대시보드 토글 항목 — 코드 아님
+- 마이그레이션 drift 근본 정정(baseline 재작성) — 별개 tech-debt
+
+## 영향받는 파일
+
+- `supabase/migrations/<timestamp>_db_hygiene.sql` (신규, 유일)
+- 앱 코드(`src/`) 변경 없음
+
+## 단계별 체크리스트
+
+- [x] 1. 마이그레이션 SQL 작성 (정책 14 + 함수 7 + 인덱스 3)
+- [x] 2. before 스냅샷 저장 (pg_policies·proconfig·pg_indexes)
+- [x] 3. MCP apply_migration으로 dev 적용 (success)
+- [x] 4. after 재조회 → semantics 보존 확인 + advisor 4카테고리 0 확인
+- [x] 5. verify-task
+
+## Verification
+
+- `node scripts/verify-task.mjs db-hygiene-migration`
+- `mcp__claude_ai_Supabase__get_advisors` (performance + security) — 4카테고리 0
+- `pg_policies` before/after diff — admin 조건·cmd·roles 불변, auth.uid()만 래핑
+
+## ADR 판단
+
+불필요 — `supabase/migrations/`는 ADR_TRIGGER_PARTS지만 이번은 스키마 구조·인증 정책 의미·데이터 흐름을 바꾸지 않는 advisor 위생 정리다. 정책은 semantics-preserving 변환(값 동일), 함수는 search_path만 추가(본문 불변), 인덱스는 계획 최적화. 영구 결정 없음.
+
+---
+
+<!-- 검증 섹션 -->
+
+## Codex 계획 검증
+
+- **결론**: PASS (confidence: high)
+- **현재 판단**: 계획과 최종 SQL을 함께 검토, material·expression 지적 0건. 값 동일·정책 조건 보존·7함수 search_path 안전을 포함한 6개 질문을 확인했고, 적용 후 pg_policies diff와 advisor 재조회를 필수로 남겼다. 질문별 상세는 검증 이력 참조.
+- **다음 행동**: WORK — dev 적용 후 before/after diff
+
+## Codex 1차 검증
+
+- **결론**: PASS (계획 검증이 최종 SQL을 그대로 검토 — 별도 1차 불필요)
+- **현재 판단**: 구현 diff는 마이그레이션 SQL 1개뿐이고, Codex 계획 검증이 그 파일(`20260702000001_db_hygiene.sql`)을 verbatim으로 이미 검토해 PASS했다(적용본과 동일, 주석 외 차이 없음). 그 위에 dev 적용 후 실측으로 다시 확인했다 — `pg_policies`에서 `auth.uid()`를 안 감싼 정책 0개·admin 조건 보존, 함수 9개 search_path 보유, 인덱스 3건 반영.
+- **다음 행동**: Claude 2차 검증
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — advisor 4카테고리 0, 정책 semantics 보존, verify-task 통과.
+- **현재 판단**: dev 실측으로 확인 — `auth_rls_initplan` 14→0, `function_search_path_mutable` →0, `duplicate_index` 1→0, `unindexed_foreign_keys` 2→0. `auth.uid()`를 안 감싼 정책 0개, admin 조건은 테이블별로 그대로(bulletins `status='approved'` 포함, sermons 미포함). `unused_index` 2→4는 신규 FK 인덱스가 통계 없어 뜬 것(회귀 아님). 앱 코드 무변경이라 lint·build·knip은 직전 run과 동일.
+- **다음 행동**: 사용자 승인 후 커밋
+
+| 시점 | run-id | lint | styles | build | knip신규 | DB 실측 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260702-182148 | ✅ | ✅ | ✅ | 0 | advisor 4카테고리 0, 정책 미래핑 0, 함수 search_path 9/9 |
+
+## 검증 이력
+
+## 후속 작업
+
+- `multiple_permissive_policies` 정리 (tech-debt 유지)
+  - 이유: RLS 명령 재구조화 고위험, 소테이블 효과 미미
+  - 다음 기준: 테이블 행이 크게 늘거나 정책 정비를 별도로 할 때
+  - 기록 위치: `docs/tech-debt/active.md` DB 위생 항목

--- a/docs/exec-plans/active/2026-07-02-db-hygiene-migration.md
+++ b/docs/exec-plans/active/2026-07-02-db-hygiene-migration.md
@@ -99,6 +99,15 @@ Supabase advisor(dev) 경고 중 안전하고 값이 분명한 4가지를 마이
 
 ## 검증 이력
 
+## PR 리뷰 대응 (#139)
+
+| 지적 | 출처 | 대조 | 판정 | 조치 |
+| --- | --- | --- | --- | --- |
+| Supabase Preview CI 실패 — `handle_updated_at()` 없음 | Supabase 봇 (Migrations task) | 실패 로그 직접 확인 — fresh replay가 고아 함수에서 `ALTER FUNCTION` 실패. dev에만 있고 마이그레이션 체인엔 없음(`set_updated_at`은 `20260509…:10`에 있어 고아 아님, `handle_updated_at` 하나만 고아) | 타당 (내 drift 주의가 실현됨) | 함수 `ALTER`를 `to_regprocedure` 존재 가드(DO 루프)로 감쌈 — fresh DB는 고아 함수 skip. dev에서 전체 idempotent 재실행 `syntax ok` |
+| RLS 정책에 `public.` 스키마 명시 권장 (5건) | Gemini | 봇 근거("런타임 search_path로 엉뚱한 스키마 참조")를 검증 — **저장된 RLS 정책은 정의 시점 OID 바인딩이라 세션 search_path에 영향 없음**(적용 후 `pg_policies` deparse로 확인). 근거는 부정확하나 명시는 좋은 관례 | 근거는 오탐, 개선은 채택 | 정책 table·enum에 `public.` 추가(런타임 의미 동일, DDL 견고성 개선). Codex 교차검증 PASS(high) |
+
+Codex 교차검증: 5개 항목(RLS OID 바인딩·명시 영향·가드 정확성·replay 안전성·dev 정합성) 모두 CORRECT, 결론 PASS(high). 사실 보정 1건 반영(고아는 `handle_updated_at` 하나).
+
 ## 후속 작업
 
 - `multiple_permissive_policies` 정리 (tech-debt 유지)

--- a/supabase/migrations/20260702000001_db_hygiene.sql
+++ b/supabase/migrations/20260702000001_db_hygiene.sql
@@ -11,44 +11,45 @@
 -- 정책은 ALTER POLICY로 auth.uid()만 바꾸고 cmd·roles·admin 조건은 그대로 둔다.
 -- 함수는 ALTER FUNCTION으로 search_path만 더한다(본문 불변, 모든 참조가 public qualified).
 --
--- 주의(마이그레이션 drift): 정책·함수·인덱스 이름은 dev 실 DB 기준이다. 빈 prod 재생성 시
--- baseline 체인이 같은 이름으로 만들면 replay되고, 이름이 어긋나면 실패한다(기존 drift tech-debt).
+-- drift 대비: 이 저장소는 마이그레이션이 실 DB를 재현하지 못한다. 정책·enum·테이블은
+-- public. 스키마를 명시하고, 함수 ALTER는 존재할 때만 실행한다(to_regprocedure 가드).
+-- handle_updated_at·set_updated_at은 dev에만 있는 고아 함수라, fresh DB 재생 시 건너뛴다.
 
 -- ─────────────────────────────────────────────────────────────
--- 1) RLS 정책 auth.uid() 래핑 (14)
+-- 1) RLS 정책 auth.uid() 래핑 (14) — public. 스키마 명시
 -- ─────────────────────────────────────────────────────────────
 
 -- bulletins / bulletin_images : role='admin' AND status='approved'
 alter policy bulletins_insert_admin_only on public.bulletins
   with check (exists (
-    select 1 from profiles
+    select 1 from public.profiles
     where profiles.id = (select auth.uid())
-      and profiles.role = 'admin'::role_enum
-      and profiles.status = 'approved'::profile_status_enum
+      and profiles.role = 'admin'::public.role_enum
+      and profiles.status = 'approved'::public.profile_status_enum
   ));
 
 alter policy bulletins_update_admin_only on public.bulletins
   using (exists (
-    select 1 from profiles
+    select 1 from public.profiles
     where profiles.id = (select auth.uid())
-      and profiles.role = 'admin'::role_enum
-      and profiles.status = 'approved'::profile_status_enum
+      and profiles.role = 'admin'::public.role_enum
+      and profiles.status = 'approved'::public.profile_status_enum
   ));
 
 alter policy bulletin_images_insert_admin_only on public.bulletin_images
   with check (exists (
-    select 1 from profiles
+    select 1 from public.profiles
     where profiles.id = (select auth.uid())
-      and profiles.role = 'admin'::role_enum
-      and profiles.status = 'approved'::profile_status_enum
+      and profiles.role = 'admin'::public.role_enum
+      and profiles.status = 'approved'::public.profile_status_enum
   ));
 
 alter policy bulletin_images_delete_admin_only on public.bulletin_images
   using (exists (
-    select 1 from profiles
+    select 1 from public.profiles
     where profiles.id = (select auth.uid())
-      and profiles.role = 'admin'::role_enum
-      and profiles.status = 'approved'::profile_status_enum
+      and profiles.role = 'admin'::public.role_enum
+      and profiles.status = 'approved'::public.profile_status_enum
   ));
 
 -- profiles : 본인 행만
@@ -58,84 +59,95 @@ alter policy profiles_select_own on public.profiles
 -- sermons / sermon_resources : role='admin' (status 조건 없음)
 alter policy sermons_select_admin on public.sermons
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy sermons_insert_admin on public.sermons
   with check (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy sermons_update_admin on public.sermons
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ))
   with check (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy sermon_resources_insert_admin on public.sermon_resources
   with check (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy sermon_resources_update_admin on public.sermon_resources
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ))
   with check (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 -- site_collections / site_settings / staff / worship_schedules : FOR ALL, role='admin'
 -- USING만 바꾸면 미설정 WITH CHECK가 새 USING을 그대로 상속한다(INSERT/UPDATE 보존).
 alter policy "only admins can modify site_collections" on public.site_collections
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy "only admins can modify site_settings" on public.site_settings
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy "only admins can modify staff" on public.staff
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 alter policy "only admins can modify worship_schedules" on public.worship_schedules
   using (exists (
-    select 1 from profiles
-    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+    select 1 from public.profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::public.role_enum
   ));
 
 -- ─────────────────────────────────────────────────────────────
 -- 2) SECURITY DEFINER / 트리거 함수 search_path 고정 (7)
---    본문은 그대로 두고 config만 더한다.
+--    존재할 때만 실행 — fresh DB 재생 시 없는 함수(고아)는 건너뛴다.
 -- ─────────────────────────────────────────────────────────────
 
-alter function public.create_sermon(jsonb, jsonb) set search_path = public, pg_temp;
-alter function public.update_sermon(bigint, jsonb, uuid[], jsonb) set search_path = public, pg_temp;
-alter function public.delete_sermon(bigint) set search_path = public, pg_temp;
-alter function public.get_adjacent_bulletins(bigint) set search_path = public, pg_temp;
-alter function public.handle_new_user() set search_path = public, pg_temp;
-alter function public.handle_updated_at() set search_path = public, pg_temp;
-alter function public.set_updated_at() set search_path = public, pg_temp;
+do $$
+declare
+  fn text;
+begin
+  foreach fn in array array[
+    'public.create_sermon(jsonb, jsonb)',
+    'public.update_sermon(bigint, jsonb, uuid[], jsonb)',
+    'public.delete_sermon(bigint)',
+    'public.get_adjacent_bulletins(bigint)',
+    'public.handle_new_user()',
+    'public.handle_updated_at()',
+    'public.set_updated_at()'
+  ]
+  loop
+    if to_regprocedure(fn) is not null then
+      execute format('alter function %s set search_path = public, pg_temp', fn);
+    end if;
+  end loop;
+end $$;
 
 -- ─────────────────────────────────────────────────────────────
 -- 3) 중복 인덱스 제거 (idx_sermons_date == idx_sermons_date_desc)
---    idx_sermons_date_desc를 남긴다(001_sermon_schema가 만드는 이름).
 -- ─────────────────────────────────────────────────────────────
 
 drop index if exists public.idx_sermons_date;

--- a/supabase/migrations/20260702000001_db_hygiene.sql
+++ b/supabase/migrations/20260702000001_db_hygiene.sql
@@ -1,0 +1,148 @@
+-- DB 위생 정리 (2026-07-02 refactor-audit P2)
+--
+-- Supabase advisor(dev)가 경고한 4가지를 걷어낸다. 전부 in-place 변경이라
+-- 스키마 구조·인증 정책 의미·데이터 흐름을 바꾸지 않는다.
+--   1) RLS auth.uid() 미래핑 14정책 → (select auth.uid())  [auth_rls_initplan]
+--   2) SECURITY DEFINER/트리거 함수 7개 search_path 고정      [function_search_path_mutable]
+--   3) 중복 인덱스 idx_sermons_date 제거                      [duplicate_index]
+--   4) FK 인덱스 2개 추가                                     [unindexed_foreign_keys]
+--
+-- 보존 근거: (select auth.uid())는 auth.uid()와 같은 값을 반환하되 쿼리당 1회 평가한다(InitPlan).
+-- 정책은 ALTER POLICY로 auth.uid()만 바꾸고 cmd·roles·admin 조건은 그대로 둔다.
+-- 함수는 ALTER FUNCTION으로 search_path만 더한다(본문 불변, 모든 참조가 public qualified).
+--
+-- 주의(마이그레이션 drift): 정책·함수·인덱스 이름은 dev 실 DB 기준이다. 빈 prod 재생성 시
+-- baseline 체인이 같은 이름으로 만들면 replay되고, 이름이 어긋나면 실패한다(기존 drift tech-debt).
+
+-- ─────────────────────────────────────────────────────────────
+-- 1) RLS 정책 auth.uid() 래핑 (14)
+-- ─────────────────────────────────────────────────────────────
+
+-- bulletins / bulletin_images : role='admin' AND status='approved'
+alter policy bulletins_insert_admin_only on public.bulletins
+  with check (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid())
+      and profiles.role = 'admin'::role_enum
+      and profiles.status = 'approved'::profile_status_enum
+  ));
+
+alter policy bulletins_update_admin_only on public.bulletins
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid())
+      and profiles.role = 'admin'::role_enum
+      and profiles.status = 'approved'::profile_status_enum
+  ));
+
+alter policy bulletin_images_insert_admin_only on public.bulletin_images
+  with check (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid())
+      and profiles.role = 'admin'::role_enum
+      and profiles.status = 'approved'::profile_status_enum
+  ));
+
+alter policy bulletin_images_delete_admin_only on public.bulletin_images
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid())
+      and profiles.role = 'admin'::role_enum
+      and profiles.status = 'approved'::profile_status_enum
+  ));
+
+-- profiles : 본인 행만
+alter policy profiles_select_own on public.profiles
+  using ((select auth.uid()) = id);
+
+-- sermons / sermon_resources : role='admin' (status 조건 없음)
+alter policy sermons_select_admin on public.sermons
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy sermons_insert_admin on public.sermons
+  with check (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy sermons_update_admin on public.sermons
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ))
+  with check (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy sermon_resources_insert_admin on public.sermon_resources
+  with check (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy sermon_resources_update_admin on public.sermon_resources
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ))
+  with check (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+-- site_collections / site_settings / staff / worship_schedules : FOR ALL, role='admin'
+-- USING만 바꾸면 미설정 WITH CHECK가 새 USING을 그대로 상속한다(INSERT/UPDATE 보존).
+alter policy "only admins can modify site_collections" on public.site_collections
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy "only admins can modify site_settings" on public.site_settings
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy "only admins can modify staff" on public.staff
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+alter policy "only admins can modify worship_schedules" on public.worship_schedules
+  using (exists (
+    select 1 from profiles
+    where profiles.id = (select auth.uid()) and profiles.role = 'admin'::role_enum
+  ));
+
+-- ─────────────────────────────────────────────────────────────
+-- 2) SECURITY DEFINER / 트리거 함수 search_path 고정 (7)
+--    본문은 그대로 두고 config만 더한다.
+-- ─────────────────────────────────────────────────────────────
+
+alter function public.create_sermon(jsonb, jsonb) set search_path = public, pg_temp;
+alter function public.update_sermon(bigint, jsonb, uuid[], jsonb) set search_path = public, pg_temp;
+alter function public.delete_sermon(bigint) set search_path = public, pg_temp;
+alter function public.get_adjacent_bulletins(bigint) set search_path = public, pg_temp;
+alter function public.handle_new_user() set search_path = public, pg_temp;
+alter function public.handle_updated_at() set search_path = public, pg_temp;
+alter function public.set_updated_at() set search_path = public, pg_temp;
+
+-- ─────────────────────────────────────────────────────────────
+-- 3) 중복 인덱스 제거 (idx_sermons_date == idx_sermons_date_desc)
+--    idx_sermons_date_desc를 남긴다(001_sermon_schema가 만드는 이름).
+-- ─────────────────────────────────────────────────────────────
+
+drop index if exists public.idx_sermons_date;
+
+-- ─────────────────────────────────────────────────────────────
+-- 4) FK 커버링 인덱스 추가
+-- ─────────────────────────────────────────────────────────────
+
+create index if not exists idx_sermon_resources_sermon on public.sermon_resources (sermon_id);
+create index if not exists idx_site_collections_updated_by on public.site_collections (updated_by);


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: Supabase advisor(dev)가 띄운 성능·보안 경고를 실 DB로 진단해, 값이 분명하고 안전한 4종을 마이그레이션 1건으로 걷어낸다. 앱 코드는 바꾸지 않는다.

**범위**:

- RLS 정책 14건에서 행마다 재평가되던 `auth.uid()`를 `(select auth.uid())`로 감쌈
- SECURITY DEFINER·트리거 함수 7개의 열린 search_path를 고정
- 중복 인덱스 제거 + FK 인덱스 2개 추가

---

## 🔗 개발 컨텍스트

- **Task ID**: `db-hygiene-migration`
- **Exec Plan**: `docs/exec-plans/active/2026-07-02-db-hygiene-migration.md`
- **관련 ADR**: 해당 없음 (스키마 구조·인증 정책 의미·데이터 흐름을 바꾸지 않는 advisor 위생 정리)
- **관련 tech debt**: `docs/tech-debt/active.md` DB 위생 항목 (multiple_permissive·unused_index defer)
- **작업 범위**: `auth_rls_initplan`, `function_search_path_mutable`, `duplicate_index`, `unindexed_foreign_keys`
- **제외한 범위**: `multiple_permissive_policies`, `unused_index`, 대시보드 토글(코드 아님), 마이그레이션 baseline 재작성

---

## 💡 문제와 진단 (Problem & Diagnosis)

### 1. 증상 — advisor 경고 더미, 그런데 어디까지가 진짜인가

Supabase advisor(dev)가 성능·보안 경고를 무더기로 띄웠다. 하지만 advisor는 보수적이라 값이 낮거나 오탐성인 경고도 섞인다. 그래서 문제는 "경고를 다 끄는 것"이 아니라 **어느 것이 실제 위험이고, 어떻게 고쳐야 RLS·인증을 깨지 않는가**였다.

### 2. 함정 — 마이그레이션 파일을 믿을 수 없었다 (drift)

이 저장소는 `supabase/migrations/`가 실 DB를 재현하지 못하는 drift가 알려져 있다. 실제로 파일과 DB가 어긋난 증거를 두 개 확인했다.

- `supabase/migrations/001_sermon_schema.sql:91`은 `CREATE INDEX idx_sermon_resources_sermon ...`으로 FK 인덱스를 만든다고 적혀 있다. 그런데 실 DB `pg_indexes`엔 그 인덱스가 없다.
- `supabase/migrations/20260314000000_create_bulletin_rpc.sql:77`은 `get_adjacent_bulletins`에 `SET search_path = public, pg_temp`를 건다고 적혀 있다. 그런데 실 DB `pg_proc.proconfig`엔 그 함수의 search_path가 비어 있다.

파일만 보면 "이미 고쳐졌다"고 오판했을 항목들이다. 그래서 **실 DB를 SSOT로 직접 조회**해(`pg_policies`·`pg_proc`·`pg_indexes`) 실제 상태를 확정했다.

### 3. 드러난 4가지 — 각각 왜 문제인가

| 항목 | 실 DB에서 확인한 것 | 왜 문제인가 |
| --- | --- | --- |
| `auth_rls_initplan` (14) | admin 정책 14건이 `auth.uid()`를 감싸지 않고 씀 | Postgres가 이 함수를 **행마다** 재평가한다. 행이 N개면 호출 N번. 지금은 테이블이 작아 무해하지만 규모가 커지면 성능 절벽이 된다 |
| `function_search_path_mutable` (7) | SECURITY DEFINER 함수 5개 + 트리거 2개가 search_path 미고정 | search_path가 열린 SECURITY DEFINER 함수는, 공격자가 경로 앞 스키마에 동명 객체를 심으면 정의자(definer) 권한으로 그 객체를 실행할 수 있는 권한 상승 벡터다. 함수 본문이 일부 미qualified 참조(enum 캐스팅 등)를 써서 위험이 남아 있었다 |
| `duplicate_index` (1) | `idx_sermons_date`와 `idx_sermons_date_desc`가 둘 다 `(sermon_date DESC)`로 동일 | 같은 인덱스가 둘이면 쓰기마다 양쪽을 갱신해 쓰기 비용·용량만 늘고 이득이 없다 |
| `unindexed_foreign_keys` (2) | `sermon_resources.sermon_id`·`site_collections.updated_by`에 커버링 인덱스 없음 | FK 조인·부모 삭제(cascade) 시 seq scan이 걸린다 |

---

## 🔧 해결 — 왜 이 방법으로 고쳤나 (Fix & Rationale)

여기서 진짜 위험은 고치는 대상이 아니라 **고치다가 RLS·인증을 깨는 것**이었다. 그래서 결과가 바뀌지 않음을 증명할 수 있는 연산만 골랐다.

- **정책은 `ALTER POLICY`로 `auth.uid()`만 교체** (DROP/CREATE 아님). 이름·roles·cmd와 admin 조건을 그대로 두고 식 안의 `auth.uid()`만 `(select auth.uid())`로 바꾼다. `(select auth.uid())`는 같은 값을 반환하되 쿼리당 1회만 평가한다 — 값이 아니라 평가 횟수만 바뀐다.
  - admin 조건이 테이블마다 달라 정확히 보존했다: `bulletins`·`bulletin_images`는 `role='admin' AND status='approved'`, `sermons`·`sermon_resources`·`site_*`·`staff`·`worship`는 `role='admin'`만, `profiles_select_own`은 `auth.uid() = id`.
- **함수는 `ALTER FUNCTION ... SET search_path`로 config만 추가** (CREATE OR REPLACE 아님). 본문을 다시 쓰지 않아 전사 오류가 원천적으로 없다. 모든 함수 본문이 `public.profiles`처럼 qualified 참조 + `now()`·`split_part` 같은 pg_catalog 내장이라 `public, pg_temp` 고정이 안전하다(`handle_new_user` 가입 트리거 포함).
- **인덱스는 중복 하나 제거 + FK 인덱스 2개 추가.** 인덱스는 결과가 아니라 실행 계획만 바꾼다.

**advisor before → after (dev 실측)**

| advisor 항목 | before | after |
| --- | --- | --- |
| auth_rls_initplan | 14 | 0 |
| function_search_path_mutable | 7 (SECURITY DEFINER 5 + 트리거 2) | 0 |
| duplicate_index | 1 | 0 |
| unindexed_foreign_keys | 2 | 0 |

- 대표 경로: `supabase/migrations/20260702000001_db_hygiene.sql`

**Non-goal (미룬 이유)**

- `multiple_permissive_policies`: FOR ALL 정책을 INSERT/UPDATE/DELETE로 나누거나 sermons SELECT 2정책을 병합하는 건 RLS 명령 커버리지를 다시 짜는 작업이라 고위험이고, 39행 이하 테이블에서 효과가 사실상 없다 → tech-debt 유지
- `unused_index` 2건: 미래 필터에서 다시 쓸지 확인이 필요하고 advisor INFO 레벨이라 미룬다

> ⚠️ **마이그레이션 drift 주의**: 정책·함수·인덱스 이름은 dev 실 DB 기준이다. 빈 prod 재생성 시 baseline 체인이 같은 이름을 만들어야 replay되고, 이름이 어긋나면 실패한다 (기존 drift tech-debt).

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 실제 상태 판정 기준 | 실 DB 직접 조회(pg_policies 등) | 마이그레이션 파일이 실 DB와 어긋남(drift 증거 2건) | 마이그레이션 파일 신뢰 — 이미 고쳐졌다고 오판 |
| 정책 변경 방식 | `ALTER POLICY`로 `auth.uid()`만 교체 | 이름·roles·cmd·admin 조건 보존 | `DROP`/`CREATE` — 조건 전사 오류 위험 |
| search_path 적용 | `ALTER FUNCTION`만 | 본문 전사 오류 회피 | `CREATE OR REPLACE` — 본문 재작성 위험 |
| multiple_permissive | 미룸 | 고위험·소테이블 효과 미미 | 지금 분리 — 명령 커버리지 재구성 |

---

## ✅ 하네스 검증 (Harness Verification)

고친 뒤 "아무것도 안 깨졌다"를 어떻게 확인했는지:

- Codex가 적용 전 최종 SQL을 그대로 검토(값 동일성·WITH CHECK 상속·search_path 안전 등 6개 질문).
- dev 적용 후 `pg_policies` 재조회 — `auth.uid()`를 안 감싼 정책 **0개**, admin 조건은 테이블별로 그대로. 함수 9개 search_path 보유, 인덱스 3건 반영 확인.
- advisor 재실행 — 목표 4카테고리 전부 0.

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs db-hygiene-migration` — PASS, RUN_ID=`20260702-182148`, failed=0, warned=Knip |
| `harness-gate` | PASS (`node scripts/harness-gate.mjs db-hygiene-migration`) |
| Codex 계획 검증 | PASS (최종 SQL까지 verbatim 검토) |
| Codex 1차 검증 | PASS (계획 검증이 최종 SQL을 그대로 검토, 별도 1차 불필요) |
| Claude 2차 검증 | 완료 |
| ADR 판단 | 불필요 (advisor 위생 정리, 영구 결정 없음) |
| 남은 warning | 기존 부채 (Knip) |

---

## 👀 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 없음 (앱 코드 무변경, 런타임 결과 동일)
- **운영 리스크**: dev 적용 완료. prod는 baseline 이름 일치를 전제한다 (drift 주의 참조)
- **QA 후속**: 없음 (DB 실측으로 advisor 4카테고리 0 확인 완료)
- **롤백 시 영향**: 없음 (값 동일 변환·search_path 추가·인덱스 조정이라 되돌려도 안전)

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- advisor 경고를 끌 땐 파일이 아니라 실 DB를 봐라 — 이 저장소는 마이그레이션이 실 DB와 어긋난다(이번에도 FK 인덱스·함수 search_path 2건이 파일엔 있는데 DB엔 없었다).
- `unused_index`가 2 → 4로 는 것은 회귀가 아니다. 늘어난 2개는 이번에 만든 FK 인덱스(`idx_sermon_resources_sermon`·`idx_site_collections_updated_by`)로, 방금 생성돼 `idx_scan = 0`이라 뜬 것이다. 워크로드가 쌓이면 조인·삭제에서 쓰인다.
- `multiple_permissive`·`unused_index` defer는 tech-debt에 유지한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
