### PR TITLE
[Refactor] 목록·회차·주보 조회를 화면이 실제 쓰는 컬럼만 받도록 축소 — 응답 최대 84% 감소

### DIFF
--- a/docs/exec-plans/active/2026-07-02-p5-select-narrowing.md
+++ b/docs/exec-plans/active/2026-07-02-p5-select-narrowing.md
@@ -1,0 +1,204 @@
+# p5-select-narrowing
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-07-02
+- **브랜치**: refactor/p5-select-narrowing
+- **Open questions**: none
+- **ADR needed**: no — 셀렉트와 타입 계약을 좁히고 죽은 쿼리를 지운다. 레이어 서열, 캐시, 인증, 데이터 흐름은 그대로다
+
+## 목표
+
+감사 P5: 목록 쿼리들이 상세용 넓은 셀렉트를 공유하던 것을 소비처가 실제 읽는 필드로 좁힌다. PR #91 회귀(소비처 감사 누락 → `cover_image_url` 유실)의 재도전이라, **타입을 먼저 좁혀 tsc가 누락을 잡는 그물**로 삼고 공유 상수 대신 경로별 전용 셀렉트를 만든다.
+
+## 검증된 Assumptions
+
+explorer 전수 맵(도구 호출 68회)으로 훑고, 무게가 실리는 단정은 직접 다시 검증했다. 근거 명령을 함께 적는다.
+
+- **A. `list()` 소비처(5곳: featured·recent 캐러셀·/sermons/all·다른설교·sitemap)는 `sermon_resources`를 안 읽는다** — `rg '\.sermon_resources' src` 2건뿐: `SermonDetailSections.tsx:61`(상세)·`sermon-form-mapper.ts:64`(어드민 폼). 목록 union은 기존 `SermonCardItem` 필드와 일치(+preacher name·title, series id·slug·title).
+- **B. 회차(bySeriesSlug·bySeriesId episodes) 소비처는 관계 3종을 전부 안 읽는다** — `rg 'preacher|\.content' SeriesDetailPage/` 0건. 필요 스칼라 9개: id, series_order, sermon_date, video_id, video_provider, thumbnail_url, title, scripture, duration.
+- **C. bulletins에서 `content`·`updated_at`·`view_count`를 읽는 곳 0** — `rg '\.content\b' src`는 notices뿐. bulletins union: id, title, sunday_date, created_at, author_id. bulletin_images union: id, cloudinary_id, order_index (`bulletin_id`·`created_at` 미사용).
+- **D. getAllSeries union: id, slug, title, description, cover_image_url, started_at, ended_at (+sermon_count)** — `year`·`created_at`만 제거 가능. **PR #91 회귀 필드 `cover_image_url`은 SeriesCard:12가 읽으므로 유지 필수.** getAllPreachers union: id, name, title (+sermon_count) — bio·photo_url·created_at·updated_at 제거 가능.
+- admin은 별도 쿼리(`getAdminSeries/getAdminPreachers`, `select('*')`)로 타입만 공유 — 타입을 union으로 좁혀도 superset 셀렉트라 구조적으로 만족.
+- Pick 키는 전부 실존 — `database.types.ts` Row 대조(bulletins·bulletin_images·sermon_series·preachers).
+- 죽은 코드 2건 확정: `sermonService.detailBySlug`(wrapper 없음, 호출 0)·`getBulletinList`+`bulletinService.list()`(deprecated, summary는 listQuery 직접 사용) — `rg` 정의 외 0건.
+- 선례: `recent()`가 이미 좁은 셀렉트+`SermonListItem` 타입 패턴 — 이번 작업이 따라갈 모양.
+
+## Success Criteria
+
+- **타입 그물**: 타입을 소비처 union으로 먼저 좁힌 뒤 `yarn build`(tsc) 통과 — 놓친 소비처가 있으면 컴파일 실패로 드러남.
+- **셀렉트↔타입 1:1 대조표 (Codex CR)**: 전용 셀렉트 7곳(`SERMON_CARD_SELECT`·`SERIES_EPISODE_SELECT`·bulletin list/latest/detail·allSeries·allPreachers) 각각 "셀렉트 컬럼 == 선언 타입 Pick 필드"를 표로 대조해 검증 기록에 남긴다. 의도적 superset은 명기(SermonCardItem의 `slug`·`summary`). 서비스의 `as unknown as` 캐스트가 tsc 그물을 우회하는 사각지대(셀렉트가 타입보다 좁은 경우)를 사람 대조로 막는다.
+- 셀렉트별 제거 확인: list()에서 `sermon_resources` join 소멸, 회차에서 관계 3종 소멸, bulletin_images 3필드만, series/preachers 미사용 컬럼 소멸.
+- payload 실측: 4쿼리 REST 응답 바이트 before/after 기록.
+- dev 브라우저 실측 — 회귀 이력 지점 우선: `/sermons` 시리즈 캐러셀 **cover 이미지**, `/sermons/all` 사이드바·배너·필터시트, `/sermons/series/[id]` 히어로+회차, `/sermons/[id]` 사이드바·다른설교·**자료 다운로드**, 홈(WeeklyBulletin), `/news/bulletins`(+latest 이미지)·상세, admin 목록 필터·new/edit 폼.
+- `rg "detailBySlug|getBulletinList"` src 0건. verify-task PASS, knip 신규 0.
+
+## 영향받는 파일
+
+- `src/types/sermon.ts` — `SeriesWithSermonCount`·`PreacherWithSermonCount`를 union Pick으로 축소, `SeriesEpisodeItem` 신설, `SeriesDetail.episodes` 교체
+- `src/types/bulletin.ts` — `BulletinWithImages`를 union Pick 기반으로 축소
+- `src/services/sermon/sermon-service.ts` — `SERMON_CARD_SELECT`·`SERIES_EPISODE_SELECT` 신설, list/bySeriesSlug/bySeriesId 전환, allSeries/allPreachers 컬럼 명시, `detailBySlug` 삭제
+- `src/services/bulletin/bulletin-service.ts` — 공용 셀렉트 상수(스칼라 5 + images 3), `list()` 삭제
+- `src/services/bulletin/index.ts` — `getBulletinList` 삭제
+- 소비처 prop 타입 전환: `SermonFeatured`·`SermonRecentList`·`SermonFilteredList`·`SermonOtherByPreacher`(→SermonCardItem), `EpisodeGrid`·`SeriesEpisodeCard`·`SermonSeriesSidebar`(→SeriesEpisodeItem), `BulletinTable`·`BulletinTableSection`(→좁은 타입)
+
+## 단계별 체크리스트
+
+- [x] 1. D — series/preacher 타입 union 축소 + 셀렉트 명시 → tsc가 Preacher 전체 행 요구 8곳 적발·교체 → 커밋 41a5973
+- [x] 2. A — list()를 `SERMON_CARD_SELECT`+`SermonCardItem`으로 전환, 소비처 6곳 교체, `detailBySlug` 삭제 → tsc 통과 → 커밋 8e897de
+- [x] 3. B — 회차를 `SERIES_EPISODE_SELECT`+`SeriesEpisodeItem`으로 전환, 소비처 5곳 교체 → tsc 통과 → 커밋 497055d
+- [x] 4. C — bulletin 셀렉트·타입 축소 + `getBulletinList`/`list()` 삭제 → tsc가 테이블·최신 주보 prop 3곳 적발·교체 → 커밋 581c1d0
+- [x] 5. 셀렉트↔Pick 1:1 대조표 기록 + payload 실측 + dev 실측 8라우트 통과 + VERIFY PASS (RUN_ID 20260703-051746)
+
+(단계별 dev 실측은 서버 재기동을 줄이기 위해 5에서 일괄 수행으로 조정 — tsc 그물이 단계별 회귀 확인을 대신함)
+
+## 셀렉트↔타입 1:1 대조 (Codex CR 이행)
+
+| 셀렉트 | 컬럼 | 타입 | 판정 |
+| --- | --- | --- | --- |
+| `SERMON_CARD_SELECT` | id, slug, sermon_date, video_id, video_provider, thumbnail_url, title, scripture, service_type, summary, duration + preacher(name,title) + sermon_series(id,slug,title) | `SermonCardItem` = SermonListItem(9필드+preacher 2) + summary·duration + series 3 | 1:1 일치 (소비처 대비 superset은 slug·summary — D3 의도 명기) |
+| `SERIES_EPISODE_SELECT` | id, series_order, sermon_date, video_id, video_provider, thumbnail_url, title, scripture, duration | `SeriesEpisodeItem` Pick 9필드 | 1:1 일치 |
+| `BULLETIN_WITH_IMAGES_SELECT` | id, title, sunday_date, created_at, author_id + bulletin_images(id, cloudinary_id, order_index) | `BulletinWithImages` Pick 5 + images Pick 3 | 1:1 일치 — 초안의 `profiles?`는 Codex 1차 검증이 불일치로 적발, 어떤 쿼리도 안 채우는 죽은 필드라 제거(687434f) |
+| allSeries 셀렉트 | id, slug, title, description, cover_image_url, started_at, ended_at + sermons!inner(count) | `SeriesWithSermonCount` Pick 7 + sermon_count | 1:1 일치 (**cover_image_url 유지 — PR #91 회귀 필드**) |
+| allPreachers 셀렉트 | id, name, title + sermons!inner(count) | `PreacherWithSermonCount` Pick 3 + sermon_count | 1:1 일치 |
+
+## payload 실측 (dev REST, 같은 필터로 old/new 셀렉트 응답 바이트)
+
+| 쿼리 | before | after | 감소 |
+| --- | --- | --- | --- |
+| A. 설교 목록 (published 9행, limit 12) | 6,915 B | 2,308 B | **-66.6%** |
+| B. 시리즈 회차 (실 시리즈 1개) | 1,203 B | 189 B | **-84.3%** |
+| C. 주보 목록 (limit 10) | 466 B | 302 B | -35.2% |
+| D-1. 시리즈 전체 | 349 B | 258 B | -26.1% |
+| D-2. 설교자 전체 | 554 B | 227 B | -59.0% |
+
+- D4 count shape 확인: 명시 컬럼 + `sermons!inner(count)` 응답이 `"sermons":[{"count":1}]` — `mapRowsWithSermonCount`가 기대하는 형태 그대로.
+
+## Verification
+
+- `node scripts/verify-task.mjs p5-select-narrowing`
+- 단계마다 tsc(빌드) — 타입 그물 가동 확인
+- dev 실측 라우트 체크리스트 (SC 참조)
+- REST 응답 바이트 before/after 4쿼리
+
+## Non-goals
+
+- `detailById`·`getSermonForEdit`의 셀렉트 축소 — 상세·폼은 전 필드에 가깝게 실사용 (bySeriesId의 series 단건 `select('*')`도 superset이라 유지)
+- admin 쿼리(`getAdminSeries/getAdminPreachers`·`ADMIN_SERMON_SELECT`) 축소 — 타입만 공유, 별도 작업
+- `summary()`의 items/latest에서 이미지 join 자체를 분리하는 공유 함수 재설계 — 이번엔 필드 축소만
+- DB 스키마·인덱스 변경 없음
+
+## 의사결정 로그
+
+- **D1 — 타입을 먼저 좁혀 tsc를 회귀 그물로 쓴다**
+  - 문제: PR #91 회귀는 셀렉트만 좁히고 타입은 넓게 남겨(전 필드 타입인데 런타임엔 없음) 컴파일이 조용히 통과한 것이 구조적 원인이다. 수동 소비처 감사는 그때도 누락됐다.
+  - 해결: 공유 타입(`SeriesWithSermonCount` 등)을 소비처 union Pick으로 먼저 좁히고 빌드를 돌린다. 놓친 소비처가 있으면 tsc가 그 자리에서 실패한다 — 사람 감사(explorer 전수 맵 + 직접 재검증) 위에 기계 검증을 한 겹 더 얹는다.
+  - 결과: "감사 누락 → 조용한 런타임 구멍" 경로가 컴파일 에러로 바뀐다.
+
+- **D2 — 공유 상수 좁히기 대신 경로별 전용 셀렉트**
+  - 문제: `SERMON_WITH_RELATIONS_SELECT`는 상세(전 필드 필요)와 목록(카드 필드만)이 공유한다. 상수를 직접 좁히면 상세가 깨진다 — 2026-05-15 exec-plan도 "별건 전용 쿼리 필요"로 보류했었다.
+  - 해결: 상세는 기존 상수를 그대로 두고, 목록(`SERMON_CARD_SELECT`)·회차(`SERIES_EPISODE_SELECT`)에 전용 셀렉트를 신설한다. `recent()`+`SermonListItem`이 이미 같은 패턴의 선례다.
+  - 결과: 경로별 셀렉트가 소비처 요구와 1:1로 맞고, 상세 경로는 무변경이라 회귀 면적이 없다.
+
+- **D3 — list() 타입은 기존 `SermonCardItem` 재사용, `slug`·`summary`는 의도적 superset (Codex 계획 검증 expression-only)**
+  - 문제: 목록 소비처는 `slug`·`summary`를 안 읽는데 `SermonCardItem`은 포함한다. 딱 맞는 새 타입을 만들지, 기존 타입을 재사용할지.
+  - 해결: 기존 타입 재사용을 택했다 — 새 타입은 GridCard 등 기존 prop 타입까지 갈아엎는 연쇄 수정을 부르고, 두 필드는 짧은 문자열이라 payload 비용이 미미하다. 1:1 대조표에 "의도적 superset: slug·summary"로 명기해 누락과 구분한다.
+  - 결과: 타입 신설 없이 소비처 prop 타입 교체가 최소화된다.
+
+- **D4 — `sermons!inner(count)` 임베드 count는 기존 문법 유지, REST 실측에서 shape 기록 (Codex 계획 검증 expression-only)**
+  - 문제: PostgREST 14 기준 괄호 없는 `count`는 legacy 표기다(동작은 지원).
+  - 해결: 기존 4곳(allSeries·allPreachers·admin 2곳)이 이미 이 문법이라 이번 작업에서 문법을 바꾸지 않는다 — 바꾸면 축소 범위를 넘는 인접 변경이다. 대신 REST 실측에서 명시 컬럼 + count 조합의 응답 shape를 기록해 회귀를 확인한다.
+  - 결과: 문법 통일은 범위 밖으로 유지, 응답 shape 검증은 SC에 흡수.
+
+## ADR 판단
+
+- 불필요 — services 층을 고치지만 셀렉트·타입 계약 축소와 죽은 쿼리 삭제뿐이다. 레이어 서열·캐시 태그·인증·데이터 흐름·라이브러리는 그대로다. 전용 셀렉트 패턴은 기존 `recent()` 선례의 반복이라 영구 결정이 아니다.
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST (신뢰도 high) → 반영 완료
+- **현재 판단**: 필드 union A~D는 Codex가 소비처 파일을 직접 읽어 전부 CONFIRMED — spread(`{...sermon}`) 0건, 동적 접근 0건, admin에서 뺀 필드 접근 0건까지 다시 확인했다(explorer→Claude→Codex 삼중 확인). material CR 1건: 서비스의 `as unknown as` 캐스트 때문에 셀렉트가 타입보다 좁아도 tsc가 통과하는 사각지대 — 셀렉트↔Pick 1:1 대조표를 SC에 추가했다. expression-only 2건은 D3(SermonCardItem superset 명기)·D4(count legacy shape 기록)로 반영.
+- **다음 행동**: WORK 진입 (체크리스트 1: D 시리즈/설교자)
+
+## Codex 1차 검증
+
+- **결론**: CHANGE_REQUEST (신뢰도 high) → 반영 완료 (687434f)
+- **현재 판단**: 1:1 대조 재검증에서 5개 중 4개 일치, 1개 불일치 적발 — `BulletinWithImages`의 `profiles?` 필드가 셀렉트에 없음(옛 셀렉트도 임베드 안 하던 죽은 타입 표면). 남기면 미래 소비자의 `profiles?.display_name` 접근을 tsc가 못 막는 사각지대라 타입에서 제거했다. 그 외 확인:
+  - 소비처가 어긋나는 새 패턴 0건 (JSON.stringify·spread·동적 접근 검색)
+  - superset 2곳(getSeriesDetail `select('*')`, admin 쿼리)은 의도대로
+  - 레이어 역방향 import 0건, 죽은 코드 참조 0건
+- **다음 행동**: 문서 커밋 후 verify-task 재실행(diff 갱신분) → PR
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS
+- **현재 판단**: 타입 그물이 설계대로 작동 — 좁힌 타입이 Preacher 전체 행을 요구하던 8곳과 bulletin prop 3곳을 컴파일 에러로 드러내 교체했다 (knip 미사용 export도 28→27, getBulletinList 제거분). dev 실측 8라우트 통과: /sermons(featured·캐러셀 — cover_image_url 키 REST 존재 확인, 어두운 카드는 DB cover null의 기존 placeholder), /sermons/all(사이드바 카운트·카드), 시리즈 상세(히어로·회차), 설교 상세(사이드바 회차·다른 설교 3카드·자료 섹션), 주보 목록(테이블·latest 이미지)·상세(작성자·등록일·이미지), 홈 WeeklyBulletin, admin 필터·new 폼 셀렉트. 비어 보인 썸네일 2건은 DB 대조로 원래 데이터 없음(placeholder 정상)을 확인했다.
+- **다음 행동**: Codex 1차 검증 결과 기록 후 문서 커밋
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2차 | 20260703-051746 | ✅ | ✅ | ✅ | 0 (27로 감소) | dev 실측 8라우트 완료 |
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 후속 작업
+
+<!-- 이번 범위 밖 일. Non-goals·체크리스트에 중복 기술 금지 — 여기에만.
+- <후속 항목>
+  - 이유: <왜 이번에 안 하나>
+  - 다음 기준: <언제 다시 하나>
+  - 기록 위치: `docs/tech-debt/active.md` 또는 없음 -->
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/src/app/(admin)/admin/sermons/_components/SermonFormShell.tsx
+++ b/src/app/(admin)/admin/sermons/_components/SermonFormShell.tsx
@@ -9,7 +9,7 @@ import { createSermonAction, updateSermonAction } from '@/actions/sermon.action'
 import { applyPatch } from '@/lib/sermon-form';
 import { useToastStore } from '@/store/toast.store';
 import { useAdminBreadcrumbStore } from '@/store/admin-breadcrumb.store';
-import type { Preacher, SeriesWithSermonCount } from '@/types/sermon';
+import type { PreacherWithSermonCount, SeriesWithSermonCount } from '@/types/sermon';
 import {
   INITIAL_SERMON_FORM_DATA,
   type SermonFormData,
@@ -22,7 +22,7 @@ interface SermonFormShellProps {
   sermonId?: number;
   initialTitle?: string;
   initialData?: SermonFormData;
-  preachers: Preacher[];
+  preachers: PreacherWithSermonCount[];
   series: SeriesWithSermonCount[];
 }
 

--- a/src/app/(content)/news/bulletins/_component/BulletinTable.tsx
+++ b/src/app/(content)/news/bulletins/_component/BulletinTable.tsx
@@ -10,16 +10,16 @@ import {
 } from '@tanstack/react-table';
 import { Pagination } from '@/components/ui';
 import { ITEM_PER_PAGE } from '@/constants/bulletin';
-import type { BulletinType } from '@/types/common';
+import type { BulletinWithImages } from '@/types/bulletin';
 import styles from './BulletinTable.module.scss';
 
 type BulletinTableProps = {
-  bulletins: BulletinType[] | null;
+  bulletins: BulletinWithImages[] | null;
   total: number;
   currentPage: number;
 };
 
-const columnHelper = createColumnHelper<BulletinType>();
+const columnHelper = createColumnHelper<BulletinWithImages>();
 
 export default function BulletinTable({ bulletins, total, currentPage }: BulletinTableProps) {
   // cell 콜백이 total·currentPage를 닫으므로 두 값이 바뀔 때만 재생성 (TanStack Table 안정 참조 권장)

--- a/src/app/(content)/news/bulletins/_component/BulletinTableSection.tsx
+++ b/src/app/(content)/news/bulletins/_component/BulletinTableSection.tsx
@@ -1,13 +1,13 @@
 import BulletinYearFilter from '@/app/(content)/news/bulletins/_component/BulletinYearFilter';
 import BulletinTable from '@/app/(content)/news/bulletins/_component/BulletinTable';
 import CreateBulletinButton from '@/app/(content)/news/bulletins/_component/CreateBulletinButton';
-import { BulletinType } from '@/types/common';
+import type { BulletinWithImages } from '@/types/bulletin';
 import styles from './BulletinTableSection.module.scss';
 
 type Props = {
   yearFilter?: number;
   years: number[];
-  bulletins: BulletinType[];
+  bulletins: BulletinWithImages[];
   total: number;
   currentPage: number;
 };

--- a/src/app/(content)/news/bulletins/_component/LatestBulletin.tsx
+++ b/src/app/(content)/news/bulletins/_component/LatestBulletin.tsx
@@ -6,7 +6,7 @@ import styles from './LastBulletin.module.scss';
 
 type Props = {
   title: string;
-  images: BulletinImageType[];
+  images: Pick<BulletinImageType, 'cloudinary_id'>[];
 };
 
 export default function LatestBulletin({ title, images }: Props) {

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -10,7 +10,7 @@ import { isNumeric } from '@/utils/validator';
 import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
 import { getOgImageUrl } from '@/utils/cloudinary';
 import { OG_FALLBACK_IMAGE } from '@/config/seo';
-import type { SermonCardItem, SermonWithRelations } from '@/types/sermon';
+import type { SeriesEpisodeItem, SermonCardItem, SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
 import SermonViewTracker from '../_component/SermonDetailPage/SermonViewTracker';
 
@@ -99,7 +99,7 @@ export default async function SermonDetail({ params }: PageProps) {
   const [seriesEpisodes, otherByPreacher] = await Promise.all([
     sermon.sermon_series?.slug
       ? getSermonsBySeries(sermon.sermon_series.slug)
-      : Promise.resolve([] as SermonWithRelations[]),
+      : Promise.resolve([] as SeriesEpisodeItem[]),
     sermon.preacher?.id
       ? getSermons({ preacherId: sermon.preacher.id, pageSize: 4 }).then((res) =>
           res.sermons.filter((s) => s.id !== sermon.id).slice(0, 3)

--- a/src/app/(content)/sermons/[id]/page.tsx
+++ b/src/app/(content)/sermons/[id]/page.tsx
@@ -10,7 +10,7 @@ import { isNumeric } from '@/utils/validator';
 import { formatPreacherLabel, getSermonThumbnail } from '@/utils/sermon';
 import { getOgImageUrl } from '@/utils/cloudinary';
 import { OG_FALLBACK_IMAGE } from '@/config/seo';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SermonCardItem, SermonWithRelations } from '@/types/sermon';
 import SermonDetailPage from '../_component/SermonDetailPage/SermonDetailPage';
 import SermonViewTracker from '../_component/SermonDetailPage/SermonViewTracker';
 
@@ -104,7 +104,7 @@ export default async function SermonDetail({ params }: PageProps) {
       ? getSermons({ preacherId: sermon.preacher.id, pageSize: 4 }).then((res) =>
           res.sermons.filter((s) => s.id !== sermon.id).slice(0, 3)
         )
-      : Promise.resolve([] as SermonWithRelations[])
+      : Promise.resolve([] as SermonCardItem[])
   ]);
 
   const otherSermonsByPreacher = otherByPreacher.length === 3 ? otherByPreacher : [];

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/EpisodeGrid.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/EpisodeGrid.tsx
@@ -1,10 +1,10 @@
 import { EmptyState } from '@/components/ui';
 import SeriesEpisodeCard from './SeriesEpisodeCard';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SeriesEpisodeItem } from '@/types/sermon';
 import styles from './SeriesDetailPage.module.scss';
 
 type Props = {
-  episodes: SermonWithRelations[];
+  episodes: SeriesEpisodeItem[];
 };
 
 export default function EpisodeGrid({ episodes }: Props) {

--- a/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesEpisodeCard.tsx
+++ b/src/app/(content)/sermons/_component/SeriesDetailPage/SeriesEpisodeCard.tsx
@@ -4,11 +4,11 @@ import CloudinaryImage from '@/components/common/CloudinaryImage';
 import { cloudinaryFetchUrl } from '@/utils/cloudinary';
 import { formattedDate } from '@/utils/date';
 import { formatSermonDuration, getSermonThumbnail } from '@/utils/sermon';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SeriesEpisodeItem } from '@/types/sermon';
 import styles from './SeriesDetailPage.module.scss';
 
 type Props = {
-  sermon: SermonWithRelations;
+  sermon: SeriesEpisodeItem;
   order: number;
 };
 

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -12,12 +12,12 @@ import {
   formatSermonDuration,
   getSermonThumbnail
 } from '@/utils/sermon';
-import type { SermonCardItem, SermonWithRelations } from '@/types/sermon';
+import type { SeriesEpisodeItem, SermonCardItem, SermonWithRelations } from '@/types/sermon';
 import styles from './SermonDetailPage.module.scss';
 
 type Props = {
   sermon: SermonWithRelations;
-  seriesEpisodes: SermonWithRelations[];
+  seriesEpisodes: SeriesEpisodeItem[];
   otherSermonsByPreacher: SermonCardItem[];
 };
 

--- a/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
+++ b/src/app/(content)/sermons/_component/SermonDetailPage/SermonDetailPage.tsx
@@ -12,13 +12,13 @@ import {
   formatSermonDuration,
   getSermonThumbnail
 } from '@/utils/sermon';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SermonCardItem, SermonWithRelations } from '@/types/sermon';
 import styles from './SermonDetailPage.module.scss';
 
 type Props = {
   sermon: SermonWithRelations;
   seriesEpisodes: SermonWithRelations[];
-  otherSermonsByPreacher: SermonWithRelations[];
+  otherSermonsByPreacher: SermonCardItem[];
 };
 
 export default function SermonDetailPage({

--- a/src/app/(content)/sermons/_component/SermonFeatured/SermonFeatured.tsx
+++ b/src/app/(content)/sermons/_component/SermonFeatured/SermonFeatured.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link';
 import { IoPlay } from 'react-icons/io5';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SermonCardItem } from '@/types/sermon';
 import { cloudinaryFetchUrl } from '@/utils/cloudinary';
 import { getSermonThumbnail, formatPreacherLabel, formatSermonDuration } from '@/utils/sermon';
 import { formattedDate } from '@/utils/date';
 import styles from './SermonFeatured.module.scss';
 
 type Props = {
-  sermon: SermonWithRelations | null;
+  sermon: SermonCardItem | null;
 };
 
 export default function SermonFeatured({ sermon }: Props) {

--- a/src/app/(content)/sermons/_component/SermonListPage/SermonFilteredList.tsx
+++ b/src/app/(content)/sermons/_component/SermonListPage/SermonFilteredList.tsx
@@ -1,10 +1,10 @@
 import GridCard from '../GridCard/GridCard';
 import { EmptyState } from '@/components/ui';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SermonCardItem } from '@/types/sermon';
 import styles from './SermonListPage.module.scss';
 
 type Props = {
-  sermons: SermonWithRelations[];
+  sermons: SermonCardItem[];
 };
 
 export default function SermonFilteredList({ sermons }: Props) {

--- a/src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.tsx
+++ b/src/app/(content)/sermons/_component/SermonOtherByPreacher/SermonOtherByPreacher.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { IoPlay } from 'react-icons/io5';
 import CloudinaryImage from '@/components/common/CloudinaryImage';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SermonCardItem } from '@/types/sermon';
 import { cloudinaryFetchUrl } from '@/utils/cloudinary';
 import { getSermonThumbnail } from '@/utils/sermon';
 import { formattedDate } from '@/utils/date';
@@ -10,7 +10,7 @@ import styles from './SermonOtherByPreacher.module.scss';
 
 type Props = {
   preacherLabel: string;
-  sermons: SermonWithRelations[];
+  sermons: SermonCardItem[];
 };
 
 export default function SermonOtherByPreacher({ preacherLabel, sermons }: Props) {
@@ -35,7 +35,7 @@ export default function SermonOtherByPreacher({ preacherLabel, sermons }: Props)
   );
 }
 
-function OtherCard({ sermon }: { sermon: SermonWithRelations }) {
+function OtherCard({ sermon }: { sermon: SermonCardItem }) {
   const thumb = cloudinaryFetchUrl(getSermonThumbnail(sermon));
 
   return (

--- a/src/app/(content)/sermons/_component/SermonRecentList/SermonRecentList.tsx
+++ b/src/app/(content)/sermons/_component/SermonRecentList/SermonRecentList.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link';
-import type { SermonWithRelations } from '@/types/sermon';
+import type { SermonCardItem } from '@/types/sermon';
 import GridCard from '../GridCard/GridCard';
 import styles from './SermonRecentList.module.scss';
 
 type Props = {
-  sermons: SermonWithRelations[];
+  sermons: SermonCardItem[];
 };
 
 export default function SermonRecentList({ sermons }: Props) {

--- a/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx
+++ b/src/app/(content)/sermons/_component/SermonSeriesSidebar/SermonSeriesSidebar.tsx
@@ -2,12 +2,12 @@ import Link from 'next/link';
 import clsx from 'clsx';
 import { formattedDate } from '@/utils/date';
 import { formatSermonDuration } from '@/utils/sermon';
-import type { SermonSeries, SermonWithRelations } from '@/types/sermon';
+import type { SermonSeries, SeriesEpisodeItem } from '@/types/sermon';
 import styles from './SermonSeriesSidebar.module.scss';
 
 type Props = {
   series: SermonSeries;
-  episodes: SermonWithRelations[];
+  episodes: SeriesEpisodeItem[];
   currentSermonId: number;
 };
 
@@ -56,7 +56,7 @@ export default function SermonSeriesSidebar({ series, episodes, currentSermonId 
 }
 
 type EpisodeRowProps = {
-  episode: SermonWithRelations;
+  episode: SeriesEpisodeItem;
   order: number;
   isCurrent: boolean;
 };

--- a/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
+++ b/src/components/admin/sermons/SermonForm/Preview/PreviewCard.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import { HiOutlineEye, HiOutlinePhotograph } from 'react-icons/hi';
 import { formattedDate } from '@/utils/date';
 import { formatPreacherLabel } from '@/utils/sermon';
-import type { Preacher, SeriesWithSermonCount } from '@/types/sermon';
+import type { PreacherWithSermonCount, SeriesWithSermonCount } from '@/types/sermon';
 import type { SermonFormData } from '@/types/sermon-form';
 import parent from '../index.module.scss';
 import styles from './preview.module.scss';
@@ -10,7 +10,7 @@ import styles from './preview.module.scss';
 interface PreviewCardProps {
   formData: SermonFormData;
   series: SeriesWithSermonCount[];
-  preachers: Preacher[];
+  preachers: PreacherWithSermonCount[];
 }
 
 export default function PreviewCard({ formData, series, preachers }: PreviewCardProps) {

--- a/src/components/admin/sermons/SermonForm/index.tsx
+++ b/src/components/admin/sermons/SermonForm/index.tsx
@@ -10,7 +10,7 @@ import ResourcesCard from './sections/ResourcesCard';
 import PublishCard from './sections/PublishCard';
 import PreviewCard from './Preview/PreviewCard';
 import Checklist from './Preview/Checklist';
-import type { Preacher, SeriesWithSermonCount } from '@/types/sermon';
+import type { PreacherWithSermonCount, SeriesWithSermonCount } from '@/types/sermon';
 import {
   type SermonFormData,
   type SermonFormPatch,
@@ -27,7 +27,7 @@ interface SermonFormProps {
   onCancel: () => void;
   isPending: boolean;
   publishLabel: string;
-  preachers: Preacher[];
+  preachers: PreacherWithSermonCount[];
   series: SeriesWithSermonCount[];
 }
 

--- a/src/components/admin/sermons/SermonListPage/index.tsx
+++ b/src/components/admin/sermons/SermonListPage/index.tsx
@@ -14,7 +14,7 @@ import { getTotalPages } from '@/utils/pagination';
 import type {
   AdminSermon,
   AdminSermonListParams,
-  Preacher,
+  PreacherWithSermonCount,
   SeriesWithSermonCount,
   SermonStatusTab
 } from '@/types/sermon';
@@ -35,7 +35,7 @@ interface SermonListPageProps {
   total: number;
   statusCounts: Record<SermonStatusTab, number>;
   initialParams: AdminSermonListParams;
-  preachers: Preacher[];
+  preachers: PreacherWithSermonCount[];
   series: SeriesWithSermonCount[];
 }
 

--- a/src/components/admin/sermons/SermonListPage/parts/ActiveFilters.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/ActiveFilters.tsx
@@ -2,7 +2,7 @@
 
 import { HiX } from 'react-icons/hi';
 import { NONE_SERIES_ID } from '@/lib/utils/sermon-filter';
-import type { Preacher, SeriesWithSermonCount } from '@/types/sermon';
+import type { PreacherWithSermonCount, SeriesWithSermonCount } from '@/types/sermon';
 import styles from '../index.module.scss';
 
 interface ActiveFiltersProps {
@@ -11,7 +11,7 @@ interface ActiveFiltersProps {
   series: string[];
   dateFrom: string;
   dateTo: string;
-  preachersData: Preacher[];
+  preachersData: PreacherWithSermonCount[];
   seriesData: SeriesWithSermonCount[];
   onRemovePreacher: (id: string) => void;
   onRemoveSeries: (id: string) => void;

--- a/src/components/admin/sermons/SermonListPage/parts/PreacherFilter.tsx
+++ b/src/components/admin/sermons/SermonListPage/parts/PreacherFilter.tsx
@@ -1,10 +1,10 @@
 import FilterDropdown from './FilterDropdown';
 import DropdownItem from './DropdownItem';
-import type { Preacher } from '@/types/sermon';
+import type { PreacherWithSermonCount } from '@/types/sermon';
 import dropdownStyles from '../dropdown.module.scss';
 
 interface PreacherFilterProps {
-  preachers: Preacher[];
+  preachers: PreacherWithSermonCount[];
   selected: string[];
   onToggle: (id: string) => void;
   isOpen: boolean;

--- a/src/services/bulletin/bulletin-service.ts
+++ b/src/services/bulletin/bulletin-service.ts
@@ -10,14 +10,18 @@ import type {
   BulletinWithImages
 } from '@/types/bulletin';
 
-/** list·summary가 공유하는 목록 쿼리 — 연도 필터 + 최신순 + 페이지 range */
+/** 목록·상세 공용 셀렉트 — BulletinWithImages와 1:1 대조 유지 (P5, content 등 미사용 컬럼 제외) */
+const BULLETIN_WITH_IMAGES_SELECT =
+  'id, title, sunday_date, created_at, author_id, bulletin_images(id, cloudinary_id, order_index)';
+
+/** summary가 쓰는 목록 쿼리 — 연도 필터 + 최신순 + 페이지 range */
 const listQuery = (
   supabase: SupabaseClient<Database>,
   { year, page = 1, limit = 10 }: BulletinParams = {}
 ) => {
   let query = supabase
     .from(BULLETIN_BUCKET)
-    .select('*, bulletin_images(*)', { count: 'exact' })
+    .select(BULLETIN_WITH_IMAGES_SELECT, { count: 'exact' })
     .is('deleted_at', null)
     .order('sunday_date', { ascending: false });
 
@@ -33,19 +37,13 @@ const listQuery = (
 const latestQuery = (supabase: SupabaseClient<Database>) =>
   supabase
     .from(BULLETIN_BUCKET)
-    .select('*, bulletin_images(*)')
+    .select(BULLETIN_WITH_IMAGES_SELECT)
     .is('deleted_at', null)
     .order('sunday_date', { ascending: false })
     .limit(1)
     .maybeSingle();
 
 export const bulletinService = (supabase: SupabaseClient<Database>) => ({
-  list: async (params: BulletinParams = {}) => {
-    const res = await listQuery(supabase, params);
-
-    return handleResponse(res);
-  },
-
   allIds: async () => {
     const res = await supabase
       .from(BULLETIN_BUCKET)
@@ -59,7 +57,7 @@ export const bulletinService = (supabase: SupabaseClient<Database>) => ({
   detailById: async (id: string) => {
     const res = await supabase
       .from(BULLETIN_BUCKET)
-      .select('*, bulletin_images(*)')
+      .select(BULLETIN_WITH_IMAGES_SELECT)
       .eq('id', Number(id))
       .is('deleted_at', null)
       .single();

--- a/src/services/bulletin/index.ts
+++ b/src/services/bulletin/index.ts
@@ -6,15 +6,6 @@ import { createServerSideClient } from '@/lib/supabase/server';
 import { createStaticClient } from '@/lib/supabase/static';
 import type { BulletinEditFormParams, BulletinFormParams, BulletinParams } from '@/types/bulletin';
 
-/**
- *
- * @deprecated
- */
-export const getBulletinList = (params: BulletinParams = {}) => {
-  const supabase = createStaticClient(bulletinCache.list());
-  return bulletinService(supabase).list(params);
-};
-
 export const getBulletinSummary = (params: BulletinParams) => {
   const supabase = createStaticClient(bulletinCache.summary());
   return bulletinService(supabase).summary(params);

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -8,6 +8,7 @@ import type {
   SermonWithRelations,
   SermonListItem,
   SermonCardItem,
+  SeriesEpisodeItem,
   SeriesWithSermonCount,
   SeriesDetail,
   PreacherWithSermonCount,
@@ -44,6 +45,12 @@ const SERMON_CARD_SELECT = `
   title, scripture, service_type, summary, duration,
   preacher:preachers(name, title),
   sermon_series(id, slug, title)
+`;
+
+/** 시리즈 회차 전용 셀렉트 — SeriesEpisodeItem과 1:1, 관계 join 없음 (P5) */
+const SERIES_EPISODE_SELECT = `
+  id, series_order, sermon_date, video_id, video_provider, thumbnail_url,
+  title, scripture, duration
 `;
 
 const ADMIN_SERMON_SELECT = `
@@ -153,7 +160,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
 
     const res = await supabase
       .from('sermons')
-      .select(SERMON_WITH_RELATIONS_SELECT)
+      .select(SERIES_EPISODE_SELECT)
       .eq('series_id', seriesHandled.data.id)
       .eq('is_published', true)
       .is('deleted_at', null)
@@ -161,7 +168,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
       .order('sermon_date', { ascending: true });
 
     const handled = handleResponse(res);
-    return (handled.data ?? []) as unknown as SermonWithRelations[];
+    return (handled.data ?? []) as unknown as SeriesEpisodeItem[];
   },
 
   /**
@@ -182,7 +189,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
 
     const res = await supabase
       .from('sermons')
-      .select(SERMON_WITH_RELATIONS_SELECT)
+      .select(SERIES_EPISODE_SELECT)
       .eq('series_id', id)
       .eq('is_published', true)
       .is('deleted_at', null)
@@ -190,7 +197,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
       .order('sermon_date', { ascending: true });
 
     const handled = handleResponse(res);
-    const episodes = (handled.data ?? []) as unknown as SermonWithRelations[];
+    const episodes = (handled.data ?? []) as unknown as SeriesEpisodeItem[];
     const seriesRow = seriesHandled.data as unknown as SeriesWithSermonCount;
 
     return {

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -130,11 +130,11 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
     return (handled.data as unknown as SermonWithRelations | null) ?? null;
   },
 
-  /** 활성 시리즈 전체를 published + 미삭제 설교 개수와 함께 조회 */
+  /** 활성 시리즈 전체를 published + 미삭제 설교 개수와 함께 조회 — 소비처 union 컬럼만 (P5) */
   allSeries: async (): Promise<SeriesWithSermonCount[]> => {
     const res = await supabase
       .from('sermon_series')
-      .select('*, sermons!inner(count)')
+      .select('id, slug, title, description, cover_image_url, started_at, ended_at, sermons!inner(count)')
       .eq('is_active', true)
       .eq('sermons.is_published', true)
       .is('sermons.deleted_at', null)
@@ -213,7 +213,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
   allPreachers: async (): Promise<PreacherWithSermonCount[]> => {
     const res = await supabase
       .from('preachers')
-      .select('*, sermons!inner(count)')
+      .select('id, name, title, sermons!inner(count)')
       .eq('is_active', true)
       .eq('sermons.is_published', true)
       .is('sermons.deleted_at', null)

--- a/src/services/sermon/sermon-service.ts
+++ b/src/services/sermon/sermon-service.ts
@@ -7,6 +7,7 @@ import type {
   SermonListParams,
   SermonWithRelations,
   SermonListItem,
+  SermonCardItem,
   SeriesWithSermonCount,
   SeriesDetail,
   PreacherWithSermonCount,
@@ -35,6 +36,14 @@ const SERMON_LIST_ITEM_SELECT = `
   id, slug, sermon_date, video_id, video_provider, thumbnail_url,
   title, scripture, service_type,
   preacher:preachers(name, title)
+`;
+
+/** 목록 카드 전용 셀렉트 — SermonCardItem과 1:1 (slug·summary는 의도적 superset, P5) */
+const SERMON_CARD_SELECT = `
+  id, slug, sermon_date, video_id, video_provider, thumbnail_url,
+  title, scripture, service_type, summary, duration,
+  preacher:preachers(name, title),
+  sermon_series(id, slug, title)
 `;
 
 const ADMIN_SERMON_SELECT = `
@@ -79,7 +88,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
   }: SermonListParams = {}) => {
     let query = supabase
       .from('sermons')
-      .select(SERMON_WITH_RELATIONS_SELECT, { count: 'exact' })
+      .select(SERMON_CARD_SELECT, { count: 'exact' })
       .eq('is_published', true)
       .is('deleted_at', null)
       .order('sermon_date', { ascending: sort === 'oldest' });
@@ -106,7 +115,7 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
     const res = await query.range(from, to);
     const handled = handleResponse(res);
 
-    const sermons = (handled.data ?? []) as unknown as SermonWithRelations[];
+    const sermons = (handled.data ?? []) as unknown as SermonCardItem[];
     const total = handled.count ?? 0;
 
     return {
@@ -114,20 +123,6 @@ export const sermonService = (supabase: SupabaseClient<Database>) => ({
       total,
       hasMore: from + sermons.length < total
     };
-  },
-
-  /** slug로 설교 상세(설교자·시리즈·리소스 포함) 조회 */
-  detailBySlug: async (slug: string) => {
-    const res = await supabase
-      .from('sermons')
-      .select(SERMON_WITH_RELATIONS_SELECT)
-      .eq('slug', slug)
-      .eq('is_published', true)
-      .is('deleted_at', null)
-      .maybeSingle();
-
-    const handled = handleResponse(res);
-    return (handled.data as unknown as SermonWithRelations | null) ?? null;
   },
 
   /** 활성 시리즈 전체를 published + 미삭제 설교 개수와 함께 조회 — 소비처 union 컬럼만 (P5) */

--- a/src/types/bulletin.ts
+++ b/src/types/bulletin.ts
@@ -6,7 +6,6 @@ export type BulletinWithImages = Pick<
   'id' | 'title' | 'sunday_date' | 'created_at' | 'author_id'
 > & {
   bulletin_images: Pick<BulletinImageType, 'id' | 'cloudinary_id' | 'order_index'>[];
-  profiles?: { display_name: string | null } | null;
 };
 
 export type BulletinParams = { year?: number; page?: number; limit?: number };

--- a/src/types/bulletin.ts
+++ b/src/types/bulletin.ts
@@ -1,7 +1,11 @@
 import { BulletinImageType, BulletinType } from '@/types/common';
 
-export type BulletinWithImages = BulletinType & {
-  bulletin_images: BulletinImageType[];
+/** 목록·상세 소비처가 실제 읽는 필드 union — BULLETIN_WITH_IMAGES_SELECT와 1:1 대조 유지 (P5) */
+export type BulletinWithImages = Pick<
+  BulletinType,
+  'id' | 'title' | 'sunday_date' | 'created_at' | 'author_id'
+> & {
+  bulletin_images: Pick<BulletinImageType, 'id' | 'cloudinary_id' | 'order_index'>[];
   profiles?: { display_name: string | null } | null;
 };
 

--- a/src/types/sermon-form.ts
+++ b/src/types/sermon-form.ts
@@ -1,5 +1,5 @@
 import type { Database } from '@/types/database.types';
-import type { Preacher, SeriesWithSermonCount, ServiceType } from '@/types/sermon';
+import type { PreacherWithSermonCount, SeriesWithSermonCount, ServiceType } from '@/types/sermon';
 
 export type SermonResourceType = Database['public']['Enums']['sermon_resource_type'];
 
@@ -54,7 +54,7 @@ export type BasicInfoCardProps = Pick<
   SermonFormData,
   'title' | 'sermonDate' | 'preacherId' | 'seriesId' | 'serviceType'
 > & {
-  preachers: Preacher[];
+  preachers: PreacherWithSermonCount[];
   series: SeriesWithSermonCount[];
   onChange: (patch: SermonFormPatch) => void;
 };

--- a/src/types/sermon.ts
+++ b/src/types/sermon.ts
@@ -32,6 +32,20 @@ export type SermonCardItem = SermonListItem &
     sermon_series: Pick<SermonSeries, 'id' | 'slug' | 'title'> | null;
   };
 
+/** 시리즈 회차 전용 — 회차 카드·사이드바가 읽는 스칼라만, 관계 join 없음 (P5) */
+export type SeriesEpisodeItem = Pick<
+  Sermon,
+  | 'id'
+  | 'series_order'
+  | 'sermon_date'
+  | 'video_id'
+  | 'video_provider'
+  | 'thumbnail_url'
+  | 'title'
+  | 'scripture'
+  | 'duration'
+>;
+
 /** 공개·admin 소비처가 실제 읽는 필드 union — allSeries 셀렉트와 1:1 대조 유지 (P5) */
 export type SeriesWithSermonCount = Pick<
   SermonSeries,
@@ -41,7 +55,7 @@ export type SeriesWithSermonCount = Pick<
 /** 시리즈 상세 페이지: 시리즈 단건 + 회차(설교) */
 export type SeriesDetail = {
   series: SeriesWithSermonCount;
-  episodes: SermonWithRelations[];
+  episodes: SeriesEpisodeItem[];
 };
 
 /** 소비처가 실제 읽는 필드 union — allPreachers 셀렉트와 1:1 대조 유지 (P5) */

--- a/src/types/sermon.ts
+++ b/src/types/sermon.ts
@@ -32,7 +32,11 @@ export type SermonCardItem = SermonListItem &
     sermon_series: Pick<SermonSeries, 'id' | 'slug' | 'title'> | null;
   };
 
-export type SeriesWithSermonCount = SermonSeries & { sermon_count: number };
+/** 공개·admin 소비처가 실제 읽는 필드 union — allSeries 셀렉트와 1:1 대조 유지 (P5) */
+export type SeriesWithSermonCount = Pick<
+  SermonSeries,
+  'id' | 'slug' | 'title' | 'description' | 'cover_image_url' | 'started_at' | 'ended_at'
+> & { sermon_count: number };
 
 /** 시리즈 상세 페이지: 시리즈 단건 + 회차(설교) */
 export type SeriesDetail = {
@@ -40,7 +44,10 @@ export type SeriesDetail = {
   episodes: SermonWithRelations[];
 };
 
-export type PreacherWithSermonCount = Preacher & { sermon_count: number };
+/** 소비처가 실제 읽는 필드 union — allPreachers 셀렉트와 1:1 대조 유지 (P5) */
+export type PreacherWithSermonCount = Pick<Preacher, 'id' | 'name' | 'title'> & {
+  sermon_count: number;
+};
 
 export type SermonSortKey = 'recent' | 'oldest';
 

--- a/src/utils/sermon.ts
+++ b/src/utils/sermon.ts
@@ -57,7 +57,7 @@ export function resolveSeriesSlug(
  */
 export function resolvePreacherName(
   name: string | undefined,
-  allPreachers: Preacher[],
+  allPreachers: Pick<Preacher, 'id' | 'name'>[],
 ): string | undefined {
   if (!name) return undefined;
   const found = allPreachers.find((preacher) => preacher.name === name);


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 목록·회차·주보 쿼리가 상세 페이지용 넓은 셀렉트를 같이 쓰면서 화면이 안 쓰는 컬럼까지 받아오던 것을, 실제 쓰는 컬럼만 조회하도록 줄인다. 같은 시도가 PR #91에서 화면 깨짐으로 전부 되돌려진 적이 있어, 이번에는 **컬럼을 빠뜨리면 빌드가 실패하도록 타입부터 좁힌 뒤** 진행했다.

**범위**:

- 경로별 전용 셀렉트 신설(`SERMON_CARD_SELECT`·`SERIES_EPISODE_SELECT`)과 주보·시리즈·설교자 셀렉트 컬럼 명시
- 공유 타입을 소비처 union Pick으로 축소(`SermonCardItem`·`SeriesEpisodeItem`·`BulletinWithImages` 등)
- 죽은 코드 3건 제거(`detailBySlug`·`getBulletinList`+`list()`·`profiles?` 필드)

---

## 🔗 개발 컨텍스트

- **Task ID**: `p5-select-narrowing`
- **Exec Plan**: `docs/exec-plans/active/2026-07-02-p5-select-narrowing.md`
- **관련 ADR**: 해당 없음 (레이어 서열·캐시·인증·데이터 흐름 불변)
- **관련 tech debt**: 해당 없음
- **작업 범위**: 목록·회차·주보 셀렉트/타입 축소, 소비처 prop 타입 교체, 죽은 쿼리 삭제
- **제외한 범위**: 상세·폼 셀렉트(`detailById`·`getSermonForEdit`), admin 쿼리, count 임베드 문법 통일, DB 스키마

---

## 💡 리팩토링 배경 (Motivation)

**이 작업은 PR #91에서 전면 revert된 셀렉트 축소의 재도전이다.**

PR #91은 Gemini 제안으로 `getAllSeries`의 셀렉트 컬럼을 줄였다. 그런데 소비처 감사가 `/sermons` 시리즈 캐러셀과 admin 폼을 놓쳐 `cover_image_url`이 빠졌다. Codex 1차 검증이 이 회귀를 잡아 PR 전체를 되돌렸고, "공유 쿼리를 줄이기 전에 소비처를 전수 확인한다"는 교훈만 남았다.

돌아보면 진짜 문제는 한 곳을 빠뜨린 실수 자체가 아니다. 어떤 화면이 어떤 컬럼을 읽는지 **사람이 눈으로 찾아 확인하는 것 말고는 검사 수단이 없었다**는 것이다. #91은 조회 컬럼만 줄이고 타입 선언은 모든 컬럼을 가진 채로 뒀다. 타입상으로는 필드가 있으니, 실제 응답에 그 필드가 없어도 빌드는 아무 에러 없이 통과했다.

사람이 하는 전수 확인은 또 빠뜨릴 수 있다. 그래서 이번에는 빠뜨리면 빌드가 실패하게 만드는 장치를 먼저 넣었다.

**개선하려는 문제:**

- [x] 성능 병목 (목록 응답이 카드가 안 쓰는 필드까지 실어 나름)
- [x] 유지보수 난이도 증가 (넓은 셀렉트가 소비처 요구와 안 맞음)
- [x] 기술 부채 해소 (죽은 쿼리·죽은 타입 필드 3건)
- [x] 기타: PR #91 회귀의 구조적 재발 방지

**관련 이슈:**

- 선행 PR #91 (revert됨)

---

## 🔧 주요 변경점 (Key Changes)

순서를 바꿨다. 조회 컬럼(셀렉트)을 먼저 줄이는 대신, **타입 선언을 "화면이 실제 읽는 필드 목록"으로 먼저 줄였다.** 이렇게 하면 줄어든 타입에 없는 필드를 읽는 코드가 어딘가에 남아 있을 때 그 자리에서 빌드가 실패한다.

실제로 타입을 좁히자 Preacher 전체 행을 기대하던 8곳과 주보 prop 3곳에서 빌드 에러가 났고, 전부 실제 사용 필드 타입으로 바꿨다. #91처럼 확인에서 빠진 화면이 있었다면 같은 방식으로 여기서 드러났을 것이다.

다만 이 장치가 못 잡는 경우가 하나 있다. 서비스 층이 응답을 `as unknown as`로 타입 단언하기 때문에, 반대 방향 — 조회 컬럼이 타입보다 적은 경우(타입에는 있는데 실제 응답에는 없는 필드) — 는 빌드가 그대로 통과한다. Codex 계획 검증이 이 경우를 CHANGE_REQUEST로 짚었다.

그래서 셀렉트 컬럼 목록과 타입 필드 목록을 하나씩 맞대보는 1:1 대조표를 성공 기준으로 넣었다. 이 대조가 실전에서 `BulletinWithImages`의 죽은 `profiles?` 필드 1건(타입에만 있고 어떤 쿼리도 안 채움)을 잡아 제거했다(687434f). 정리하면 — 빠뜨린 화면은 빌드 에러로, 빠뜨린 컬럼은 대조표로 각각 확인한다.

소비처는 세 번 확인했다. explorer 전수 맵(도구 호출 68회)으로 훑고, Claude가 직접 재검증하고, Codex가 spread·동적 접근·admin 쿼리까지 독립으로 다시 봤다. #91에서 유실됐던 `cover_image_url`은 `SeriesCard`가 읽는 것을 확인해 명시적으로 남겼다.

**셀렉트·타입 변경:**

- 설교 목록: `list()`가 상세용 `SERMON_WITH_RELATIONS_SELECT` 공유를 끊고 `SERMON_CARD_SELECT`로 전환, 타입은 기존 `SermonCardItem` 재사용. 소비처 6곳 prop 교체 (8e897de)
- 시리즈 회차: `bySeriesSlug`·`bySeriesId`의 episodes를 `SERIES_EPISODE_SELECT`(스칼라 9개)로 좁히고 `SeriesEpisodeItem` 신설, 관계 join 3종(preacher·sermon_series·sermon_resources) 제거. 소비처 5곳 교체 (497055d)
- 주보: `BULLETIN_WITH_IMAGES_SELECT`를 스칼라 5 + images 3으로 축소, `BulletinWithImages` 동반 축소. 테이블·최신 주보 prop 3곳 교체 (581c1d0)
- 시리즈/설교자 전체: `getAllSeries`·`getAllPreachers` 셀렉트에 컬럼 명시, 타입을 union Pick으로 축소. `cover_image_url` 유지 (#91 회귀 필드) (41a5973)

**죽은 코드 제거 (3건):**

- `sermonService.detailBySlug` — 호출 0, wrapper 없음 (8e897de)
- `getBulletinList` + `bulletinService.list()` — deprecated, summary는 listQuery 직접 사용 (581c1d0)
- `BulletinWithImages.profiles?` — 어떤 쿼리도 안 채우는 죽은 필드 (687434f)

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 회귀 방어 순서 | 타입을 소비처 union Pick으로 먼저 좁힘 | - 넓은 행을 기대하던 소비처가 컴파일 에러로 드러남<br>- #91은 셀렉트만 좁히고 타입을 남겨 조용히 통과했음 | 셀렉트만 좁히고 타입 유지 — #91에서 `cover_image_url` 유실로 revert |
| 셀렉트 재사용 vs 신설 | 상세는 기존 상수 유지, 목록·회차에 전용 셀렉트 신설 | - 상세는 전 필드가 필요<br>- `recent()`가 이미 같은 전용 셀렉트 선례 | 공유 상수 직접 축소 — 상세 경로가 깨짐 (2026-05-15에도 같은 이유로 보류) |
| 목록 타입 신설 여부 | 기존 `SermonCardItem` 재사용, `slug`·`summary`는 의도적 superset | - 새 타입은 `GridCard` 등 prop 연쇄 수정 유발<br>- 두 필드는 짧은 문자열이라 payload 비용 미미 | 딱 맞는 새 타입 신설 — 연쇄 수정 대비 이득 작음 |
| count 임베드 문법 | `sermons!inner(count)` 기존 문법 유지 | - 문법 변경은 축소 범위 밖 인접 변경<br>- REST 실측으로 응답 shape 확인 | 괄호 count 문법으로 통일 — 외과적 범위 초과 |

> ⚠️ **주의사항:** 서비스의 `as unknown as` 타입 단언이 남아 있는 한, 조회 컬럼이 타입보다 적어지는 변경은 빌드가 못 잡는다. 이 셀렉트들을 앞으로 손댈 때는 1:1 대조표를 함께 갱신해야 한다.

**변경 전 구조:**

목록·회차·주보가 상세용 넓은 셀렉트를 공유하고, 타입도 전 필드로 넓었다. 셀렉트를 줄여도 타입이 넓어 컴파일러가 소비처 누락을 못 잡는다.

**변경 후 구조:**

경로별 전용 셀렉트 + 실제 사용 필드만 담은 타입으로 나뉜다. 빠뜨린 사용처는 빌드 에러로, 빠뜨린 조회 컬럼은 1:1 대조표로 드러난다.

---

## 📊 개선 지표 (Improvement Metrics)

**응답 페이로드** (dev REST 실측, 같은 필터로 old/new 셀렉트 응답 바이트):

| 쿼리 | Before | After | 감소 |
| --- | --- | --- | --- |
| A. 설교 목록 (published 9행, limit 12) | 6,915 B | 2,308 B | **-66.6%** |
| B. 시리즈 회차 | 1,203 B | 189 B | **-84.3%** |
| C. 주보 목록 (limit 10) | 466 B | 302 B | -35.2% |
| D-1. 시리즈 전체 | 349 B | 258 B | -26.1% |
| D-2. 설교자 전체 | 554 B | 227 B | -59.0% |

지금 데이터 규모에서는 절감폭이 KB 단위다. 다만 설교가 누적될수록 목록 응답의 절대 바이트가 함께 줄어드는 구조라, 데이터가 커질수록 이득이 커진다.

**죽은 코드·미사용 export:**

| 항목 | Before | After |
| --- | --- | --- |
| 죽은 쿼리/타입 필드 | 3건 | 0건 |
| knip 미사용 export | 28 | 27 |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs p5-select-narrowing` — PASS ×2, 최종 RUN_ID=`20260703-052852`, failed=0, warned=Knip |
| `harness-gate` | `node scripts/harness-gate.mjs p5-select-narrowing` — PASS |
| Codex 계획 검증 | CHANGE_REQUEST(high) → 반영 (셀렉트↔Pick 1:1 대조표를 성공 기준에 추가). 필드 union A~D는 Codex 독립 재검증에서 전부 CONFIRMED |
| Codex 1차 검증 | CHANGE_REQUEST(high) → 반영 (687434f — 죽은 `profiles?` 필드 제거). 나머지 대조 4/4 일치, 레이어·외과적 변경 위반 0 |
| Claude 2차 검증 | 완료 — dev 실측 8라우트 (`/sermons` 캐러셀 cover 키 REST 확인·주보 목록/상세·홈·admin 필터/폼 포함) |
| ADR 판단 | 불필요 (레이어·캐시·인증 불변, `recent()` 선례 반복) |
| 남은 warning | 기존 부채 (Knip 27건) |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**리팩토링 완성도**

- [x] 외부 동작(기능, API 인터페이스) 변경 없음 확인 — dev 8라우트 실측 통과
- [x] 불필요한 기능 변경 미포함 확인 — 셀렉트/타입 축소와 죽은 코드 삭제만

**코드 품질**

- [x] 변수명·함수명의 의도 명확성 — `SERMON_CARD_SELECT`·`SeriesEpisodeItem` 등 용도 드러남
- [x] 불필요한 코드·디버그 로그 제거 여부 — 죽은 쿼리 3건 제거

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 없음 — 화면 동작 불변, 응답 페이로드만 축소
- **운영 리스크**: 없음 — DB 스키마·캐시 태그·인증·레이어 서열 모두 불변
- **QA 후속**: 없음 — dev 8라우트 실측 완료
- **롤백 시 영향**: 없음 — 셀렉트·타입만 변경, 스키마 무변경
- **먼저 볼 화면 / 흐름**: `/sermons` 시리즈 캐러셀 cover 이미지 (#91 회귀 지점) → `/sermons/[id]` 자료 다운로드 → `/news/bulletins` 최신 주보 이미지

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- `as unknown as` 타입 단언 때문에 "조회 컬럼이 타입보다 적은" 변경은 빌드가 잡지 못한다. 이번에는 1:1 대조표로 확인했으니, 이 셀렉트들을 앞으로 손댈 때도 대조표를 함께 갱신할 것.
- 남은 축소 후보(Non-goals): 상세·폼 셀렉트, admin 쿼리(`getAdminSeries`/`getAdminPreachers`), `sermons!inner(count)` 문법 통일, `summary()` 이미지 join 분리. 이번 범위 밖으로 뒀다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
