### PR TITLE
[Feat] 소식 갤러리 나눔 피드 화면 (읽기 전용·mock)

### DIFF
--- a/src/app/(content)/news/gallery/_component/Avatar.tsx
+++ b/src/app/(content)/news/gallery/_component/Avatar.tsx
@@ -1,0 +1,20 @@
+import styles from './gallery.module.scss';
+
+type Props = {
+  initial: string;
+  // 성도별 아바타 배경색(데이터값). 테마 토큰이 아니라 Member.avatarColor에 해당해 inline으로 적용한다.
+  color: string;
+  size: 'lg' | 'sm';
+};
+
+export default function Avatar({ initial, color, size }: Props) {
+  return (
+    <span
+      className={size === 'lg' ? styles.avatar_lg : styles.avatar_sm}
+      style={{ backgroundColor: color }}
+      aria-hidden="true"
+    >
+      {initial}
+    </span>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryComposer.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryComposer.tsx
@@ -1,0 +1,17 @@
+import { LuCamera } from 'react-icons/lu';
+import styles from './gallery.module.scss';
+
+// 목업의 작성 입력 바 — 읽기 전용 단계라 표시용(비인터랙티브). 실제 작성 흐름은 후속 단계.
+export default function GalleryComposer() {
+  return (
+    <div className={styles.composer}>
+      <span className={styles.composer_avatar} aria-hidden="true">
+        나
+      </span>
+      <span className={styles.composer_placeholder}>은혜의 순간을 나눠보세요</span>
+      <span className={styles.composer_camera} aria-hidden="true">
+        <LuCamera />
+      </span>
+    </div>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryFeed.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryFeed.tsx
@@ -1,0 +1,17 @@
+import GalleryPostCard from './GalleryPostCard';
+import type { GalleryPost } from '../_types';
+import styles from './gallery.module.scss';
+
+export default function GalleryFeed({ posts }: { posts: GalleryPost[] }) {
+  if (posts.length === 0) {
+    return <p className={styles.empty}>조건에 맞는 순간이 없어요</p>;
+  }
+
+  return (
+    <div className={styles.feed}>
+      {posts.map((post) => (
+        <GalleryPostCard key={post.id} post={post} />
+      ))}
+    </div>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryPhotos.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPhotos.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useRef } from 'react';
+import { Gallery, Item } from 'react-photoswipe-gallery';
+import clsx from 'clsx';
+import { LuImages } from 'react-icons/lu';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import cloudinaryLoader, { cloudinaryFetchUrl } from '@/utils/cloudinary';
+import { BASE_PHOTOSWIPE_OPTIONS, isBackgroundTarget } from '@/utils/photoswipe';
+import PhotoSwipeType, { type PhotoSwipeOptions } from 'photoswipe';
+import type { GalleryPhoto } from '../_types';
+import styles from './gallery.module.scss';
+// 라이트박스 CSS — 이 컴포넌트가 실리는 라우트에만 로드(전역 오염 방지).
+import 'photoswipe/dist/photoswipe.css';
+
+// 사진 수별 그리드 배치. mock은 최대 4장 — 5장 이상은 3열로 모두 노출(실데이터 단계에서 +N 접기 검토).
+function layoutClass(count: number): string {
+  if (count === 1) return styles.media_single;
+  if (count === 2) return styles.media_two;
+  if (count === 3) return styles.media_three;
+  if (count === 4) return styles.media_four;
+  return styles.media_many;
+}
+
+export default function GalleryPhotos({ photos }: { photos: GalleryPhoto[] }) {
+  const pswpRef = useRef<PhotoSwipeType | null>(null);
+
+  const options: PhotoSwipeOptions = {
+    ...BASE_PHOTOSWIPE_OPTIONS,
+    tapAction: (_, originalEvent) => {
+      const target = originalEvent?.target;
+      if (target instanceof HTMLElement && isBackgroundTarget(target)) {
+        pswpRef.current?.close();
+      } else {
+        pswpRef.current?.element?.classList.toggle('pswp--ui-visible');
+      }
+    }
+  };
+
+  return (
+    <Gallery options={options} onBeforeOpen={(pswp) => (pswpRef.current = pswp)}>
+      <div className={clsx(styles.media, layoutClass(photos.length))}>
+        {photos.map((photo, index) => {
+          const src = cloudinaryFetchUrl(photo.remoteUrl) ?? photo.remoteUrl;
+          const original = cloudinaryLoader({ src, width: 1600 });
+
+          return (
+            <Item
+              key={photo.remoteUrl + index}
+              original={original}
+              thumbnail={original}
+              width={photo.width}
+              height={photo.height}
+            >
+              {({ ref, open }) => (
+                <button
+                  type="button"
+                  ref={ref as React.Ref<HTMLButtonElement>}
+                  className={styles.media_tile}
+                  onClick={open}
+                  aria-label={`${index + 1}번째 사진 크게 보기`}
+                >
+                  <CloudinaryImage
+                    src={src}
+                    alt={`갤러리 사진 ${index + 1}`}
+                    fill
+                    sizes="(max-width: 640px) 50vw, 320px"
+                  />
+                </button>
+              )}
+            </Item>
+          );
+        })}
+
+        {photos.length > 1 && (
+          <span className={styles.count_badge}>
+            <LuImages aria-hidden="true" />
+            {photos.length}
+          </span>
+        )}
+      </div>
+    </Gallery>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryPostCard.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPostCard.tsx
@@ -1,0 +1,75 @@
+import clsx from 'clsx';
+import type { IconType } from 'react-icons';
+import { LuSun, LuHeart, LuFlame, LuSparkles, LuMessageCircle } from 'react-icons/lu';
+import Avatar from './Avatar';
+import GalleryPhotos from './GalleryPhotos';
+import { REACTION_TYPES, type GalleryPost, type ReactionType } from '../_types';
+import styles from './gallery.module.scss';
+
+// 교회형 반응 아이콘 매핑 (읽기 전용 표시).
+const REACTION_ICON: Record<ReactionType, IconType> = {
+  은혜: LuSun,
+  아멘: LuHeart,
+  기도해요: LuFlame,
+  축복: LuSparkles
+};
+
+export default function GalleryPostCard({ post }: { post: GalleryPost }) {
+  return (
+    <article className={styles.card}>
+      <header className={styles.head}>
+        <Avatar initial={post.avatarInitial} color={post.avatarColor} size="lg" />
+        <div className={styles.head_text}>
+          <b className={styles.author}>{post.authorName}</b>
+          <span className={styles.meta}>
+            {post.department} · {post.createdLabel}
+          </span>
+        </div>
+      </header>
+
+      {post.photos.length > 0 && <GalleryPhotos photos={post.photos} />}
+
+      {post.text && <p className={styles.caption}>{post.text}</p>}
+
+      {/* 반응은 읽기 전용 표시 — 카운트만 보여주고 토글은 후속 단계. */}
+      <div className={styles.reactions}>
+        {REACTION_TYPES.map((type) => {
+          const Icon = REACTION_ICON[type];
+          const active = post.viewerReaction === type;
+
+          return (
+            <span key={type} className={clsx(styles.reaction, active && styles.reaction_on)}>
+              <Icon className={styles.reaction_icon} aria-hidden="true" />
+              <span className={styles.reaction_label}>{type}</span>
+              <span className={styles.reaction_count}>{post.reactions[type]}</span>
+            </span>
+          );
+        })}
+      </div>
+
+      <div className={styles.foot}>
+        <span className={styles.comment_stat}>
+          <LuMessageCircle aria-hidden="true" />
+          댓글 {post.commentCount}
+        </span>
+      </div>
+
+      {post.topComment && (
+        <div className={styles.preview}>
+          <Avatar
+            initial={post.topComment.avatarInitial}
+            color={post.topComment.avatarColor}
+            size="sm"
+          />
+          <div className={styles.preview_body}>
+            <b className={styles.preview_author}>{post.topComment.authorName}</b>
+            <span className={styles.preview_text}>{post.topComment.text}</span>
+            {post.commentCount > 1 && (
+              <span className={styles.preview_more}>댓글 {post.commentCount}개 모두 보기</span>
+            )}
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/gallery.module.scss
+++ b/src/app/(content)/news/gallery/_component/gallery.module.scss
@@ -1,0 +1,287 @@
+// ══════════════════════════════════════════
+// 갤러리 피드 — 목업(docs/references/gallery) 기반, warm 톤($home-*).
+// 읽기 전용: 카테고리 필터·사진 라이트박스만 인터랙티브, 반응·댓글은 정적 표시.
+// ══════════════════════════════════════════
+
+// ── 작성 입력 바 (컴포저 — 목업 상단, 읽기 전용 표시) ──
+.composer {
+  display: flex;
+  align-items: center;
+  gap: $spacing-10;
+  padding: $spacing-10 $spacing-12;
+  background-color: $bg-card;
+  border: 1px solid $home-border-divider;
+  border-radius: $radius-m;
+}
+
+.composer_avatar {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 3.8rem;
+  height: 3.8rem;
+  border-radius: $radius-circle;
+  background-color: $home-accent;
+  color: $txt-inverse;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+}
+
+.composer_placeholder {
+  flex: 1;
+  min-width: 0;
+  font-size: $font-size-14;
+  font-weight: $font-weight-medium;
+  color: $home-text-muted;
+}
+
+.composer_camera {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 4rem;
+  height: 4rem;
+  border-radius: $radius-s;
+  background-color: $home-tint-card;
+  color: $home-accent;
+
+  svg {
+    width: 1.9rem;
+    height: 1.9rem;
+  }
+}
+
+// ── 피드 ──
+.feed {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-16;
+}
+
+.empty {
+  padding: $spacing-48 $spacing-24;
+  text-align: center;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $home-text-muted;
+}
+
+// ── 게시글 카드 ──
+.card {
+  overflow: hidden;
+  background-color: $bg-card;
+  border: 1px solid $home-border-divider;
+  border-radius: $radius-l;
+}
+
+.head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-10;
+  padding: $spacing-12 $spacing-12 $spacing-10;
+}
+
+.head_text {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  min-width: 0;
+}
+
+.author {
+  font-size: $font-size-14;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+}
+
+.meta {
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $home-text-muted;
+}
+
+.caption {
+  padding: $spacing-12 $spacing-16 $spacing-4;
+  font-size: $font-size-14;
+  line-height: $line-height-body-reading;
+  color: $home-text;
+}
+
+// ── 사진 그리드 ──
+.media {
+  position: relative;
+}
+
+.media_tile {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  padding: 0;
+  border: none;
+  overflow: hidden;
+  background-color: $home-tint;
+  cursor: pointer;
+
+  @include focus-ring('strong');
+}
+
+.media_single .media_tile {
+  aspect-ratio: 4 / 3;
+}
+
+.media_two,
+.media_four {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: $spacing-2;
+}
+
+.media_three,
+.media_many {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $spacing-2;
+}
+
+.count_badge {
+  position: absolute;
+  top: $spacing-8;
+  right: $spacing-8;
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-4;
+  padding: $spacing-4 $spacing-8;
+  border-radius: $radius-circle;
+  background-color: $overlay-scrim;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  color: $txt-inverse;
+  pointer-events: none;
+}
+
+// ── 반응 (읽기 전용) ──
+.reactions {
+  display: flex;
+  gap: $spacing-4;
+  padding: $spacing-10 $spacing-12 $spacing-4;
+  overflow-x: auto;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.reaction {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-4;
+  flex-shrink: 0;
+  padding: $spacing-6 $spacing-10;
+  border: 1px solid $home-border;
+  border-radius: $radius-circle;
+  background-color: $home-surface;
+  font-size: $font-size-12;
+  font-weight: $font-weight-bold;
+  color: $home-text-sub;
+  white-space: nowrap;
+}
+
+.reaction_on {
+  border-color: transparent;
+  background-color: $home-tint-card;
+  color: $home-accent;
+}
+
+.reaction_icon {
+  width: 1.4rem;
+  height: 1.4rem;
+  color: $home-text-muted;
+
+  .reaction_on & {
+    color: $home-accent;
+  }
+}
+
+.reaction_count {
+  color: inherit;
+}
+
+// ── 댓글 요약 + 미리보기 ──
+.foot {
+  display: flex;
+  align-items: center;
+  padding: $spacing-10 $spacing-16 $spacing-12;
+}
+
+.comment_stat {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-6;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $home-text-sub;
+
+  svg {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+.preview {
+  display: flex;
+  gap: $spacing-8;
+  padding: $spacing-12 $spacing-16;
+  border-top: 1px solid $home-border-divider;
+  background-color: $home-surface;
+}
+
+.preview_body {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  min-width: 0;
+}
+
+.preview_author {
+  font-size: $font-size-12;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+}
+
+.preview_text {
+  font-size: $font-size-13;
+  line-height: $line-height-body-default;
+  color: $home-text-sub;
+}
+
+.preview_more {
+  margin-top: $spacing-2;
+  font-size: $font-size-12;
+  font-weight: $font-weight-bold;
+  color: $home-accent;
+}
+
+// ── 아바타 ──
+.avatar_lg,
+.avatar_sm {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  border-radius: $radius-circle;
+  color: $txt-inverse;
+  font-weight: $font-weight-bold;
+}
+
+.avatar_lg {
+  width: 4.2rem;
+  height: 4.2rem;
+  font-size: $font-size-16;
+}
+
+.avatar_sm {
+  width: 2.8rem;
+  height: 2.8rem;
+  font-size: $font-size-11;
+}

--- a/src/app/(content)/news/gallery/_component/gallery.module.scss
+++ b/src/app/(content)/news/gallery/_component/gallery.module.scss
@@ -123,7 +123,8 @@
   background-color: $home-tint;
   cursor: pointer;
 
-  @include focus-ring('strong');
+  // 타일이 카드 가장자리에 붙고 `.card`가 overflow:hidden이라 바깥 링은 잘린다 → 안쪽 링으로 둔다.
+  @include focus-ring('strong', $offset: calc(-1 * $focus-ring-offset));
 }
 
 .media_single .media_tile {

--- a/src/app/(content)/news/gallery/_data/posts.ts
+++ b/src/app/(content)/news/gallery/_data/posts.ts
@@ -1,0 +1,136 @@
+import type { GalleryPost, GalleryPhoto } from '../_types';
+
+// mock 사진 — Unsplash 원격 URL. 렌더 시 Cloudinary image/fetch로 감싼다(로더 관례 유지).
+// 실제 스키마·업로드 연동은 후속 단계. 아래 id는 fetch 200 확인 완료.
+const photo = (id: string, width = 1600, height = 1067): GalleryPhoto => ({
+  remoteUrl: `https://images.unsplash.com/photo-${id}?w=1600&q=80`,
+  width,
+  height
+});
+
+export const GALLERY_POSTS: GalleryPost[] = [
+  {
+    id: 'p1',
+    authorName: '김은혜',
+    avatarInitial: '김',
+    avatarColor: '#C08552',
+    department: '청년부',
+    category: '청년부',
+    createdLabel: '2시간 전',
+    text: '오늘 청년예배, 오랜만에 다 같이 목소리 모아 찬양하는데 마음이 뜨거워졌어요. 함께라서 감사한 저녁이었습니다.',
+    photos: [photo('1511632765486-a01980e01a18')],
+    reactions: { 은혜: 42, 아멘: 18, 기도해요: 7, 축복: 4 },
+    viewerReaction: '은혜',
+    commentCount: 3,
+    topComment: {
+      authorName: '박믿음',
+      avatarInitial: '박',
+      avatarColor: '#A9713B',
+      text: '저도 그 자리에 있었는데 정말 은혜로웠어요'
+    }
+  },
+  {
+    id: 'p2',
+    authorName: '이든',
+    avatarInitial: '이',
+    avatarColor: '#6B8E5A',
+    department: '봉사팀',
+    category: '봉사',
+    createdLabel: '어제',
+    text: '토요일 이른 아침, 교회 주변을 함께 쓸고 닦았습니다. 손발은 바빴지만 마음은 넉넉했던 시간이었어요.',
+    photos: [photo('1438032005730-c779502df39b'), photo('1445019980597-93fa8acb246c')],
+    reactions: { 은혜: 51, 아멘: 12, 기도해요: 6, 축복: 23 },
+    viewerReaction: '축복',
+    commentCount: 5,
+    topComment: {
+      authorName: '정소망',
+      avatarInitial: '정',
+      avatarColor: '#9C6B4E',
+      text: '수고 많으셨어요! 다음엔 저도 함께할게요'
+    }
+  },
+  {
+    id: 'p3',
+    authorName: '최소망',
+    avatarInitial: '최',
+    avatarColor: '#B0975F',
+    department: '다음세대',
+    category: '다음세대',
+    createdLabel: '2일 전',
+    text: '주일학교 아이들과 함께한 여름 성경학교 첫날. 웃음소리가 예배당을 가득 채웠습니다.',
+    photos: [photo('1470225620780-dba8ba36b745')],
+    reactions: { 은혜: 19, 아멘: 6, 기도해요: 14, 축복: 3 },
+    viewerReaction: '기도해요',
+    commentCount: 2,
+    topComment: {
+      authorName: '한사랑',
+      avatarInitial: '한',
+      avatarColor: '#7C8B54',
+      text: '아이들 표정이 너무 밝아요 🙂'
+    }
+  },
+  {
+    id: 'p4',
+    authorName: '정한결',
+    avatarInitial: '정',
+    avatarColor: '#8A6D4B',
+    department: '찬양팀',
+    category: '주일예배',
+    createdLabel: '3일 전',
+    text: '주일 대예배 찬양 연습. 한 소절 한 소절 맞춰가며 드릴 예배를 준비했습니다. 이번 주도 은혜로 채워지길.',
+    photos: [
+      photo('1519681393784-d120267933ba'),
+      photo('1506905925346-21bda4d32df4'),
+      photo('1529070538774-1843cb3265df')
+    ],
+    reactions: { 은혜: 33, 아멘: 27, 기도해요: 9, 축복: 11 },
+    viewerReaction: '아멘',
+    commentCount: 8,
+    topComment: {
+      authorName: '김찬양',
+      avatarInitial: '김',
+      avatarColor: '#B67C4B',
+      text: '연습 소리만 들어도 벌써 은혜받아요'
+    }
+  },
+  {
+    id: 'p5',
+    authorName: '한지혜',
+    avatarInitial: '한',
+    avatarColor: '#A57C55',
+    department: '교육부',
+    category: '나눔',
+    createdLabel: '4일 전',
+    text: '구역 나눔 모임에서 각자 준비한 음식을 나눴어요. 소박한 상 위에 감사가 넘쳤습니다.',
+    photos: [
+      photo('1507692049790-de58290a4334'),
+      photo('1490730141103-6cac27aaab94'),
+      photo('1533174072545-7a4b6ad7a6c3'),
+      photo('1428765048792-aa4bdde46fea')
+    ],
+    reactions: { 은혜: 24, 아멘: 8, 기도해요: 5, 축복: 16 },
+    viewerReaction: null,
+    commentCount: 1,
+    topComment: {
+      authorName: '오은총',
+      avatarInitial: '오',
+      avatarColor: '#96693F',
+      text: '다음 모임이 벌써 기다려집니다'
+    }
+  },
+  {
+    id: 'p6',
+    authorName: '오평강',
+    avatarInitial: '오',
+    avatarColor: '#7A6654',
+    department: '중보기도팀',
+    category: '기도',
+    createdLabel: '지난주',
+    text: '새벽 중보기도 모임. 조용한 예배당에서 함께 무릎 꿇는 시간이 가장 큰 힘이 됩니다.',
+    photos: [photo('1519681393784-d120267933ba')],
+    reactions: { 은혜: 15, 아멘: 21, 기도해요: 30, 축복: 6 },
+    viewerReaction: '기도해요',
+    commentCount: 0,
+    topComment: null
+  }
+];

--- a/src/app/(content)/news/gallery/_types.ts
+++ b/src/app/(content)/news/gallery/_types.ts
@@ -1,0 +1,42 @@
+// 갤러리 피드 읽기용 타입 — 참여형 스키마(docs/references/gallery)의 표시 필요분만 추린 축약본.
+// 쓰기(작성·반응 토글·댓글)·모더레이션·업로드는 후속 단계라 여기 없다.
+
+// 카테고리는 게시글 데이터에 남겨 스키마 충실도를 유지한다. 카테고리 필터 UI는 후속 단계라
+// 지금은 export하지 않는다(GalleryCategory 타입 파생에만 쓰인다).
+const GALLERY_CATEGORIES = ['주일예배', '청년부', '다음세대', '봉사', '나눔', '기도'] as const;
+
+export type GalleryCategory = (typeof GALLERY_CATEGORIES)[number];
+
+export const REACTION_TYPES = ['은혜', '아멘', '기도해요', '축복'] as const;
+
+export type ReactionType = (typeof REACTION_TYPES)[number];
+
+export type GalleryPhoto = {
+  // 원격 스톡 URL(mock). 렌더 시 cloudinaryFetchUrl로 감싸 Cloudinary fetch 전송을 태운다.
+  remoteUrl: string;
+  width: number;
+  height: number;
+};
+
+export type GalleryComment = {
+  authorName: string;
+  avatarInitial: string;
+  avatarColor: string;
+  text: string;
+};
+
+export type GalleryPost = {
+  id: string;
+  authorName: string;
+  avatarInitial: string;
+  avatarColor: string; // 성도별 아바타 배경색 — 스키마 Member.avatarColor(hex) 필드에 해당하는 데이터값
+  department: string; // 표시용 소속 (예: 청년부, 봉사팀)
+  category: GalleryCategory;
+  createdLabel: string; // mock 상대 시각 (예: '2시간 전', '어제')
+  text: string;
+  photos: GalleryPhoto[];
+  reactions: Record<ReactionType, number>;
+  viewerReaction: ReactionType | null; // 강조할 반응 (mock)
+  commentCount: number;
+  topComment: GalleryComment | null;
+};

--- a/src/app/(content)/news/gallery/page.module.scss
+++ b/src/app/(content)/news/gallery/page.module.scss
@@ -1,0 +1,14 @@
+.blind_title {
+  @include blind;
+}
+
+.wrap {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-16;
+
+  // 피드는 소셜 단일 컬럼 — 데스크톱에서 과하게 넓어지지 않게 읽기 폭으로 가둔다.
+  width: 100%;
+  max-width: 62rem;
+  margin: 0 auto;
+}

--- a/src/app/(content)/news/gallery/page.tsx
+++ b/src/app/(content)/news/gallery/page.tsx
@@ -1,10 +1,24 @@
 import type { Metadata } from 'next';
-import ComingSoon from '@/components/common/ComingSoon/ComingSoon';
+import MainContainer from '@/components/layout/container/MainContainer';
+import GalleryComposer from './_component/GalleryComposer';
+import GalleryFeed from './_component/GalleryFeed';
+import { GALLERY_POSTS } from './_data/posts';
+import styles from './page.module.scss';
 
 export const metadata: Metadata = {
-  title: '갤러리'
+  title: '갤러리',
+  description: '대구동남교회 성도들이 나눈 은혜의 순간을 함께 봅니다.'
 };
 
-export default function Gallery() {
-  return <ComingSoon title="갤러리" />;
+export default function GalleryPage() {
+  return (
+    <MainContainer title="갤러리">
+      {/* Hero 제거로 사라진 페이지 제목 — 시각은 MobileHeader가 대신하고, 데스크톱·스크린리더용 h1을 둔다 */}
+      <h1 className={styles.blind_title}>갤러리</h1>
+      <div className={styles.wrap}>
+        <GalleryComposer />
+        <GalleryFeed posts={GALLERY_POSTS} />
+      </div>
+    </MainContainer>
+  );
 }


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: `/news/gallery`의 ComingSoon 플레이스홀더를 목업 기반 나눔 피드 화면으로 교체한다(읽기 전용·mock 데이터).

**범위**:

- 컴포저 바 + 게시글 카드(아바타·사진 그리드·반응 pill·댓글 미리보기) + PhotoSwipe 라이트박스를 mock 6건으로 렌더
- 사진은 Cloudinary image/fetch로 감싸 기존 로더 관례를 유지
- `news/gallery` 하위 신규 파일과 `page.tsx` 교체만 — DB·config·레이어는 무변경

---

## 🔗 개발 컨텍스트

- **Task ID**: `gallery-feed`
- **Exec Plan**: `docs/exec-plans/active/2026-07-05-gallery-feed.md`
- **관련 ADR**: 해당 없음 (app 라우트·컴포넌트·mock 데이터만 추가)
- **관련 tech debt**: 해당 없음
- **작업 범위**: 읽기 전용 갤러리 피드 UI + mock 데이터 (`src/app/(content)/news/gallery/` 하위)
- **제외한 범위**: 쓰기 동작(작성·반응 토글·댓글), 카테고리 필터 UI, 실제 스키마·DB·서비스 배선, navigation·config 변경

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

`/news/gallery`가 ComingSoon 안내 화면뿐이라 방문자가 볼 내용이 없었다. 소식 영역의 형제 탭(주보·공지)은 채워졌는데 갤러리만 비어 있어, 목업 기준으로 먼저 화면을 만들고 스키마 연동은 뒤로 미루기로 했다(사용자 결정: "UI부터, 스키마 연동은 후속").

**관련 이슈:**

- 해당 없음 (개인 사이드 프로젝트, 이슈 트래커 미사용)

---

## 🔧 주요 변경점 (Key Changes)

- `page.tsx` — ComingSoon을 `MainContainer` + 컴포저 + 피드로 교체하고, 스크린리더·데스크톱용 blind h1과 description 메타를 추가했다.
- `_component/GalleryPostCard.tsx`·`Avatar.tsx` — 게시글 카드(아바타·이름·부서·상대시각·본문·반응 pill 4종·댓글 수·대표 댓글 미리보기)를 정적으로 렌더한다.
- `_component/GalleryPhotos.tsx` (client) — 사진 수별 그리드(1장 4/3, 2장 2열, 3장 3열, 4장 2×2)와 개수 배지, `react-photoswipe-gallery` 라이트박스를 `CloudinaryImage` + 로더로 붙였다.
- `_component/GalleryComposer.tsx`·`GalleryFeed.tsx` — 표시용 작성 입력 바(비인터랙티브)와 피드 목록·빈 상태를 만든다.
- `_data/posts.ts`·`_types.ts` — 읽기용 축약 타입과 mock 게시글 6건(카테고리·사진 수·반응·댓글을 다양화)을 뒀다.
- `_component/gallery.module.scss`·`page.module.scss` — warm 토큰(`$home-*`·`$accent`) 기반 스타일을 상위 module 1개로 통합했다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| mock 사진 소스 | Cloudinary image/fetch로 원격 스톡 URL 렌더 | 갤러리 자산이 교회 Cloudinary에 없고, "이미지는 항상 Cloudinary URL + 로더" 관례를 지켜야 라이트박스가 의미 있다 | 로컬 `/public` 이미지 — 로더 관례에 어긋나 버림 |
| 컴포저·반응·댓글 | 표시용(비인터랙티브)으로 노출 | phase 1은 읽기 전용 — 인터랙션 입구를 살리면 "되는 척"이 된다 | 컴포저 생략 — 사용자 "입력 바도 UI로 넣어둬"로 폐기 |
| 카테고리 필터 UI | 넣지 않음 (카테고리는 데이터·타입에만 유지) | 목업 기본 화면에 칩 필터·개수 줄이 없다 | 칩 바 + "전체 순간 N개" 줄 — 목업과 안 맞아 제거 |

> ⚠️ **트레이드오프:** mock 사진은 Unsplash 원격 URL을 Cloudinary fetch로 감싼 자산이라, 실데이터 도입 시 `posts.ts`를 통째로 교체해야 한다. 일부 사진은 캡션과 덜 어울려(다음세대 등) 후속 큐레이션이 필요하다.

---

## 📸 스크린샷 (Screenshots)

| 단일 사진 피드 | 다중 사진 피드 |
|--|--|
|  <img width="407" height="773" alt="image" src="https://github.com/user-attachments/assets/30a71889-0aa3-4e6d-ab46-a0981e47bd0a" />| <img width="408" height="776" alt="image" src="https://github.com/user-attachments/assets/3a515e90-8211-4129-a629-a9d3488aff5b" />|

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs gallery-feed` — PASS, RUN_ID=`20260705-162741`, HEAD=`57b8e8d`(검증 실행 시점), failed=0, warned=Knip |
| `harness-gate` | N/A (머지 직전 실행) |
| Codex 계획 검증 | N/A (저위험 — 사용자 승인으로 생략) |
| Codex 1차 검증 | N/A (레이어·DB·인증·캐시 무변경, 신규 파일 한정) |
| Claude 2차 검증 | 완료 (PASS) |
| ADR 판단 | 불필요 (app 라우트·컴포넌트·mock 데이터만) |
| 남은 warning | 기존 부채 (Knip) — gallery 신규 0 |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 요구사항 전체 충족 여부 (카드 6건·1/2/3/4장 그리드·반응·댓글·라이트박스 실측)
- [x] Null, 빈 배열 등 엣지 케이스 처리 여부 (`photos` 빈 배열·`topComment` null·`viewerReaction` null·피드 빈 상태 처리)

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 불필요한 코드·디버그 로그 제거 여부

**보안 및 견고성**

- [x] 하드코딩된 비밀값(토큰, 비밀번호) 미포함 확인
- [x] 사용자 입력값 적절한 검증 여부 (읽기 전용 — 입력 경로 없음)

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: `/news/gallery`가 ComingSoon 대신 나눔 피드(카드 6건 + 사진 라이트박스)로 바뀐다.
- **운영 리스크**: 없음 — DB·환경변수·마이그레이션과 무관하고 신규 파일만 는다. mock 사진은 Unsplash 원격 URL을 Cloudinary fetch로 감싼다.
- **QA 후속**: 실제 스키마·업로드 연동, mock 사진 큐레이션(일부가 캡션과 덜 어울림).
- **롤백 시 영향**: 없음 — `page.tsx`를 ComingSoon으로 되돌리면 끝난다.
- **먼저 볼 화면 / 흐름**: `/news/gallery` 모바일·데스크톱 → 사진 탭 → PhotoSwipe 라이트박스("2/4" 카운터).

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 카테고리는 데이터·타입에 남겨 뒀다(`GALLERY_CATEGORIES` export는 knip 신규 경고를 막으려 제거). 필터 UI를 붙일 때 export를 복원하고 트리거(검색·카테고리 탭)를 추가한다.
- 반응·댓글·컴포저는 지금 정적 표시다 — 쓰기를 붙일 때 Server Action + `createServerSideClient` 경로로 간다.
- mock 사진은 Unsplash id를 하드코딩했다(fetch 200 확인). 실데이터 도입 시 `posts.ts`를 통째로 교체한다.
