### PR TITLE
[Feat] 갤러리 나눔글 작성·게시글 상세 모달 (UI·mock)

### DIFF
--- a/src/app/(content)/news/gallery/_component/GalleryBoard.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryBoard.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import GalleryComposer from './GalleryComposer';
+import GalleryFeed from './GalleryFeed';
+import GalleryComposeSheet from './GalleryComposeSheet';
+import GalleryPostSheet from './GalleryPostSheet';
+import type { GalleryPost } from '../_types';
+
+// 피드 + 두 모달의 상태를 쥐는 client 래퍼. 컴포저 → 작성 모달, 카드 → 상세 모달.
+export default function GalleryBoard({ posts }: { posts: GalleryPost[] }) {
+  const [composeOpen, setComposeOpen] = useState(false);
+  const [detailPost, setDetailPost] = useState<GalleryPost | null>(null);
+
+  return (
+    <>
+      <GalleryComposer onClick={() => setComposeOpen(true)} />
+      <GalleryFeed posts={posts} onOpenDetail={setDetailPost} />
+      <GalleryComposeSheet open={composeOpen} onClose={() => setComposeOpen(false)} />
+      <GalleryPostSheet post={detailPost} onClose={() => setDetailPost(null)} />
+    </>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryComposeSheet.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryComposeSheet.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useState } from 'react';
+import { IoClose } from 'react-icons/io5';
+import { LuImagePlus, LuCheck } from 'react-icons/lu';
+import clsx from 'clsx';
+import { BottomSheet, Button, Textarea, Pill } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import {
+  GALLERY_CATEGORIES,
+  GALLERY_SCOPES,
+  type GalleryCategory,
+  type GalleryScope
+} from '../_types';
+import styles from './gallery.module.scss';
+
+const STEP_COUNT = 3;
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+// 나눔글 작성 모달 — 목업의 3단계 위저드(사진 → 이야기 → 카테고리·공개 범위).
+// 읽기 전용/UI 단계라 실제 업로드·저장은 없다(올리기는 안내 토스트 후 닫기).
+export default function GalleryComposeSheet({ open, onClose }: Props) {
+  const { info } = useToastStore();
+  const [step, setStep] = useState(0);
+  const [text, setText] = useState('');
+  const [category, setCategory] = useState<GalleryCategory | null>(null);
+  const [scope, setScope] = useState<GalleryScope>('public');
+
+  // 열림 전환 시 초기화 — effect 대신 렌더 중 prev 비교(React 권장, NoticeControlBar와 동일 패턴).
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setStep(0);
+      setText('');
+      setCategory(null);
+      setScope('public');
+    }
+  }
+
+  const isLast = step === STEP_COUNT - 1;
+
+  const handleSubmit = () => {
+    info('나눔글 작성은 준비 중이에요. 곧 직접 올릴 수 있어요.');
+    onClose();
+  };
+
+  const header = (
+    <>
+      <div className={styles.sheet_head}>
+        <span className={styles.sheet_head_spacer} aria-hidden="true" />
+        <h2 className={styles.sheet_title}>나눔글 작성</h2>
+        <button type="button" className={styles.sheet_head_btn} onClick={onClose} aria-label="닫기">
+          <IoClose />
+        </button>
+      </div>
+      <div className={styles.segments} aria-hidden="true">
+        {Array.from({ length: STEP_COUNT }, (_, i) => (
+          <span key={i} className={clsx(styles.segment, i <= step && styles.segment_on)} />
+        ))}
+      </div>
+    </>
+  );
+
+  const footer = (
+    <>
+      {step > 0 && (
+        <Button variant="secondary" onClick={() => setStep((s) => s - 1)}>
+          이전
+        </Button>
+      )}
+      {isLast ? (
+        <Button fullWidth onClick={handleSubmit}>
+          올리기
+        </Button>
+      ) : (
+        <Button fullWidth onClick={() => setStep((s) => s + 1)}>
+          다음
+        </Button>
+      )}
+    </>
+  );
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      size="full"
+      ariaLabel="나눔글 작성"
+      enableHistory
+      header={header}
+      footer={footer}
+    >
+      <div className={styles.compose_body}>
+        {step === 0 && (
+          <>
+            <h3 className={styles.compose_title}>어떤 순간을 나눌까요?</h3>
+            <p className={styles.compose_sub}>사진을 선택해 주세요 · 최대 10장</p>
+            <button
+              type="button"
+              className={styles.compose_photo_main}
+              onClick={() => info('사진 업로드는 준비 중이에요.')}
+            >
+              <LuImagePlus aria-hidden="true" />
+              대표 사진 추가
+            </button>
+            <div className={styles.compose_photo_row}>
+              {Array.from({ length: 3 }, (_, i) => (
+                <button
+                  key={i}
+                  type="button"
+                  className={styles.compose_photo_add}
+                  onClick={() => info('사진 업로드는 준비 중이에요.')}
+                >
+                  <LuImagePlus aria-hidden="true" />
+                  추가
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+
+        {step === 1 && (
+          <>
+            <h3 className={styles.compose_title}>이야기를 들려주세요</h3>
+            <p className={styles.compose_sub}>오늘 받은 은혜, 함께한 순간을 나눠보세요</p>
+            <Textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              maxLength={500}
+              showCounter
+              rows={5}
+              aria-label="나눔글 내용"
+              placeholder="예) 오랜만에 다 같이 목소리 모아 찬양하는데 마음이 뜨거워졌어요. 함께라서 감사한 저녁이었습니다."
+            />
+            <p className={styles.compose_hint}>짧아도 좋아요. 진심 한 줄이면 충분해요.</p>
+          </>
+        )}
+
+        {step === 2 && (
+          <>
+            <h3 className={styles.compose_title}>거의 다 됐어요</h3>
+            <p className={styles.compose_sub}>카테고리와 공개 범위를 정해주세요</p>
+
+            <p className={styles.compose_label}>카테고리</p>
+            <div className={styles.compose_cats}>
+              {GALLERY_CATEGORIES.map((cat) => (
+                <Pill key={cat} active={category === cat} onClick={() => setCategory(cat)}>
+                  {cat}
+                </Pill>
+              ))}
+            </div>
+
+            <p className={styles.compose_label}>공개 범위</p>
+            <div className={styles.scope_cards}>
+              {GALLERY_SCOPES.map((option) => {
+                const on = scope === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={clsx(styles.scope_card, on && styles.scope_card_on)}
+                    onClick={() => setScope(option.value)}
+                    aria-pressed={on}
+                  >
+                    <span className={clsx(styles.scope_check, on && styles.scope_check_on)}>
+                      {on && <LuCheck aria-hidden="true" />}
+                    </span>
+                    <span className={styles.scope_text}>
+                      <b className={styles.scope_name}>{option.label}</b>
+                      <span className={styles.scope_desc}>{option.desc}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        )}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryComposer.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryComposer.tsx
@@ -1,10 +1,10 @@
 import { LuCamera } from 'react-icons/lu';
 import styles from './gallery.module.scss';
 
-// 목업의 작성 입력 바 — 읽기 전용 단계라 표시용(비인터랙티브). 실제 작성 흐름은 후속 단계.
-export default function GalleryComposer() {
+// 목업의 작성 입력 바 — 탭하면 나눔글 작성 모달을 연다.
+export default function GalleryComposer({ onClick }: { onClick: () => void }) {
   return (
-    <div className={styles.composer}>
+    <button type="button" className={styles.composer} onClick={onClick}>
       <span className={styles.composer_avatar} aria-hidden="true">
         나
       </span>
@@ -12,6 +12,6 @@ export default function GalleryComposer() {
       <span className={styles.composer_camera} aria-hidden="true">
         <LuCamera />
       </span>
-    </div>
+    </button>
   );
 }

--- a/src/app/(content)/news/gallery/_component/GalleryFeed.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryFeed.tsx
@@ -1,8 +1,15 @@
+'use client';
+
 import GalleryPostCard from './GalleryPostCard';
 import type { GalleryPost } from '../_types';
 import styles from './gallery.module.scss';
 
-export default function GalleryFeed({ posts }: { posts: GalleryPost[] }) {
+type Props = {
+  posts: GalleryPost[];
+  onOpenDetail: (post: GalleryPost) => void;
+};
+
+export default function GalleryFeed({ posts, onOpenDetail }: Props) {
   if (posts.length === 0) {
     return <p className={styles.empty}>조건에 맞는 순간이 없어요</p>;
   }
@@ -10,7 +17,7 @@ export default function GalleryFeed({ posts }: { posts: GalleryPost[] }) {
   return (
     <div className={styles.feed}>
       {posts.map((post) => (
-        <GalleryPostCard key={post.id} post={post} />
+        <GalleryPostCard key={post.id} post={post} onOpenDetail={() => onOpenDetail(post)} />
       ))}
     </div>
   );

--- a/src/app/(content)/news/gallery/_component/GalleryPhotos.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPhotos.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Gallery, Item } from 'react-photoswipe-gallery';
 import clsx from 'clsx';
 import { LuImages } from 'react-icons/lu';
@@ -44,6 +44,20 @@ type Props = {
 
 export default function GalleryPhotos({ photos, onOpen }: Props) {
   const pswpRef = useRef<PhotoSwipeType | null>(null);
+  const lightboxOpenRef = useRef(false);
+
+  // 라이트박스가 열려 있는 동안 Escape는 라이트박스만 닫는다. 부모 시트(useDialog)의
+  // Escape 닫힘 리스너가 함께 실행돼 시트까지 닫히는 걸, 캡처 단계에서 가로채 막는다.
+  useEffect(() => {
+    const handleEscapeCapture = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && lightboxOpenRef.current) {
+        e.stopPropagation();
+        pswpRef.current?.close();
+      }
+    };
+    document.addEventListener('keydown', handleEscapeCapture, true);
+    return () => document.removeEventListener('keydown', handleEscapeCapture, true);
+  }, []);
 
   // 피드: 사진 그리드 전체가 상세 모달을 여는 버튼. 개별 라이트박스는 상세 안에서.
   if (onOpen) {
@@ -77,8 +91,16 @@ export default function GalleryPhotos({ photos, onOpen }: Props) {
     }
   };
 
+  const handleBeforeOpen = (pswp: PhotoSwipeType) => {
+    pswpRef.current = pswp;
+    lightboxOpenRef.current = true;
+    pswp.on('destroy', () => {
+      lightboxOpenRef.current = false;
+    });
+  };
+
   return (
-    <Gallery options={options} onBeforeOpen={(pswp) => (pswpRef.current = pswp)}>
+    <Gallery options={options} onBeforeOpen={handleBeforeOpen}>
       <div className={clsx(styles.media, layoutClass(photos.length))}>
         {photos.map((photo, index) => {
           const src = fetchSrc(photo);

--- a/src/app/(content)/news/gallery/_component/GalleryPhotos.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPhotos.tsx
@@ -22,9 +22,49 @@ function layoutClass(count: number): string {
   return styles.media_many;
 }
 
-export default function GalleryPhotos({ photos }: { photos: GalleryPhoto[] }) {
+function fetchSrc(photo: GalleryPhoto): string {
+  return cloudinaryFetchUrl(photo.remoteUrl) ?? photo.remoteUrl;
+}
+
+function CountBadge({ count }: { count: number }) {
+  if (count <= 1) return null;
+  return (
+    <span className={styles.count_badge}>
+      <LuImages aria-hidden="true" />
+      {count}
+    </span>
+  );
+}
+
+type Props = {
+  photos: GalleryPhoto[];
+  /** 제공하면 사진 전체가 상세 열기 버튼이 된다(피드). 없으면 각 사진을 라이트박스로 연다(상세 모달). */
+  onOpen?: () => void;
+};
+
+export default function GalleryPhotos({ photos, onOpen }: Props) {
   const pswpRef = useRef<PhotoSwipeType | null>(null);
 
+  // 피드: 사진 그리드 전체가 상세 모달을 여는 버튼. 개별 라이트박스는 상세 안에서.
+  if (onOpen) {
+    return (
+      <button
+        type="button"
+        className={clsx(styles.media, styles.media_open, layoutClass(photos.length))}
+        onClick={onOpen}
+        aria-label="게시글 상세 보기"
+      >
+        {photos.map((photo, index) => (
+          <span key={photo.remoteUrl + index} className={styles.media_tile_static}>
+            <CloudinaryImage src={fetchSrc(photo)} alt="" fill sizes="(max-width: 640px) 50vw, 320px" />
+          </span>
+        ))}
+        <CountBadge count={photos.length} />
+      </button>
+    );
+  }
+
+  // 상세 모달: 각 사진을 PhotoSwipe 라이트박스로.
   const options: PhotoSwipeOptions = {
     ...BASE_PHOTOSWIPE_OPTIONS,
     tapAction: (_, originalEvent) => {
@@ -41,7 +81,7 @@ export default function GalleryPhotos({ photos }: { photos: GalleryPhoto[] }) {
     <Gallery options={options} onBeforeOpen={(pswp) => (pswpRef.current = pswp)}>
       <div className={clsx(styles.media, layoutClass(photos.length))}>
         {photos.map((photo, index) => {
-          const src = cloudinaryFetchUrl(photo.remoteUrl) ?? photo.remoteUrl;
+          const src = fetchSrc(photo);
           const original = cloudinaryLoader({ src, width: 1600 });
 
           return (
@@ -71,13 +111,7 @@ export default function GalleryPhotos({ photos }: { photos: GalleryPhoto[] }) {
             </Item>
           );
         })}
-
-        {photos.length > 1 && (
-          <span className={styles.count_badge}>
-            <LuImages aria-hidden="true" />
-            {photos.length}
-          </span>
-        )}
+        <CountBadge count={photos.length} />
       </div>
     </Gallery>
   );

--- a/src/app/(content)/news/gallery/_component/GalleryPostCard.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPostCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import clsx from 'clsx';
 import type { IconType } from 'react-icons';
 import { LuSun, LuHeart, LuFlame, LuSparkles, LuMessageCircle } from 'react-icons/lu';
@@ -14,7 +16,14 @@ const REACTION_ICON: Record<ReactionType, IconType> = {
   축복: LuSparkles
 };
 
-export default function GalleryPostCard({ post }: { post: GalleryPost }) {
+type Props = {
+  post: GalleryPost;
+  onOpenDetail: () => void;
+};
+
+export default function GalleryPostCard({ post, onOpenDetail }: Props) {
+  const topComment = post.comments[0] ?? null;
+
   return (
     <article className={styles.card}>
       <header className={styles.head}>
@@ -27,7 +36,7 @@ export default function GalleryPostCard({ post }: { post: GalleryPost }) {
         </div>
       </header>
 
-      {post.photos.length > 0 && <GalleryPhotos photos={post.photos} />}
+      {post.photos.length > 0 && <GalleryPhotos photos={post.photos} onOpen={onOpenDetail} />}
 
       {post.text && <p className={styles.caption}>{post.text}</p>}
 
@@ -48,24 +57,22 @@ export default function GalleryPostCard({ post }: { post: GalleryPost }) {
       </div>
 
       <div className={styles.foot}>
-        <span className={styles.comment_stat}>
+        <button type="button" className={styles.comment_stat} onClick={onOpenDetail}>
           <LuMessageCircle aria-hidden="true" />
           댓글 {post.commentCount}
-        </span>
+        </button>
       </div>
 
-      {post.topComment && (
+      {topComment && (
         <div className={styles.preview}>
-          <Avatar
-            initial={post.topComment.avatarInitial}
-            color={post.topComment.avatarColor}
-            size="sm"
-          />
+          <Avatar initial={topComment.avatarInitial} color={topComment.avatarColor} size="sm" />
           <div className={styles.preview_body}>
-            <b className={styles.preview_author}>{post.topComment.authorName}</b>
-            <span className={styles.preview_text}>{post.topComment.text}</span>
+            <b className={styles.preview_author}>{topComment.authorName}</b>
+            <span className={styles.preview_text}>{topComment.text}</span>
             {post.commentCount > 1 && (
-              <span className={styles.preview_more}>댓글 {post.commentCount}개 모두 보기</span>
+              <button type="button" className={styles.preview_more} onClick={onOpenDetail}>
+                댓글 {post.commentCount}개 모두 보기
+              </button>
             )}
           </div>
         </div>

--- a/src/app/(content)/news/gallery/_component/GalleryPostSheet.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPostSheet.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useState } from 'react';
+import { IoChevronBack } from 'react-icons/io5';
+import {
+  LuEllipsis,
+  LuSend,
+  LuSun,
+  LuHeart,
+  LuFlame,
+  LuSparkles,
+  LuMessageCircle
+} from 'react-icons/lu';
+import type { IconType } from 'react-icons';
+import clsx from 'clsx';
+import { BottomSheet, Textarea } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import Avatar from './Avatar';
+import GalleryPhotos from './GalleryPhotos';
+import { REACTION_TYPES, type GalleryPost, type ReactionType } from '../_types';
+import styles from './gallery.module.scss';
+
+const REACTION_ICON: Record<ReactionType, IconType> = {
+  은혜: LuSun,
+  아멘: LuHeart,
+  기도해요: LuFlame,
+  축복: LuSparkles
+};
+
+type Props = {
+  post: GalleryPost | null;
+  onClose: () => void;
+};
+
+// 게시글 상세 모달 — 목업의 풀스크린 상세. 사진 라이트박스·댓글 목록을 보여준다.
+// 읽기 전용/UI 단계라 댓글 전송·반응 토글은 없다(안내 토스트).
+export default function GalleryPostSheet({ post, onClose }: Props) {
+  const { info } = useToastStore();
+  const [comment, setComment] = useState('');
+
+  const handleSend = () => {
+    info('댓글은 준비 중이에요. 곧 남길 수 있어요.');
+    setComment('');
+  };
+
+  const header = (
+    <div className={styles.sheet_head}>
+      <button type="button" className={styles.sheet_head_btn} onClick={onClose} aria-label="뒤로 가기">
+        <IoChevronBack />
+      </button>
+      <h2 className={styles.sheet_title}>게시글</h2>
+      <button
+        type="button"
+        className={styles.sheet_head_btn}
+        onClick={() => info('준비 중이에요.')}
+        aria-label="더보기"
+      >
+        <LuEllipsis />
+      </button>
+    </div>
+  );
+
+  const footer = post ? (
+    <div className={styles.comment_form}>
+      <span className={styles.self_avatar_sm} aria-hidden="true">
+        나
+      </span>
+      <Textarea
+        value={comment}
+        onChange={(e) => setComment(e.target.value)}
+        rows={1}
+        autoGrow
+        aria-label="댓글 입력"
+        placeholder="따뜻한 한마디를 남겨보세요"
+        className={styles.comment_input}
+      />
+      <button type="button" className={styles.comment_send} onClick={handleSend} aria-label="댓글 남기기">
+        <LuSend aria-hidden="true" />
+      </button>
+    </div>
+  ) : null;
+
+  return (
+    <BottomSheet
+      open={Boolean(post)}
+      onClose={onClose}
+      size="full"
+      ariaLabel="게시글"
+      enableHistory
+      header={header}
+      footer={footer}
+    >
+      {post && (
+        <div className={styles.detail_body}>
+          <div className={styles.detail_head}>
+            <Avatar initial={post.avatarInitial} color={post.avatarColor} size="lg" />
+            <div className={styles.head_text}>
+              <b className={styles.author}>{post.authorName}</b>
+              <span className={styles.meta}>
+                {post.department} · {post.createdLabel}
+              </span>
+            </div>
+            <span className={styles.detail_cat}>{post.category}</span>
+          </div>
+
+          {post.photos.length > 0 && <GalleryPhotos photos={post.photos} />}
+
+          {post.text && <p className={styles.detail_caption}>{post.text}</p>}
+
+          <div className={styles.reactions}>
+            {REACTION_TYPES.map((type) => {
+              const Icon = REACTION_ICON[type];
+              const active = post.viewerReaction === type;
+
+              return (
+                <span key={type} className={clsx(styles.reaction, active && styles.reaction_on)}>
+                  <Icon className={styles.reaction_icon} aria-hidden="true" />
+                  <span className={styles.reaction_label}>{type}</span>
+                  <span className={styles.reaction_count}>{post.reactions[type]}</span>
+                </span>
+              );
+            })}
+          </div>
+
+          <h3 className={styles.comment_title}>
+            댓글 <span className={styles.comment_num}>{post.commentCount}</span>
+          </h3>
+
+          {post.comments.length === 0 ? (
+            <p className={styles.comment_empty}>
+              <LuMessageCircle aria-hidden="true" />
+              아직 댓글이 없어요. 첫 마음을 남겨보세요.
+            </p>
+          ) : (
+            <ul className={styles.comment_list}>
+              {post.comments.map((item) => (
+                <li key={item.id} className={styles.comment_item}>
+                  <Avatar initial={item.avatarInitial} color={item.avatarColor} size="sm" />
+                  <div className={styles.comment_body}>
+                    <div className={styles.comment_meta}>
+                      <b className={styles.comment_author}>{item.authorName}</b>
+                      <span className={styles.comment_time}>{item.createdLabel}</span>
+                    </div>
+                    <p className={styles.comment_text}>{item.text}</p>
+                    <div className={styles.comment_actions}>
+                      <span className={styles.comment_action}>공감</span>
+                      <span className={styles.comment_action}>답글</span>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/src/app/(content)/news/gallery/_component/GalleryPostSheet.tsx
+++ b/src/app/(content)/news/gallery/_component/GalleryPostSheet.tsx
@@ -38,6 +38,12 @@ export default function GalleryPostSheet({ post, onClose }: Props) {
   const { info } = useToastStore();
   const [comment, setComment] = useState('');
 
+  // 닫힘 애니메이션 동안 콘텐츠가 즉시 사라지지 않게 마지막 post를 유지한다(open은 post로, 렌더는 activePost로).
+  const [activePost, setActivePost] = useState<GalleryPost | null>(post);
+  if (post && post !== activePost) {
+    setActivePost(post);
+  }
+
   const handleSend = () => {
     info('댓글은 준비 중이에요. 곧 남길 수 있어요.');
     setComment('');
@@ -60,7 +66,7 @@ export default function GalleryPostSheet({ post, onClose }: Props) {
     </div>
   );
 
-  const footer = post ? (
+  const footer = activePost ? (
     <div className={styles.comment_form}>
       <span className={styles.self_avatar_sm} aria-hidden="true">
         나
@@ -90,50 +96,50 @@ export default function GalleryPostSheet({ post, onClose }: Props) {
       header={header}
       footer={footer}
     >
-      {post && (
+      {activePost && (
         <div className={styles.detail_body}>
           <div className={styles.detail_head}>
-            <Avatar initial={post.avatarInitial} color={post.avatarColor} size="lg" />
+            <Avatar initial={activePost.avatarInitial} color={activePost.avatarColor} size="lg" />
             <div className={styles.head_text}>
-              <b className={styles.author}>{post.authorName}</b>
+              <b className={styles.author}>{activePost.authorName}</b>
               <span className={styles.meta}>
-                {post.department} · {post.createdLabel}
+                {activePost.department} · {activePost.createdLabel}
               </span>
             </div>
-            <span className={styles.detail_cat}>{post.category}</span>
+            <span className={styles.detail_cat}>{activePost.category}</span>
           </div>
 
-          {post.photos.length > 0 && <GalleryPhotos photos={post.photos} />}
+          {activePost.photos.length > 0 && <GalleryPhotos photos={activePost.photos} />}
 
-          {post.text && <p className={styles.detail_caption}>{post.text}</p>}
+          {activePost.text && <p className={styles.detail_caption}>{activePost.text}</p>}
 
           <div className={styles.reactions}>
             {REACTION_TYPES.map((type) => {
               const Icon = REACTION_ICON[type];
-              const active = post.viewerReaction === type;
+              const active = activePost.viewerReaction === type;
 
               return (
                 <span key={type} className={clsx(styles.reaction, active && styles.reaction_on)}>
                   <Icon className={styles.reaction_icon} aria-hidden="true" />
                   <span className={styles.reaction_label}>{type}</span>
-                  <span className={styles.reaction_count}>{post.reactions[type]}</span>
+                  <span className={styles.reaction_count}>{activePost.reactions[type]}</span>
                 </span>
               );
             })}
           </div>
 
           <h3 className={styles.comment_title}>
-            댓글 <span className={styles.comment_num}>{post.commentCount}</span>
+            댓글 <span className={styles.comment_num}>{activePost.commentCount}</span>
           </h3>
 
-          {post.comments.length === 0 ? (
+          {activePost.comments.length === 0 ? (
             <p className={styles.comment_empty}>
               <LuMessageCircle aria-hidden="true" />
               아직 댓글이 없어요. 첫 마음을 남겨보세요.
             </p>
           ) : (
             <ul className={styles.comment_list}>
-              {post.comments.map((item) => (
+              {activePost.comments.map((item) => (
                 <li key={item.id} className={styles.comment_item}>
                   <Avatar initial={item.avatarInitial} color={item.avatarColor} size="sm" />
                   <div className={styles.comment_body}>

--- a/src/app/(content)/news/gallery/_component/gallery.module.scss
+++ b/src/app/(content)/news/gallery/_component/gallery.module.scss
@@ -3,15 +3,21 @@
 // 읽기 전용: 카테고리 필터·사진 라이트박스만 인터랙티브, 반응·댓글은 정적 표시.
 // ══════════════════════════════════════════
 
-// ── 작성 입력 바 (컴포저 — 목업 상단, 읽기 전용 표시) ──
+// ── 작성 입력 바 (컴포저 — 탭 시 작성 모달) ──
 .composer {
   display: flex;
   align-items: center;
   gap: $spacing-10;
+  width: 100%;
   padding: $spacing-10 $spacing-12;
   background-color: $bg-card;
   border: 1px solid $home-border-divider;
   border-radius: $radius-m;
+  text-align: left;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+  @include focus-ring('strong');
 }
 
 .composer_avatar {
@@ -112,22 +118,42 @@
   position: relative;
 }
 
-.media_tile {
+// 피드: 사진 그리드 전체가 상세 열기 버튼
+.media_open {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+
+  // 카드 overflow:hidden에 바깥 링이 잘려 안쪽 offset으로 둔다.
+  @include focus-ring('strong', $offset: calc(-1 * $focus-ring-offset));
+}
+
+// 타일 공통 면 — 라이트박스 버튼(.media_tile)·정적 span(.media_tile_static) 공용
+.media_tile,
+.media_tile_static {
   position: relative;
   display: block;
   width: 100%;
   aspect-ratio: 1 / 1;
-  padding: 0;
-  border: none;
   overflow: hidden;
   background-color: $home-tint;
-  cursor: pointer;
-
-  // 타일이 카드 가장자리에 붙고 `.card`가 overflow:hidden이라 바깥 링은 잘린다 → 안쪽 링으로 둔다.
-  @include focus-ring('strong', $offset: calc(-1 * $focus-ring-offset));
 }
 
-.media_single .media_tile {
+// 상세 모달 라이트박스 타일 — 버튼. 모달 body엔 clip이 없어 바깥 링 OK.
+.media_tile {
+  padding: 0;
+  border: none;
+  cursor: pointer;
+
+  @include focus-ring('strong');
+}
+
+.media_single .media_tile,
+.media_single .media_tile_static {
   aspect-ratio: 4 / 3;
 }
 
@@ -220,9 +246,16 @@
   display: inline-flex;
   align-items: center;
   gap: $spacing-6;
+  padding: 0;
+  border: none;
+  background: transparent;
   font-size: $font-size-13;
   font-weight: $font-weight-semibold;
   color: $home-text-sub;
+  cursor: pointer;
+
+  @include hover-color-shift($home-accent);
+  @include focus-ring('strong');
 
   svg {
     width: 1.5rem;
@@ -258,10 +291,18 @@
 }
 
 .preview_more {
+  align-self: flex-start;
   margin-top: $spacing-2;
+  padding: 0;
+  border: none;
+  background: transparent;
   font-size: $font-size-12;
   font-weight: $font-weight-bold;
   color: $home-accent;
+  text-align: left;
+  cursor: pointer;
+
+  @include focus-ring('strong');
 }
 
 // ── 아바타 ──
@@ -285,4 +326,381 @@
   width: 2.8rem;
   height: 2.8rem;
   font-size: $font-size-11;
+}
+
+// 내 아바타(작성자=본인 표시) — 데이터 hex 대신 warm 토큰.
+.self_avatar_sm {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 2.8rem;
+  height: 2.8rem;
+  border-radius: $radius-circle;
+  background-color: $home-accent;
+  color: $txt-inverse;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+}
+
+// ══════════════════════════════════════════
+// 모달 공통 (작성·상세) — BottomSheet size="full"의 커스텀 헤더/바디
+// ══════════════════════════════════════════
+
+.sheet_head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-6;
+  padding: $spacing-8 $spacing-12;
+}
+
+.sheet_head_btn {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 4rem;
+  height: 4rem;
+  padding: 0;
+  border: none;
+  border-radius: $radius-s;
+  background: transparent;
+  color: $home-text;
+  font-size: $font-size-22;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+  @include focus-ring('strong');
+}
+
+.sheet_head_spacer {
+  flex-shrink: 0;
+  width: 4rem;
+}
+
+.sheet_title {
+  flex: 1;
+  font-size: $font-size-16;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+  text-align: center;
+}
+
+// ── 작성 위저드 진행 세그먼트 ──
+.segments {
+  display: flex;
+  gap: $spacing-6;
+  padding: 0 $spacing-16 $spacing-12;
+}
+
+.segment {
+  flex: 1;
+  height: 0.4rem;
+  border-radius: $radius-circle;
+  background-color: $home-border;
+}
+
+.segment_on {
+  background-color: $home-accent;
+}
+
+// ── 작성 위저드 본문 ──
+.compose_body {
+  padding: $spacing-16 $spacing-20 $spacing-24;
+}
+
+.compose_title {
+  font-size: $font-size-20;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+}
+
+.compose_sub {
+  margin-top: $spacing-4;
+  margin-bottom: $spacing-12;
+  font-size: $font-size-13;
+  font-weight: $font-weight-medium;
+  color: $home-text-sub;
+}
+
+.compose_hint {
+  margin-top: $spacing-8;
+  font-size: $font-size-12;
+  color: $home-text-muted;
+}
+
+.compose_label {
+  margin-top: $spacing-20;
+  margin-bottom: $spacing-8;
+  font-size: $font-size-13;
+  font-weight: $font-weight-bold;
+  color: $home-text-sub;
+}
+
+// 사진 선택 (mock 플레이스홀더 — 실제 업로드는 후속)
+.compose_photo_main,
+.compose_photo_add {
+  display: grid;
+  place-items: center;
+  gap: $spacing-4;
+  width: 100%;
+  border: 0.15rem dashed $home-border;
+  border-radius: $radius-m;
+  background-color: $home-surface;
+  color: $home-text-muted;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+  @include focus-ring('strong');
+
+  svg {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+}
+
+.compose_photo_main {
+  margin-top: $spacing-16;
+  aspect-ratio: 4 / 3;
+}
+
+.compose_photo_row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $spacing-8;
+  margin-top: $spacing-8;
+}
+
+.compose_photo_add {
+  aspect-ratio: 1 / 1;
+  font-size: $font-size-12;
+
+  svg {
+    width: 1.8rem;
+    height: 1.8rem;
+  }
+}
+
+.compose_cats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: $spacing-8;
+}
+
+// ── 공개 범위 라디오 카드 ──
+.scope_cards {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-8;
+}
+
+.scope_card {
+  display: flex;
+  align-items: center;
+  gap: $spacing-12;
+  padding: $spacing-12 $spacing-16;
+  border: 1px solid $home-border;
+  border-radius: $radius-m;
+  background-color: $bg-card;
+  text-align: left;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+  @include focus-ring('strong');
+}
+
+.scope_card_on {
+  border-color: $home-accent;
+  background-color: $home-tint-card;
+
+  &:hover {
+    background-color: $home-tint-card;
+  }
+}
+
+.scope_check {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 2.4rem;
+  height: 2.4rem;
+  border: 0.15rem solid $home-border;
+  border-radius: $radius-xs;
+  color: $txt-inverse;
+
+  svg {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+}
+
+.scope_check_on {
+  border-color: transparent;
+  background-color: $home-accent;
+}
+
+.scope_text {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-2;
+  min-width: 0;
+}
+
+.scope_name {
+  font-size: $font-size-14;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+}
+
+.scope_desc {
+  font-size: $font-size-12;
+  color: $home-text-muted;
+}
+
+// ══════════════════════════════════════════
+// 상세 모달
+// ══════════════════════════════════════════
+
+.detail_head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-10;
+  padding: $spacing-16 $spacing-16 $spacing-12;
+}
+
+.detail_cat {
+  flex-shrink: 0;
+  margin-left: auto;
+  font-size: $font-size-12;
+  font-weight: $font-weight-bold;
+  color: $home-accent;
+}
+
+.detail_caption {
+  padding: $spacing-12 $spacing-16;
+  font-size: $font-size-14;
+  line-height: $line-height-body-reading;
+  color: $home-text;
+}
+
+.comment_title {
+  padding: $spacing-16 $spacing-16 $spacing-4;
+  border-top: 1px solid $home-border-divider;
+  font-size: $font-size-14;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+}
+
+.comment_num {
+  margin-left: $spacing-2;
+  color: $home-accent;
+}
+
+.comment_empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-6;
+  padding: $spacing-24;
+  font-size: $font-size-13;
+  color: $home-text-muted;
+
+  svg {
+    width: 1.6rem;
+    height: 1.6rem;
+  }
+}
+
+.comment_list {
+  list-style: none;
+}
+
+.comment_item {
+  display: flex;
+  gap: $spacing-10;
+  padding: $spacing-12 $spacing-16;
+  border-top: 1px solid $home-border-divider;
+}
+
+.comment_body {
+  flex: 1;
+  min-width: 0;
+}
+
+.comment_meta {
+  display: flex;
+  align-items: baseline;
+  gap: $spacing-6;
+}
+
+.comment_author {
+  font-size: $font-size-13;
+  font-weight: $font-weight-bold;
+  color: $home-text;
+}
+
+.comment_time {
+  font-size: $font-size-11;
+  color: $home-text-muted;
+}
+
+.comment_text {
+  margin-top: $spacing-2;
+  font-size: $font-size-13;
+  line-height: $line-height-body-default;
+  color: $home-text-sub;
+}
+
+.comment_actions {
+  display: flex;
+  gap: $spacing-16;
+  margin-top: $spacing-6;
+}
+
+.comment_action {
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  color: $home-text-muted;
+}
+
+// ── 댓글 입력 (상세 모달 푸터) ──
+.comment_form {
+  display: flex;
+  align-items: center;
+  gap: $spacing-8;
+  flex: 1;
+}
+
+.comment_input {
+  flex: 1;
+  min-width: 0;
+
+  // Textarea 기본 min-height(≈78px)·16px는 댓글 한 줄 바엔 과해 낮춘다(autoGrow로 입력 시 늘어남).
+  textarea {
+    min-height: 3.6rem;
+    font-size: $font-size-14;
+  }
+}
+
+// 전송 — 원형 아이콘 버튼(댓글 컴포저 도메인 컨트롤).
+.comment_send {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 3.6rem;
+  height: 3.6rem;
+  padding: 0;
+  border: none;
+  border-radius: $radius-circle;
+  background-color: $home-accent;
+  color: $txt-inverse;
+  cursor: pointer;
+
+  @include hover-bg-shift($home-accent-hover);
+  @include focus-ring('strong');
+
+  svg {
+    width: 1.7rem;
+    height: 1.7rem;
+  }
 }

--- a/src/app/(content)/news/gallery/_component/gallery.module.scss
+++ b/src/app/(content)/news/gallery/_component/gallery.module.scss
@@ -675,10 +675,9 @@
   flex: 1;
   min-width: 0;
 
-  // Textarea 기본 min-height(≈78px)·16px는 댓글 한 줄 바엔 과해 낮춘다(autoGrow로 입력 시 늘어남).
+  // Textarea 기본 min-height(8rem)는 댓글 한 줄 바엔 과해 낮춘다(font-size는 전역 13px 상속, autoGrow로 늘어남).
   textarea {
     min-height: 3.6rem;
-    font-size: $font-size-14;
   }
 }
 

--- a/src/app/(content)/news/gallery/_data/posts.ts
+++ b/src/app/(content)/news/gallery/_data/posts.ts
@@ -22,12 +22,32 @@ export const GALLERY_POSTS: GalleryPost[] = [
     reactions: { 은혜: 42, 아멘: 18, 기도해요: 7, 축복: 4 },
     viewerReaction: '은혜',
     commentCount: 3,
-    topComment: {
-      authorName: '박믿음',
-      avatarInitial: '박',
-      avatarColor: '#A9713B',
-      text: '저도 그 자리에 있었는데 정말 은혜로웠어요'
-    }
+    comments: [
+      {
+        id: 'c1-1',
+        authorName: '박믿음',
+        avatarInitial: '박',
+        avatarColor: '#A9713B',
+        createdLabel: '1시간 전',
+        text: '저도 그 자리에 있었는데 정말 은혜로웠어요'
+      },
+      {
+        id: 'c1-2',
+        authorName: '이한결',
+        avatarInitial: '이',
+        avatarColor: '#6B8E5A',
+        createdLabel: '52분 전',
+        text: '사진만 봐도 그날 감동이 다시 떠오르네요 🙏'
+      },
+      {
+        id: 'c1-3',
+        authorName: '최소망',
+        avatarInitial: '최',
+        avatarColor: '#B0975F',
+        createdLabel: '30분 전',
+        text: '다음 주에도 같이 찬양해요!'
+      }
+    ]
   },
   {
     id: 'p2',
@@ -42,12 +62,24 @@ export const GALLERY_POSTS: GalleryPost[] = [
     reactions: { 은혜: 51, 아멘: 12, 기도해요: 6, 축복: 23 },
     viewerReaction: '축복',
     commentCount: 5,
-    topComment: {
-      authorName: '정소망',
-      avatarInitial: '정',
-      avatarColor: '#9C6B4E',
-      text: '수고 많으셨어요! 다음엔 저도 함께할게요'
-    }
+    comments: [
+      {
+        id: 'c2-1',
+        authorName: '정소망',
+        avatarInitial: '정',
+        avatarColor: '#9C6B4E',
+        createdLabel: '20시간 전',
+        text: '수고 많으셨어요! 다음엔 저도 함께할게요'
+      },
+      {
+        id: 'c2-2',
+        authorName: '한사랑',
+        avatarInitial: '한',
+        avatarColor: '#7C8B54',
+        createdLabel: '18시간 전',
+        text: '깨끗해진 예배당 보니 마음이 다 개운하네요'
+      }
+    ]
   },
   {
     id: 'p3',
@@ -62,12 +94,24 @@ export const GALLERY_POSTS: GalleryPost[] = [
     reactions: { 은혜: 19, 아멘: 6, 기도해요: 14, 축복: 3 },
     viewerReaction: '기도해요',
     commentCount: 2,
-    topComment: {
-      authorName: '한사랑',
-      avatarInitial: '한',
-      avatarColor: '#7C8B54',
-      text: '아이들 표정이 너무 밝아요 🙂'
-    }
+    comments: [
+      {
+        id: 'c3-1',
+        authorName: '한사랑',
+        avatarInitial: '한',
+        avatarColor: '#7C8B54',
+        createdLabel: '2일 전',
+        text: '아이들 표정이 너무 밝아요 🙂'
+      },
+      {
+        id: 'c3-2',
+        authorName: '오평강',
+        avatarInitial: '오',
+        avatarColor: '#7A6654',
+        createdLabel: '1일 전',
+        text: '다음세대를 위해 기도합니다'
+      }
+    ]
   },
   {
     id: 'p4',
@@ -86,12 +130,32 @@ export const GALLERY_POSTS: GalleryPost[] = [
     reactions: { 은혜: 33, 아멘: 27, 기도해요: 9, 축복: 11 },
     viewerReaction: '아멘',
     commentCount: 8,
-    topComment: {
-      authorName: '김찬양',
-      avatarInitial: '김',
-      avatarColor: '#B67C4B',
-      text: '연습 소리만 들어도 벌써 은혜받아요'
-    }
+    comments: [
+      {
+        id: 'c4-1',
+        authorName: '김찬양',
+        avatarInitial: '김',
+        avatarColor: '#B67C4B',
+        createdLabel: '3일 전',
+        text: '연습 소리만 들어도 벌써 은혜받아요'
+      },
+      {
+        id: 'c4-2',
+        authorName: '이든',
+        avatarInitial: '이',
+        avatarColor: '#6B8E5A',
+        createdLabel: '2일 전',
+        text: '이번 주 찬양 기대할게요 🙌'
+      },
+      {
+        id: 'c4-3',
+        authorName: '한지혜',
+        avatarInitial: '한',
+        avatarColor: '#A57C55',
+        createdLabel: '2일 전',
+        text: '섬겨주셔서 감사합니다'
+      }
+    ]
   },
   {
     id: 'p5',
@@ -111,12 +175,16 @@ export const GALLERY_POSTS: GalleryPost[] = [
     reactions: { 은혜: 24, 아멘: 8, 기도해요: 5, 축복: 16 },
     viewerReaction: null,
     commentCount: 1,
-    topComment: {
-      authorName: '오은총',
-      avatarInitial: '오',
-      avatarColor: '#96693F',
-      text: '다음 모임이 벌써 기다려집니다'
-    }
+    comments: [
+      {
+        id: 'c5-1',
+        authorName: '오은총',
+        avatarInitial: '오',
+        avatarColor: '#96693F',
+        createdLabel: '4일 전',
+        text: '다음 모임이 벌써 기다려집니다'
+      }
+    ]
   },
   {
     id: 'p6',
@@ -131,6 +199,6 @@ export const GALLERY_POSTS: GalleryPost[] = [
     reactions: { 은혜: 15, 아멘: 21, 기도해요: 30, 축복: 6 },
     viewerReaction: '기도해요',
     commentCount: 0,
-    topComment: null
+    comments: []
   }
 ];

--- a/src/app/(content)/news/gallery/_types.ts
+++ b/src/app/(content)/news/gallery/_types.ts
@@ -1,11 +1,17 @@
 // 갤러리 피드 읽기용 타입 — 참여형 스키마(docs/references/gallery)의 표시 필요분만 추린 축약본.
 // 쓰기(작성·반응 토글·댓글)·모더레이션·업로드는 후속 단계라 여기 없다.
 
-// 카테고리는 게시글 데이터에 남겨 스키마 충실도를 유지한다. 카테고리 필터 UI는 후속 단계라
-// 지금은 export하지 않는다(GalleryCategory 타입 파생에만 쓰인다).
-const GALLERY_CATEGORIES = ['주일예배', '청년부', '다음세대', '봉사', '나눔', '기도'] as const;
+export const GALLERY_CATEGORIES = ['주일예배', '청년부', '다음세대', '봉사', '나눔', '기도'] as const;
 
 export type GalleryCategory = (typeof GALLERY_CATEGORIES)[number];
+
+// 공개 범위 — 작성 모달 마지막 단계.
+export const GALLERY_SCOPES = [
+  { value: 'public', label: '전체 공개', desc: '모든 사람이 볼 수 있어요' },
+  { value: 'members', label: '교인만 보기', desc: '로그인한 교인에게만 보여요' }
+] as const;
+
+export type GalleryScope = (typeof GALLERY_SCOPES)[number]['value'];
 
 export const REACTION_TYPES = ['은혜', '아멘', '기도해요', '축복'] as const;
 
@@ -19,9 +25,11 @@ export type GalleryPhoto = {
 };
 
 export type GalleryComment = {
+  id: string;
   authorName: string;
   avatarInitial: string;
   avatarColor: string;
+  createdLabel: string; // mock 상대 시각 (예: '1시간 전')
   text: string;
 };
 
@@ -37,6 +45,6 @@ export type GalleryPost = {
   photos: GalleryPhoto[];
   reactions: Record<ReactionType, number>;
   viewerReaction: ReactionType | null; // 강조할 반응 (mock)
-  commentCount: number;
-  topComment: GalleryComment | null;
+  commentCount: number; // 총 댓글 수(표시용). 아래 comments는 화면에 노출하는 목록.
+  comments: GalleryComment[];
 };

--- a/src/app/(content)/news/gallery/page.tsx
+++ b/src/app/(content)/news/gallery/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import MainContainer from '@/components/layout/container/MainContainer';
-import GalleryComposer from './_component/GalleryComposer';
-import GalleryFeed from './_component/GalleryFeed';
+import GalleryBoard from './_component/GalleryBoard';
 import { GALLERY_POSTS } from './_data/posts';
 import styles from './page.module.scss';
 
@@ -16,8 +15,7 @@ export default function GalleryPage() {
       {/* Hero 제거로 사라진 페이지 제목 — 시각은 MobileHeader가 대신하고, 데스크톱·스크린리더용 h1을 둔다 */}
       <h1 className={styles.blind_title}>갤러리</h1>
       <div className={styles.wrap}>
-        <GalleryComposer />
-        <GalleryFeed posts={GALLERY_POSTS} />
+        <GalleryBoard posts={GALLERY_POSTS} />
       </div>
     </MainContainer>
   );

--- a/src/components/ui/BottomSheet/BottomSheet.module.scss
+++ b/src/components/ui/BottomSheet/BottomSheet.module.scss
@@ -56,6 +56,30 @@
   }
 }
 
+// 풀스크린 변형 — 모바일은 화면 전체, PC는 좁은 중앙 모달. 콘텐츠가 자체 패딩을 갖는다.
+.sheet.full {
+  height: 100dvh;
+  max-height: none;
+  border-radius: 0;
+
+  .body {
+    padding: 0;
+  }
+
+  @include respond-up($breakpoint-pc-sm) {
+    height: auto;
+    max-height: 90dvh;
+    min-width: 0;
+    width: min(46rem, 100%);
+    border-radius: $radius-l;
+  }
+}
+
+// 커스텀 헤더 슬롯 — 콘텐츠가 스타일을 소유한다(뒤로가기·진행바·우측 액션).
+.custom_header {
+  flex-shrink: 0;
+}
+
 .handle {
   flex-shrink: 0;
   width: 3.6rem;

--- a/src/components/ui/BottomSheet/BottomSheet.tsx
+++ b/src/components/ui/BottomSheet/BottomSheet.tsx
@@ -20,6 +20,10 @@ type Props = PropsWithChildren<{
   footer?: ReactNode;
   /** 열릴 때 history 엔트리를 쌓아 기기 뒤로가기로 시트를 닫는다(모바일 콘텐츠 시트용). @default false */
   enableHistory?: boolean;
+  /** `full`은 모바일 풀스크린(핸들·바디 패딩 제거). PC에서는 좁은 중앙 모달. @default 'default' */
+  size?: 'default' | 'full';
+  /** 커스텀 헤더. 제공하면 기본 title/close 헤더 대신 이 노드를 렌더한다(뒤로가기·진행바·우측 액션 등). 이때 dialog 라벨은 `ariaLabel`을 쓴다. */
+  header?: ReactNode;
 }>;
 
 /**
@@ -43,6 +47,8 @@ export function BottomSheet({
   showClose = true,
   footer,
   enableHistory = false,
+  size = 'default',
+  header,
   children
 }: Props) {
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -72,29 +78,33 @@ export function BottomSheet({
       >
         <div
           ref={panelRef}
-          className={clsx(styles.sheet, open && styles.open)}
+          className={clsx(styles.sheet, size === 'full' && styles.full, open && styles.open)}
           role="dialog"
           aria-modal="true"
-          {...(trimmedTitle
+          {...(trimmedTitle && !header
             ? { 'aria-labelledby': titleId }
             : { 'aria-label': accessibleLabel })}
           tabIndex={-1}
         >
-          <div className={styles.handle} aria-hidden="true" />
-          {showHeader && (
-            <header className={styles.header}>
-              {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
-              {showClose && (
-                <button
-                  type="button"
-                  className={styles.close_btn}
-                  onClick={onClose}
-                  aria-label="닫기"
-                >
-                  <IoClose />
-                </button>
-              )}
-            </header>
+          {size !== 'full' && <div className={styles.handle} aria-hidden="true" />}
+          {header ? (
+            <div className={styles.custom_header}>{header}</div>
+          ) : (
+            showHeader && (
+              <header className={styles.header}>
+                {trimmedTitle && <h2 id={titleId} className={styles.title}>{title}</h2>}
+                {showClose && (
+                  <button
+                    type="button"
+                    className={styles.close_btn}
+                    onClick={onClose}
+                    aria-label="닫기"
+                  >
+                    <IoClose />
+                  </button>
+                )}
+              </header>
+            )
           )}
           <div className={styles.body}>{children}</div>
           {footer && <footer className={styles.footer}>{footer}</footer>}

--- a/src/components/ui/Textarea/Textarea.module.scss
+++ b/src/components/ui/Textarea/Textarea.module.scss
@@ -20,7 +20,7 @@
   width: 100%;
   min-height: 8rem;
   padding: $spacing-12;
-  font-size: $font-size-16; // iOS auto-zoom 방지
+  font-size: $font-size-13;
   font-family: inherit;
   line-height: $line-height-base;
   color: $txt-primary;
@@ -32,6 +32,7 @@
 
   &::placeholder {
     color: $txt-tertiary;
+    font-size: inherit;
   }
 
   &:hover:not(:disabled):not([readonly]) {


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: gallery-feed(읽기 전용)에서 뺐던 목업의 두 모달 — **나눔글 작성 모달**(3단계 위저드)과 **게시글 상세 모달** — 을 UI로 구현한다(mock, 실제 제출·저장 없음).

**범위**:

- 컴포저 탭 → 작성 모달(사진 선택 → 이야기 → 카테고리+공개 범위 → 올리기)
- 카드 사진·"댓글 N"·"모두 보기" 탭 → 상세 모달(사진 라이트박스·댓글 목록·입력)
- `BottomSheet`에 `size="full"`·`header` 선택 prop 추가(기존 콜러 무영향)

---

## 🔗 개발 컨텍스트

- **Task ID**: `gallery-modals`
- **Exec Plan**: `docs/exec-plans/active/2026-07-05-gallery-modals.md`
- **관련 PR**: #145 (gallery-feed 읽기 전용 피드) 후속
- **관련 ADR**: 해당 없음 (app 컴포넌트 + 공용 컴포넌트 선택 prop 추가)
- **작업 범위**: 두 모달 UI + 피드 client 배선 (`src/app/(content)/news/gallery/`, `src/components/ui/BottomSheet/`)
- **제외한 범위**: 실제 글 작성·사진 업로드·댓글 저장·반응 토글, 게시글 상세 라우트(`/[id]`), 신고·대댓글, DB·서비스·인증 배선

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

gallery-feed는 읽기 전용이라 컴포저 바와 카드가 탭해도 아무 동작을 안 했다. 목업의 참여형 흐름(글 작성·게시글 상세)을 UI로 먼저 완성해, 스키마·쓰기 연동을 붙일 자리를 만들었다.

**관련 이슈:**

- 해당 없음 (개인 사이드 프로젝트)

---

## 🔧 주요 변경점 (Key Changes)

- `BottomSheet` — `size="full"`(모바일 풀스크린·핸들/바디 패딩 제거, PC 좁은 중앙 모달)와 `header`(커스텀 헤더 슬롯) 선택 prop을 추가했다. 기본값 경로가 이전과 동일해 기존 콜러 5곳은 영향받지 않는다.
- `GalleryComposeSheet` — 3단계 위저드(사진 선택·이야기 Textarea 0/500·카테고리 Pill+공개 범위 라디오). 세그먼트 진행·이전/다음/올리기. 올리기는 안내 토스트 후 닫기(mock).
- `GalleryPostSheet` — 게시글 상세(작성자·카테고리 배지·사진·반응·"댓글 N"·댓글 목록[공감/답글]·하단 입력). 사진 탭 시 PhotoSwipe 라이트박스.
- `GalleryBoard`(신규 client) — 컴포저·피드·두 모달의 열림 상태를 쥔다. 컴포저 버튼화 + 카드 `onOpenDetail` 배선.
- `GalleryPhotos` — 피드=사진 전체가 상세 열기 버튼, 상세=개별 라이트박스 2모드로 분기.
- `_types.ts`·`_data/posts.ts` — 댓글 목록(comments[])과 공개 범위 상수 mock 확장.

---

## 📸 스크린샷 (Screenshots)

> 모바일(대구동남교회는 모바일 퍼스트). 작성 모달 3단계 + 상세 모달을 담습니다.

| 화면 | 모바일 |
| ---- | ------ |
| 작성 모달 ① 사진 선택 |  <img width="365" height="568" alt="image" src="https://github.com/user-attachments/assets/b051a8ce-10ba-4d2b-a4bd-429035db090e" />|
| 작성 모달 ② 이야기 |<img width="363" height="570" alt="image" src="https://github.com/user-attachments/assets/1df2ce64-9f0e-45da-9c5e-ea907803bd7d" />|
| 작성 모달 ③ 카테고리·공개 범위 |<img width="363" height="565" alt="image" src="https://github.com/user-attachments/assets/bce7f714-89ad-4e46-9822-e869ab530bdd" />|
| 게시글 상세(댓글·라이트박스) |<img width="365" height="772" alt="image" src="https://github.com/user-attachments/assets/7cf3664f-c705-4bf0-bdfd-e4b1d2a85564" />|


---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 풀스크린 모달 | `BottomSheet`에 `size`/`header` prop 추가 | focus trap·scroll lock·기기 뒤로가기·PC 중앙 모달을 그대로 재사용 | 풀스크린 오버레이 자작 — a11y 재구현·portal 자작 금지 규칙에 걸려 버림 |
| 작성 올리기·댓글 전송 | mock(안내 토스트 후 닫기) | 읽기 전용/UI 단계라 저장·업로드 경로가 없다 | 실제 mutation — 스키마·인증 선행이라 후속으로 |
| 전송 버튼 | 원형 아이콘 버튼(도메인 컨트롤) | 목업의 원형 전송을 재현. Button(텍스트 버튼)은 아이콘 전용에 안 맞아 찌그러졌다 | Button size="sm" — 32×24 사각형으로 깨져 버림 |

> ⚠️ **트레이드오프:** mock 데이터(댓글·사진)라 실데이터 연동 시 `posts.ts`를 교체해야 한다. 댓글 input은 13.6px로 iOS 포커스 시 확대가 날 수 있다(댓글 바에 한정).

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs gallery-modals` — PASS, RUN_ID=`20260705-193739`, failed=0, warned=Knip |
| `harness-gate` | N/A (머지 직전 실행) |
| Codex 계획 검증 | N/A (사용자 승인·저위험 — [[project_codex_windows_unavailable]]) |
| Codex 1차 검증 | N/A (공용 컴포넌트 회귀는 Claude가 직접 확인·build로 전 콜러 컴파일) |
| Claude 2차 검증 | 완료 (PASS) |
| ADR 판단 | 불필요 (app 컴포넌트 + 선택 prop) |
| 남은 warning | 기존 부채 (Knip) — 신규 0 |

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 요구사항 전체 충족 (작성 3단계·상세·라이트박스·닫기 실측)
- [x] Null·빈 배열 처리 (`comments` 빈 배열 → "아직 댓글이 없어요", `photos` 빈 배열 가드)

**코드 품질**

- [x] 변수명·함수명 의도 명확
- [x] 불필요한 코드·디버그 로그 없음

**보안 및 견고성**

- [x] 하드코딩 비밀값 없음
- [x] 입력 검증 (mock·비제출 — 저장 경로 없음)

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 컴포저 탭 → 작성 모달, 카드 탭 → 상세 모달이 열린다(둘 다 mock, 실제 저장 없음).
- **운영 리스크**: 없음 — DB·환경변수와 무관. 공용 `BottomSheet` 변경은 선택 prop이라 기존 콜러 무영향(build로 확인).
- **QA 후속**: 실제 스키마·쓰기 연동, 상대 시간 계산, mock 사진 큐레이션.
- **롤백 시 영향**: 없음 — 컴포저/카드가 다시 정적으로 돌아갈 뿐.
- **먼저 볼 화면 / 흐름**: `/news/gallery` → 컴포저 탭(작성 3단계) / 카드 사진 탭(상세 → 사진 라이트박스).

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 두 모달은 `BottomSheet size="full"` + 커스텀 `header`/`footer` 슬롯으로 만든다. 헤더는 콘텐츠가 소유(뒤로가기·진행바·우측 액션).
- 쓰기 붙일 때: 올리기·댓글 전송을 Server Action + `createServerSideClient`로. 지금은 `useToastStore().info()`로 안내만.
- `GalleryPhotos`는 `onOpen` 유무로 피드(상세 열기)·상세(라이트박스)를 분기한다.
- 별건: 공용 `Textarea` 기본 font-size(16px→13px, iOS auto-zoom 방지 주석)는 이 PR과 분리했다(전역 영향·iOS 확대 검토 필요).
