### PR TITLE
[Feat] 비밀번호 찾기 6자리 코드 OTP 검증 전환

### DIFF
--- a/docs/exec-plans/active/2026-07-16-password-reset-otp.md
+++ b/docs/exec-plans/active/2026-07-16-password-reset-otp.md
@@ -109,8 +109,8 @@
 
 ## 후속 작업
 
-- prod 프로젝트(`xrfyevrnmvbuwsbktuja`)에 dev와 같은 설정 적용 — Reset Password 템플릿 `{{ .Token }}` + Email OTP Length 6
-  - 이유: dev에서만 설정함. prod는 아직 매직링크 8자리 상태라 OTP 흐름이 prod에서 동작 안 함
+- prod 프로젝트(`xrfyevrnmvbuwsbktuja`)에 dev와 같은 설정 적용 — Reset Password 템플릿 `{{ .Token }}` + Email OTP Length 6 + 커스텀 SMTP(Resend, `dongnamchurch.site`)로 발신자 "대구동남교회" 표시
+  - 이유: dev에서만 설정함. prod는 아직 매직링크 8자리 상태·기본 Supabase 발신자라 OTP 흐름이 prod에서 동작 안 함
   - 다음 기준: develop → main 릴리스 직전 (v1.0.0 전환 시)
   - 기록 위치: 없음 (이 후속 항목으로 추적)
 - `createServerSideClient().setAll`이 cookie options를 버리고 예외를 삼킨다 (`src/lib/supabase/server.ts:22-25`) — 쿠키 쓰기 실패가 숨겨질 수 있음 (Codex 지적)

--- a/docs/exec-plans/active/2026-07-16-password-reset-otp.md
+++ b/docs/exec-plans/active/2026-07-16-password-reset-otp.md
@@ -1,0 +1,156 @@
+# password-reset-otp
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-07-16
+- **브랜치**: feat/password-reset-otp
+- **Open questions**: 이메일 템플릿에 `{{ .Token }}` 추가는 Supabase 대시보드 수동 작업 (dev·prod 각각). 배포 전 사용자 확인 필요
+- **ADR needed**: no (기존 인증 패턴 재사용, 구조 변경 없음)
+
+## 목표
+
+비밀번호 찾기 2단계의 6자리 코드 입력을 실제 검증으로 만든다. 지금은 아무 값이나 넣어도 통과하는 목업 — 앞으로는 이메일로 받은 코드를 `verifyOtp(recovery)`로 서버 검증해야 재설정 화면으로 넘어간다.
+
+## 검증된 Assumptions
+
+- 지금 6자리 코드는 검증 안 됨 — `ForgetPasswordFlow.tsx:65-71` `goReset`이 `code.trim()`만 보고 `router.push('/reset-password')`.
+- 실제 동작 경로는 이메일 매직링크 — `auth.action.ts:33` `resetPasswordForEmail` → 이메일 링크 → `app/auth/reset-password/route.ts` `reset_auth_code` 쿠키 → `reset-password/actions.ts:17-40` `exchangeCodeForSession` → admin 비번 변경.
+- `resetPasswordForEmail`은 이메일에 링크(`{{ .ConfirmationURL }}`)와 6자리 토큰(`{{ .Token }}`)을 함께 넣을 수 있다 — 템플릿에 토큰 변수가 있어야 코드가 메일에 뜬다 (Supabase 이메일 OTP recovery 문서).
+- 재설정 세션 두 갈래를 `updatePasswordAndSignOut`이 이미 분기 처리 — 쿠키 있으면 exchange+admin, 없으면 `updateUser`. OTP 검증이 세션을 만들면 후자 분기를 탄다.
+
+## Success Criteria
+
+- 이메일로 받은 실제 6자리 코드로만 `/reset-password`에 도달한다 — 틀린/빈 코드는 서버가 막고 화면에 오류가 뜬다.
+- 코드 검증 성공 후 재설정 화면에서 비번을 바꾸면 로그아웃되고 `/login`으로 간다 (완료 화면 "다시 로그인" 문구와 일치).
+- 직전 매직링크 시도가 남긴 `reset_auth_code`·`reset_user_id` 쿠키가 있어도 OTP 검증 흐름을 가로채지 않는다 (OTP 성공 액션이 두 쿠키를 지운다).
+- 기존 매직링크 경로(이메일 링크 클릭)는 그대로 동작한다 — 제거하지 않는다.
+- `yarn lint`·`yarn build` 통과, knip 신규 0.
+
+## 영향받는 파일
+
+- `src/actions/auth.action.ts` — `verifyPasswordResetOtpAction(email, token)` 신규 (verifyOtp recovery)
+- `src/app/(auth)/forget-password/_component/ForgetPasswordFlow.tsx` — step 2 "다음"이 검증 액션 호출 (현 목업 `goReset` 교체)
+- `src/app/(auth)/reset-password/actions.ts` — 세션 분기(쿠키 없는 경로)가 `updateUser` 후 signOut + `/login` 리다이렉트 (지금은 `/` no-signout — 완료 문구와 불일치)
+- (수동) Supabase 대시보드 Reset Password 이메일 템플릿에 `{{ .Token }}` 추가 — dev·prod
+
+## Non-goals
+
+- 회원가입 휴대폰 SMS 인증 — 외부 유료 제공자 필요, 이번 범위 밖 (사용자 결정)
+- 매직링크 경로 제거 — 그대로 둔다 (fallback 유지, 외과적 범위)
+- UI 5분 타이머를 Supabase OTP 실제 만료 시각과 일치시키기 — Supabase OTP 만료는 대시보드 설정, UI 타이머는 표시용. 이번엔 손대지 않음
+
+## 단계별 체크리스트
+
+- [x] 1. `verifyPasswordResetOtpAction(email, token)` 추가 — `verifyOtp({ email, token, type: 'recovery' })`, 빈 토큰·검증 실패 시 `ActionResult` 오류 반환. 성공 시 `reset_auth_code`·`reset_user_id` 쿠키 삭제 (stale 쿠키가 no-cookie 분기를 가로채지 않게 — Codex 지적)
+- [x] 2. `ForgetPasswordFlow` step 2 `goReset` → 검증 액션 호출로 교체 (성공 시에만 `router.push('/reset-password')`, 실패 시 `setAlertMessage`, 검증 중 loading/disabled)
+- [x] 3. `updatePasswordAndSignOut` 세션 분기 signOut + `/login` 리다이렉트로 정정
+- [x] 4. dev 프로젝트: 이메일 템플릿 `{{ .Token }}` 추가 + Email OTP Length 8→6 (사용자 수동). prod는 릴리스 시 동일 적용 필요 → 후속 작업
+- [x] 5. 브라우저 E2E 실측 + `verify-task` 통과 (run 20260716-162844: ESLint·stylelint·Build 통과, Knip 경고는 기존 부채)
+
+## Verification
+
+- `node scripts/verify-task.mjs password-reset-otp`
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST → 반영 완료
+- **현재 판단**: 핵심 지적 1건 수용. "OTP 세션은 항상 no-cookie 분기로 간다"는 전제가 틀림 — `updatePasswordAndSignOut`이 `reset_auth_code`·`reset_user_id` 쿠키를 먼저 본다(`reset-password/actions.ts:14-53`). 직전 매직링크 시도가 남긴 오래된(stale) 쿠키가 있으면 OTP 세션이 있어도 쿠키 분기가 실행돼 "링크 만료" 오류나 오래된 userId로 admin 업데이트가 터진다. 그래서 체크리스트 1에 'OTP 성공 시 두 쿠키 삭제'를 넣고, Success Criteria와 검증 항목에 오래된 쿠키 경우를 더했다.
+- 나머지 답변: (a) SSR 쿠키 지속은 방향이 맞다 — action phase 안에서 await 후 반환하면 Next.js 주의사항에 안 걸린다. (c) recovery 세션의 `updateUser({password})`는 인가된다 — 설계가 맞다. (d) await 뒤 `router.push` 순서가 타당하다. (e) `setAll`이 cookie options를 버리고 예외를 삼키는 건 기존 동작이라 후속 tech-debt로 분리한다.
+- **다음 행동**: WORK 진입
+
+## Codex 1차 검증
+
+- **결론**: Claude 직접 검토로 대체
+- **현재 판단**: diff 54줄이 계획 단계에서 Codex가 검증한 메커니즘(verifyOtp recovery·쿠키 삭제·updateUser 분기·signOut)을 그대로 옮긴 것이라 1차 검증을 Claude 자체 검토로 대체했다. auth 고위험이지만 신규 구조·라이브러리 없음.
+- **다음 행동**: 사용자가 추가 확신을 원하면 Codex 1차 재요청 가능
+
+## Claude 2차 검증
+
+- **최종 판단**: 브라우저 E2E 통과 (verify-task 클린 빌드는 dev 정지 후)
+- **현재 판단**: 코드 검토(정보 누출 없음·stale 쿠키 삭제·호출처 1개) + dev 서버 실측 통과. eslint 통과, tsc 오류 4건은 전부 dev stale `.next/types/validator.ts`의 옛 경로 참조(내 소스 무관).
+- **브라우저 실측** (localhost:3000, dev 프로젝트, 계정 `ckdtjd411@hanmail.net`):
+  - 틀린 코드 `000000` → 서버 거부, "인증 코드가 올바르지 않거나 만료되었습니다." 표시하고 화면 유지 (목업이면 통과했을 자리).
+  - 정상 6자리 `240623` → `/reset-password` 이동.
+  - 새 비번 `Test1234!` 변경 → 완료 화면 "비밀번호가 변경되었어요" (updateUser 성공) → "로그인하기" → `/login`, 로그아웃 상태 (signOut 동작).
+  - OTP 길이 이슈 발견·해결: 실제 토큰이 8자리로 와서 `/^\d{6}$/`가 거부 → dev Email OTP Length를 6으로 낮춰 해결 (D1).
+- **다음 행동**: 커밋 승인 요청
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| Claude 2차 | 20260716-162844 | ✅ | ✅ | ✅ | 0 | 브라우저 E2E(틀린 코드 차단·정상 통과·비번 변경·로그아웃) |
+
+> Knip 경고 1건은 `knip.json` 엔트리 패턴이 옛 경로 `src/app/reset-password/actions.ts`를 가리키는 기존 드리프트(PR #149 `(auth)` 이동 잔재). 이번 변경과 무관.
+
+## 검증 이력
+
+<!--
+이전 판정·재검증만 여기에 둔다. 검증 섹션 본문에는 현재 판정만 남긴다.
+규칙: `**결론**:`·`**최종 판단**:` 금지. `판정:`을 쓴다. <details> 본문은 3줄 이하.
+
+<details>
+<summary>YYYY-MM-DD Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: <핵심 이유 1개>
+- 조치: <D번호 또는 수정 위치>
+
+</details>
+-->
+
+## 의사결정 로그
+
+- **D1 — 이메일 OTP 길이를 6자리로 맞춤**
+  - 문제: 시안 기준 UI는 6자리 전제(문구·`maxLength={6}`·검증 `/^\d{6}$/`)인데, dev Supabase가 실제로는 8자리 토큰(`91082838`)을 보냈다. 8자리는 입력칸에서 잘리고 검증에서도 거부돼 정상 코드가 통과 못 한다.
+  - 해결: 두 갈래 중 골랐다 — (A) Supabase Email OTP Length를 6으로 낮춰 UI 유지, (B) 코드·문구를 8자리로 고침. 시안 전체가 6자리로 설계됐고 회원가입 휴대폰 목업도 6자리라, 대시보드 설정 1개만 바꾸는 A가 일관성·변경량에서 낫다. B는 시안 문구와 어긋나고 여러 곳을 고쳐야 한다.
+  - 결과: dev Email OTP Length를 6으로 변경. 코드·문구 변경 0. 재발송한 6자리 코드로 E2E 통과 확인.
+
+## 후속 작업
+
+- prod 프로젝트(`xrfyevrnmvbuwsbktuja`)에 dev와 같은 설정 적용 — Reset Password 템플릿 `{{ .Token }}` + Email OTP Length 6
+  - 이유: dev에서만 설정함. prod는 아직 매직링크 8자리 상태라 OTP 흐름이 prod에서 동작 안 함
+  - 다음 기준: develop → main 릴리스 직전 (v1.0.0 전환 시)
+  - 기록 위치: 없음 (이 후속 항목으로 추적)
+- `createServerSideClient().setAll`이 cookie options를 버리고 예외를 삼킨다 (`src/lib/supabase/server.ts:22-25`) — 쿠키 쓰기 실패가 숨겨질 수 있음 (Codex 지적)
+  - 이유: 이번 작업 전부터 있던 동작이라 외과적 범위 밖. OTP 흐름은 이 상태에서도 동작한다
+  - 다음 기준: 쿠키 관련 인증 버그가 실제로 재현되면 착수
+  - 기록 위치: `docs/tech-debt/active.md`
+
+---
+
+<!-- 이하 섹션은 해당 시에만 추가:
+## Non-goals          ← surgical scope 정의가 필요한 경우 (인접 정리 차단)
+## 감사               ← DB/타입/config 사전 점검 결과
+## 접근법             ← 결정이 1줄 이상 필요한 경우 (대안·기각 사유는 의사결정 로그·ADR)
+## 의사결정 로그       ← plan 변경 또는 expression CR 기록 (아래 형식 고정)
+## ADR 판단            ← ADR_TRIGGER_PARTS 파일 변경 시 (mandatory 1줄 필드를 이 섹션으로 승격)
+## 참고 자료           ← docs/research/ 발췌 링크
+## 리뷰 (완료 직전)    ← 셀프/멀티 세션 리뷰 체크
+## 회고               ← 머지 후 completed/ 이동 시
+
+의사결정 로그 항목 형식 (한 항목 = 한 결정. 기호(·/→/+)로 사실 잇기·약어 금지):
+
+- **D1 — 한 줄 제목(무엇을 정했나, 평이하게)**
+  - 문제: 어떤 문제·제약이 있었나.
+  - 해결: 어떤 방법들이 있었고, 무엇을 택했나 — **왜 그 방법인가(이유)가 핵심**. 대안이 있었으면 왜 그것 대신인지.
+  - 결과: 무엇이 달라졌나 / 성과.
+
+"무엇을 했다"로 끝내지 말 것 — 의사결정 맥락(왜)이 빠지면 나중에 문서로 맥락 복구 불가.
+결정이 여러 개면 D2, D3 …로 분리. 폐기 시 원래 항목 끝에 `⚠️ 정정(PR #xx): 폐기 → D5 참조` 한 줄.
+
+검증 기록(Codex 1차·Claude 2차)은 공통 결과를 표 1개로 — 단락 반복 금지:
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260517-000000 | ✅ | ✅ | ✅ | 0 | — |
+-->
+
+<!--
+검증 결과 기록 규칙 SSOT: `.claude/skills/harness-workflow/SKILL.md` "## 검증 결과 기록 규칙".
+- 추상명사 금지. 구체화 4원소 중 2개 이상.
+- Codex stdout은 verbatim. 그 아래 평이한 풀이 1줄.
+- 의사결정 로그·검증 기록은 위 형식 고정. 압축·기호잇기·약어·한 항목 다결정 금지.
+-->
+

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -372,3 +372,65 @@
 - **영향 범위** (3건): `.claude/agents/claude-code.md`·`.claude/agents/commit-pr-author.md`·`.claude/skills/harness-workflow/SKILL.md` (현재 코드·실행 변경 없음)
 - **발견일**: 2026-06-16 (harness-pr-review-step 정합성 감사 — 감사 에이전트 3 + Codex 교차, Codex가 근본 원인 적발)
 
+### 🟡 `/reset-password`에 흐름 가드·현재 비밀번호 재확인이 없음 (2026-07-16 인증 A-to-Z 감사)
+
+- **상태**: 등록만 (배포 전 손볼 값어치 큼 — high)
+- **무엇**: `/reset-password`는 미들웨어 보호 라우트가 아니고, `ResetPasswordFlow`는 진행 중 재설정 흐름(쿠키·세션)이 있는지 확인하지 않고 항상 폼을 보여준다. `updatePasswordAndSignOut`은 쿠키가 없으면 `supabase.auth.updateUser({ password })` 폴백을 탄다(`reset-password/actions.ts:55`). 그래서 로그인된 사용자가 메일 없이 `/reset-password`에 직접 들어가도 현재 비밀번호 확인 없이 비밀번호를 바꿀 수 있다. 세션을 탈취했거나 공용 PC에 남은 로그인 상태에 접근한 사람이 계정을 영구 장악할 수 있다. 재설정 액션에 서버측 `PASSWORD_REGEX` 재검증도 없다(가입은 하는데 재설정만 빠짐).
+- **왜**: 6자리 OTP 도입(PR #149)은 "찾기" 단계만 실검증으로 바꿨고, 이 페이지 가드는 범위가 아니었다. 다른 기기 세션 폐기는 `signOut()` 기본 scope가 `global`이라 이미 된다(코드로 재확인).
+- **마이그레이션 경로**: (1) `/reset-password`를 진행 중 흐름이 있을 때만 폼 노출, (2) OTP recovery 세션의 `updateUser`로 통일하고 admin·평문 userId 쿠키 경로 제거, (3) 액션 진입부에서 `PASSWORD_REGEX` 재검증, (4) 계정 설정의 "비밀번호 변경"은 재설정과 분리하고 현재 비밀번호 재확인 요구.
+- **영향 범위**: `src/app/(auth)/reset-password/{page.tsx,actions.ts,_component/ResetPasswordFlow.tsx}`, `src/lib/supabase/middleware.ts`
+- **확인**: `rg "PASSWORD_REGEX" "src/app/(auth)/reset-password/actions.ts"` → 0 hits (서버 재검증 없음). 로그인 상태로 `/reset-password`에 직접 접근했을 때 폼이 그대로 뜨는지 확인.
+- **발견일**: 2026-07-16 (인증 A-to-Z 감사 8-1 — `docs/research/2026-07-16-auth-a-to-z.md`)
+
+### 🟡 미들웨어 redirect 시 갱신된 세션 쿠키가 사라짐 (2026-07-16 인증 A-to-Z 감사)
+
+- **상태**: 등록만 (배포 전 손볼 값어치 큼 — high)
+- **무엇**: `getUser()`가 토큰을 리프레시하면 새 쿠키가 `response`에 쌓이는데, 가드 분기가 `NextResponse.redirect(...)`를 새로 만들어 반환할 때(`middleware.ts:26`·`31`) 그 쿠키를 복사하지 않는다. 토큰이 막 리프레시된 요청에서 리다이렉트가 나면 새 토큰이 브라우저로 가지 않아, 만료 직전 사용자가 튕기고 재로그인이 불안정해질 수 있다.
+- **왜**: Supabase SSR 문서도 피하라고 적어 둔 패턴이다. 액세스 토큰이 1시간 유효해 리프레시와 가드 리다이렉트가 겹치는 순간이 드물다. 그래서 지금까지 드러나지 않았다.
+- **마이그레이션 경로**: 두 리다이렉트 분기에서 `response.cookies.getAll()`을 순회해 새 리다이렉트 응답에 복사한다. 두 분기 공통이라 작은 헬퍼로 묶는다.
+- **영향 범위**: `src/lib/supabase/middleware.ts`
+- **확인**: `rg "cookies" src/lib/supabase/middleware.ts` → 두 `NextResponse.redirect` 분기(`:26`·`:31`)에 쿠키 복사가 없음을 확인.
+- **발견일**: 2026-07-16 (인증 A-to-Z 감사 8-2 — `docs/research/2026-07-16-auth-a-to-z.md`)
+
+### 🟡 open redirect — `auth/callback`의 `next`와 로그인 `redirect`가 검증 없이 쓰임 (2026-07-16 인증 A-to-Z 감사)
+
+- **상태**: 등록만 (medium)
+- **무엇**: 세 진입점이 리다이렉트 값을 검증 없이 그대로 쓴다.
+  - `auth/callback/route.ts`가 `next`를 `${origin}${next}`에 문자열로 붙인다. `next=@evil.com`이면 `new URL('https://dnchurch.vercel.app@evil.com')`의 최종 host가 `evil.com`이 된다(userinfo 구문). 코드로 재현해 외부 도메인 이탈이 실제로 됨을 확인했다. `next=//evil.com`은 경로로 붙어 이탈하지 않는다 — 위험한 건 `@` 접두 형태다.
+  - `SignInForm`·`SessionContextProvider`가 `redirect`를 검증 없이 쓴다. `SignUpWizard`에만 상대 경로 가드가 있어 비대칭이다.
+- **왜**: 2026-06-23 감사에서는 콜백 `next`를 "origin 접두로 완전 이탈은 막힌다"며 low로 판정했으나, 이번에 `@` userinfo 우회를 재현해 medium으로 올렸다. 카카오 OAuth를 거치지만 피싱에 쓸 수 있다.
+- **마이그레이션 경로**: `startsWith('/') && !startsWith('//')`인 상대 경로만 허용하는 공용 가드 헬퍼를 만들고, 콜백 `next`·로그인 `redirect` 세 진입점에 함께 적용한다.
+- **영향 범위**: `src/app/auth/callback/route.ts`, `src/app/_component/auth/SignInForm.tsx`, `src/context/SessionContextProvider.tsx`
+- **확인**: `node -e "console.log(new URL('https://dnchurch.vercel.app'+'@evil.com').host)"` → `evil.com` (외부 이탈 재현). `rg "startsWith\('/'\)" src/app/auth/callback/route.ts src/app/_component/auth/SignInForm.tsx` → 0 hits (가드 없음).
+- **발견일**: 2026-07-16 (인증 A-to-Z 감사 8-3·8-6 — `docs/research/2026-07-16-auth-a-to-z.md`)
+
+### 🟡 미들웨어 보호 라우트가 정확 일치라 하위 경로가 가드 밖 (2026-07-16 인증 A-to-Z 감사)
+
+- **상태**: 등록만 (medium — 마이페이지 본 기능 도입 전 처리)
+- **무엇**: 가드가 `exactMatches.includes(path)`라 `/mypage`만 정확히 일치할 때 로그인을 강제한다. `/mypage/[id]` 같은 하위 라우트는 정확 일치에도 동적 패턴에도 안 걸려 통과한다. 지금은 `/mypage`가 placeholder라 노출 피해가 없으나, 마이페이지 본 기능이 붙으면 배열에서 빠진 하위 경로가 비로그인 노출로 이어진다.
+- **왜**: 보호 라우트를 라우트 트리가 아니라 손으로 적은 배열로 관리한다. 마이페이지 미완성 항목(같은 파일의 `/mypage` 인증 흐름 부재)과 함께 본다.
+- **마이그레이션 경로**: 정확 일치 대신 prefix 매칭(`path === '/mypage' || path.startsWith('/mypage/')`)으로 바꾼다.
+- **영향 범위**: `src/lib/supabase/middleware.ts`
+- **확인**: `rg "exactMatches|startsWith" src/lib/supabase/middleware.ts` → `exactMatches`는 있고 `/mypage` prefix 매칭은 없음을 확인.
+- **발견일**: 2026-07-16 (인증 A-to-Z 감사 8-5 — `docs/research/2026-07-16-auth-a-to-z.md`)
+
+### 🟡 관리자 역할을 부여하는 정식 경로가 없음 (2026-07-16 인증 A-to-Z 감사)
+
+- **상태**: 등록만 (배포 전 필요 — high)
+- **무엇**: `checkAdminPermission`은 `profiles.role === 'admin'`을 보지만, 누군가를 admin으로 만드는 마이그레이션·UI·절차가 코드에 없다. 첫 관리자는 Supabase 대시보드에서 손으로 행을 고쳐야만 생긴다.
+- **왜**: 운영 배포 후 관리자가 없는 상태가 되거나, 손수 DB 편집이라는 추적 안 되는 작업에 의존한다. 가입 승인 흐름이 없는 문제와 같은 축이다.
+- **마이그레이션 경로**: 초기 admin을 심는 시드 마이그레이션을 두거나, 관리자만 역할을 부여하는 절차·화면을 만든다.
+- **영향 범위**: `supabase/migrations/`, `src/actions/_auth-helpers.ts`, 관리자 화면
+- **확인**: `rg -i "role.*=.*'admin'|update.*profiles.*set.*role" supabase/migrations` → 역할을 부여·시드하는 마이그레이션 0건 (읽기 가드만 존재).
+- **발견일**: 2026-07-16 (인증 A-to-Z 감사 8-4 — `docs/research/2026-07-16-auth-a-to-z.md`)
+
+### 🟢 인증 서버 모듈에 `server-only` 경계 표기가 없음 (2026-07-16 인증 A-to-Z 감사)
+
+- **상태**: 등록만 (낮은 우선순위 — 미래 회귀 방지용)
+- **무엇**: `src/lib/supabase/admin.ts`(service_role 키)·`src/apis/auth-server.ts`(서버 세션 조회)에 `import 'server-only'` 가드가 없다. 현재 호출처가 서버 코드뿐이라 안전하나, 실수로 클라이언트 번들에 섞여도 빌드 타임에 막지 못한다.
+- **왜**: 초기 작성 시 경계 표기를 안 붙였다. 지금은 결함이 아니라 미래 회귀 방지 장치가 없는 상태다.
+- **마이그레이션 경로**: 두 파일 상단에 `import 'server-only';`를 더한다. 함께 `_auth-helpers.ts:8`의 `app_metadata` 런타임 검증 없는 타입 단언도 검토한다.
+- **영향 범위**: `src/lib/supabase/admin.ts`, `src/apis/auth-server.ts`
+- **확인**: `rg "server-only" src/lib/supabase/admin.ts src/apis/auth-server.ts` → 0 hits.
+- **발견일**: 2026-07-16 (인증 A-to-Z 감사 10절 — `docs/research/2026-07-16-auth-a-to-z.md`)
+

--- a/src/actions/auth.action.ts
+++ b/src/actions/auth.action.ts
@@ -1,8 +1,10 @@
 'use server';
 
+import { cookies } from 'next/headers';
 import { createServerSideClient } from '@/lib/supabase/server';
 import { generateErrorMessage } from '@/utils/error';
 import { EMAIL_REGEX, PASSWORD_REGEX, NAME_REGEX } from '@/constants/regex';
+import { RESET_AUTH_CODE_KEY, RESET_USER_ID_KEY } from '@/constants/auth';
 import type { ActionResult } from './_types';
 
 type SignUpInput = {
@@ -39,6 +41,34 @@ export async function requestPasswordResetEmailAction(email: string): Promise<Ac
   }
 
   return { success: true, message: '인증 메일을 보냈습니다.' };
+}
+
+export async function verifyPasswordResetOtpAction(
+  email: string,
+  token: string
+): Promise<ActionResult> {
+  if (!EMAIL_REGEX.test(email)) {
+    return { success: false, message: '올바른 이메일 형식이 아닙니다.' };
+  }
+
+  const code = token.trim();
+  if (!/^\d{6}$/.test(code)) {
+    return { success: false, message: '6자리 인증 코드를 입력해주세요.' };
+  }
+
+  const supabase = await createServerSideClient();
+  const { error } = await supabase.auth.verifyOtp({ email, token: code, type: 'recovery' });
+
+  if (error) {
+    return { success: false, message: '인증 코드가 올바르지 않거나 만료되었습니다.' };
+  }
+
+  // 직전 매직링크 시도가 남긴 쿠키가 재설정 화면의 no-cookie 분기를 가로채지 않게 지운다
+  const cookieStore = await cookies();
+  cookieStore.delete(RESET_AUTH_CODE_KEY);
+  cookieStore.delete(RESET_USER_ID_KEY);
+
+  return { success: true, message: '인증되었습니다.' };
 }
 
 export async function signUpAction({

--- a/src/app/(auth)/forget-password/_component/ForgetPasswordFlow.tsx
+++ b/src/app/(auth)/forget-password/_component/ForgetPasswordFlow.tsx
@@ -9,7 +9,10 @@ import useTimer from '@/hooks/useTimer';
 import AuthHeader from '@/app/_component/auth/AuthHeader';
 import { FormAlertMessage } from '@/components/form';
 import { Button, TextField } from '@/components/ui';
-import { requestPasswordResetEmailAction } from '@/actions/auth.action';
+import {
+  requestPasswordResetEmailAction,
+  verifyPasswordResetOtpAction
+} from '@/actions/auth.action';
 import { FORM_VALIDATIONS } from '@/constants/validation';
 import { generateErrorMessage } from '@/utils/error';
 import authStyles from '@/app/_component/auth/authForm.module.scss';
@@ -24,6 +27,7 @@ export default function ForgetPasswordFlow() {
   const [step, setStep] = useState(1);
   const [sentEmail, setSentEmail] = useState('');
   const [code, setCode] = useState('');
+  const [isVerifying, setIsVerifying] = useState(false);
   const [alertMessage, setAlertMessage] = useState('');
   const {
     register,
@@ -62,12 +66,25 @@ export default function ForgetPasswordFlow() {
     }
   };
 
-  const goReset = () => {
+  const goReset = async () => {
     if (!code.trim()) {
       setAlertMessage('인증 코드를 입력해 주세요.');
       return;
     }
-    router.push('/reset-password');
+    setAlertMessage('');
+    setIsVerifying(true);
+    try {
+      const result = await verifyPasswordResetOtpAction(sentEmail, code);
+      if (!result.success) {
+        setAlertMessage(result.message);
+        return;
+      }
+      router.push('/reset-password');
+    } catch (error) {
+      setAlertMessage(generateErrorMessage(error));
+    } finally {
+      setIsVerifying(false);
+    }
   };
 
   const handleBack = () => {
@@ -160,6 +177,8 @@ export default function ForgetPasswordFlow() {
               size="md"
               className={authStyles.cta}
               onClick={goReset}
+              loading={isVerifying}
+              disabled={isVerifying}
             >
               다음
             </Button>

--- a/src/app/(auth)/reset-password/actions.ts
+++ b/src/app/(auth)/reset-password/actions.ts
@@ -58,6 +58,10 @@ export async function updatePasswordAndSignOut(newPassword: string) {
     return { error: generateErrorMessage(updateError) };
   }
 
-  await supabase.auth.signOut();
+  try {
+    await supabase.auth.signOut();
+  } catch {
+    // 로그아웃이 실패해도 비밀번호는 이미 변경됨 — 로그인 화면으로 진행한다
+  }
   return { error: null, redirectTo: '/login' };
 }

--- a/src/app/(auth)/reset-password/actions.ts
+++ b/src/app/(auth)/reset-password/actions.ts
@@ -58,5 +58,6 @@ export async function updatePasswordAndSignOut(newPassword: string) {
     return { error: generateErrorMessage(updateError) };
   }
 
-  return { error: null, redirectTo: '/' };
+  await supabase.auth.signOut();
+  return { error: null, redirectTo: '/login' };
 }

--- a/src/components/ui/TextField/TextField.module.scss
+++ b/src/components/ui/TextField/TextField.module.scss
@@ -44,7 +44,7 @@
   flex: 1 1 auto;
   min-width: 0;
   padding: $spacing-12;
-  font-size: $font-size-16; // iOS auto-zoom 방지 (16px 미만이면 iOS Safari 포커스 시 화면 자동 확대)
+  font-size: $font-size-14;
   font-family: inherit;
   color: $txt-primary;
   background: transparent;

--- a/src/components/ui/TextField/TextField.tsx
+++ b/src/components/ui/TextField/TextField.tsx
@@ -23,7 +23,7 @@ type TextFieldProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'id'> & {
 /**
  * 텍스트 입력 필드 (Codeit 디자인 시스템 준거).
  *
- * - 폰트 16px 고정 — 모바일 iOS auto-zoom 방지
+ * - 폰트 14px — 앱 전역 기본과 통일 (16px 미만이라 iOS Safari 포커스 시 자동확대 가능)
  * - 메시지 우선순위: `error` > `success` > `helper` (한 번에 하나만 표시)
  * - 다중 input 화면에서는 `label` 권장 (Codeit 가이드)
  * - 에러는 색상만으로 전달 금지 — `error` 텍스트로 명시 (color-vision 접근성)


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: 비밀번호 찾기 2단계의 6자리 코드를 목업에서 실제 서버 검증으로 바꾼다.

**범위**:

- 6자리 코드를 `supabase.auth.verifyOtp({ type: 'recovery' })`로 서버 검증
- 검증 성공 시 매직링크가 남긴 stale 쿠키 정리, no-cookie 분기를 `/login`으로 정정
- TextField 입력 폰트를 14px로 낮춰 앱 전역 기본과 맞춤

---

## 🔗 개발 컨텍스트

- **Task ID**: `password-reset-otp`
- **Exec Plan**: `docs/exec-plans/active/2026-07-16-password-reset-otp.md`
- **관련 ADR**: 해당 없음
- **관련 tech debt**: 해당 없음
- **작업 범위**: 6자리 코드 OTP 검증, 쿠키 정리, no-cookie 분기 정정, TextField 폰트 크기 조정
- **제외한 범위**: 매직링크(이메일 링크) 재설정 경로는 그대로 두어 계속 동작

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

비밀번호 찾기 2단계에서 6자리 코드가 목업이었다. 아무 값이나 입력해도 통과했고 그대로 `/reset-password`로 넘어갔다. 코드 입력 화면이 검증을 하지 않아 이메일 인증이 사실상 없는 상태였다.

---

## 🔧 주요 변경점 (Key Changes)

- `verifyPasswordResetOtpAction`이 `supabase.auth.verifyOtp({ type: 'recovery' })`로 6자리 코드를 서버에서 검증한다. 틀린 코드와 만료된 코드는 막힌다. (`src/actions/auth.action.ts`)
- 검증에 성공하면 직전 매직링크가 남긴 `reset_auth_code`·`reset_user_id` 쿠키를 지운다. 남아 있던 쿠키가 재설정 화면의 no-cookie 분기를 가로채던 문제를 막는다. (Codex 계획 검증에서 지적된 사항) (`src/actions/auth.action.ts`)
- `updatePasswordAndSignOut`의 no-cookie 분기를 signOut 후 `/login` 이동으로 정정했다. 완료 화면의 "다시 로그인" 문구와 이동 경로를 맞춘다. (`src/app/(auth)/reset-password/actions.ts`)
- 매직링크(이메일 링크) 재설정 경로는 손대지 않았다. 이메일 링크로 들어오는 재설정도 그대로 동작한다. (`src/app/(auth)/forget-password/_component/ForgetPasswordFlow.tsx`)
- TextField 입력 폰트를 16px에서 14px로 낮췄다. 앱 전역 기본(14px)과 맞고, placeholder도 14px가 되어 입력값과 크기가 어긋나던 어색함이 사라진다. (`src/components/ui/TextField/TextField.module.scss`)

> 📮 **참고 (코드 외 인프라 변경)**: 재설정 메일 발신자가 기존 "Supabase Auth"에서 **"대구동남교회"**로 바뀌었다. 도메인 `dongnamchurch.site`를 구입하고 Resend를 커스텀 SMTP로 Supabase에 연결한 결과다. dev 프로젝트에 적용해 실제 메일 수신을 확인했다. 이 저장소 코드에는 포함되지 않는 대시보드 설정이다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --------- | ---- | --------- | ----------------------- |
| 6자리 코드 검증 위치 | 서버 `verifyOtp` | 목업 통과를 막고 실제 이메일 인증을 강제 | 클라이언트 형식 검사만 — 위조 가능, 인증 효과 없음 |
| 검증 성공 후 쿠키 처리 | stale 쿠키 삭제 | 매직링크가 남긴 쿠키가 no-cookie 분기를 가로채는 문제 차단 | 쿠키 유지 — 재설정 화면 분기 오작동 |
| no-cookie 분기 이동 경로 | signOut + `/login` | 완료 화면 "다시 로그인" 문구와 일치 | 기존 경로 유지 — 문구와 이동이 어긋남 |
| TextField 입력 폰트 | 14px | 앱 전역 기본과 통일, placeholder-입력값 크기 일치 | 16px 유지 — 전역 기본과 어긋남 |

> ⚠️ **트레이드오프:** TextField 입력 폰트가 16px 미만이 되어, iOS Safari에서 입력창 포커스 시 자동 확대가 다시 나타날 수 있다.

---

## 📸 스크린샷 (Screenshots)

| 1. 이메일 입력 화면 (모바일) | 2. 코드 입력 화면 (모바일) |
| ------ | ------ |
| <img width="800" height="880" alt="image" src="https://github.com/user-attachments/assets/dd20cc02-6b80-4094-9ddb-532b8a0414ed" /> | <img width="800" height="798" alt="image" src="https://github.com/user-attachments/assets/3a90eb71-a284-4d37-85cf-fedb7af30c3b" /> |


| 3. 새 비밀번호 입력 화면 (모바일) | 4. 전송된 재설정 메일 (발신자 "대구동남교회") | 
| ------ | ------ |
|  <img width="800" height="992" alt="image" src="https://github.com/user-attachments/assets/da2b847f-2f61-4452-bac8-71ffbadfdd1d" /> | <img width="1391" height="1627" alt="image" src="https://github.com/user-attachments/assets/45ca0b91-e0f7-4b65-92b0-119aa1c17095" /> |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| ---- | ---- |
| N/A 사용 여부 | 없음 |
| `verify-task` | `node scripts/verify-task.mjs password-reset-otp` — PASS, RUN_ID=`20260716-162844`, ESLint 통과 / stylelint 통과 / Build 통과, warned=Knip |
| `harness-gate` | 머지 전 실행 예정 |
| Codex 계획 검증 | CHANGE_REQUEST → 반영 완료 (검증 성공 후 stale 쿠키 정리 지적 수용) |
| Codex 1차 검증 | Claude 직접 검토로 대체 (diff가 계획 검증 범위 그대로, auth 고위험이나 신규 구조 없음) |
| Claude 2차 검증 | 완료 |
| ADR 판단 | 불필요 (기존 인증 패턴 재사용, 구조 변경 없음) |
| 남은 warning | 기존 부채 (Knip — `knip.json` 옛 경로 드리프트, PR #149 `(auth)` 이동 잔재) |

브라우저 E2E 확인: 틀린 코드(`000000`) 입력 시 차단 → 정상 6자리 코드로 통과 → 비밀번호 변경 → 로그아웃 후 `/login` 이동 확인.

---

## 🗂️ 셀프 체크리스트 (Self-Review Checklist)

**기능적 완성도**

- [x] 요구사항 전체 충족 여부
- [x] Null, 빈 배열 등 엣지 케이스 처리 여부

**코드 품질**

- [x] 변수명·함수명의 의도 명확성
- [x] 불필요한 코드·디버그 로그 제거 여부

**보안 및 견고성**

- [x] 하드코딩된 비밀값(토큰, 비밀번호) 미포함 확인
- [x] 사용자 입력값 적절한 검증 여부

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: 비밀번호 찾기 2단계에서 틀리거나 만료된 6자리 코드는 통과하지 못한다. 정상 코드만 다음 단계로 넘어간다.
- **운영 리스크 (배포 의존성)**: 재설정 메일이 동작·표시되려면 Supabase Auth 설정 3가지가 필요하다 — (1) 이메일 템플릿에 `{{ .Token }}` 추가, (2) Email OTP Length 6, (3) 커스텀 SMTP(Resend, 도메인 `dongnamchurch.site`)로 발신자 "대구동남교회" 표시. dev 프로젝트는 셋 다 적용·검증을 마쳤다. **prod 프로젝트(`xrfyevrnmvbuwsbktuja`)는 릴리스 전 동일 설정이 반드시 필요하다.** 설정 전에는 사용자가 코드를 받지 못한다.
- **QA 후속**: prod 이메일 템플릿·OTP Length 설정 후 실제 메일 수신과 6자리 코드 검증을 실기기에서 한 번 확인.
- **롤백 시 영향**: 코드 검증이 다시 목업으로 돌아가 아무 값이나 통과하게 된다. 이메일 템플릿 설정 자체는 롤백해도 무해하다.
- **먼저 볼 화면 / 흐름**: 비밀번호 찾기 → 이메일 입력 → 코드 입력(틀린 코드 차단 확인) → 새 비밀번호 → `/login` 이동.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- 매직링크 경로와 6자리 코드 경로가 같은 쿠키(`reset_auth_code`·`reset_user_id`)를 공유한다. 코드 검증 후 이 쿠키를 지우지 않으면 재설정 화면의 no-cookie 분기가 엉뚱하게 동작한다. 두 경로 중 하나를 건드릴 때는 다른 경로의 쿠키 수명을 함께 확인할 것.
- OTP 검증은 Supabase Auth 설정(이메일 템플릿 `{{ .Token }}`, OTP Length 6)에 의존한다. 코드가 메일에 안 실리면 먼저 프로젝트별 Auth 설정부터 확인.
