### PR TITLE
[Feat] 마이 페이지에 프로필·비밀번호·로그아웃과 성경읽기 트래커 추가

### DIFF
--- a/docs/decisions/0022-user-owned-data-rls.md
+++ b/docs/decisions/0022-user-owned-data-rls.md
@@ -1,0 +1,55 @@
+# 0022 — 사용자 소유 데이터는 owner-RLS + 사용자 세션 Server Action
+
+- **Status**: Proposed
+- **Date**: 2026-07-17
+- **Deciders**: scseong
+- **Tags**: supabase, auth, frontend
+
+## Context
+
+성경읽기 트래커(exec-plan `bible-reading-tracker`)가 이 앱의 첫 사용자 소유 CRUD 데이터를 도입한다. 지금까지 테이블은 두 부류뿐이었다.
+
+- **admin 소유**: `sermons`·`bulletins`·`notices` 등. RLS가 `EXISTS(profiles WHERE id=auth.uid() AND role='admin')`로 관리자만 쓴다.
+- **공개 폼(쓰기 전용)**: `new_family_registrations`. 익명 insert만 허용하고 읽기는 admin 전용.
+- **`profiles`**: `role`·`status` 권한 상승 위험 때문에 클라이언트 쓰기를 GRANT 회수로 잠갔다(`20260611000000_profiles_rls_lockdown.sql`). 프로필 수정은 본인 확인 후 admin 클라이언트 Server Action으로만 한다(ADR 0021 계열 결정).
+
+읽기 기록은 이 세 부류 어디에도 안 맞는다. 사용자가 자기 기록을 자주 읽고 쓴다(장 토글). `profiles`식 admin-잠금을 그대로 적용하면 토글마다 admin 경로를 타야 해 과하고, 반대로 아무 정책 없이 클라이언트 직접 쓰기를 열면 `docs/ARCHITECTURE.md:35`("뮤테이션은 항상 Server Action — 클라이언트 직접 write 금지")와 충돌한다. 사용자 소유 데이터의 표준 경계를 정하지 않으면 앞으로 비슷한 기능마다 정책이 제각각이 된다.
+
+## Decision
+
+사용자 소유 데이터 테이블은 다음을 따른다.
+
+1. **owner-RLS 정책**: SELECT/INSERT/UPDATE/DELETE 각각에 `auth.uid() = user_id`를 건다. INSERT·UPDATE에는 `USING`뿐 아니라 **`WITH CHECK (auth.uid() = user_id)`**를 반드시 둬서 남의 `user_id` 행 삽입을 막는다.
+2. **뮤테이션은 사용자 세션 Server Action**: 클라이언트 직접 write는 하지 않는다. `actions/*.action.ts`가 `createServerSideClient()`(사용자 세션)로 쓴다. 이 클라이언트는 admin bypass가 아니라 사용자 JWT를 실어 owner-RLS가 실제로 적용된다. `user_id`는 `getUser()`가 준 값으로만 채워 스푸핑을 원천 차단한다.
+3. **admin-잠금은 권한 상승 컬럼이 있는 테이블에만**: `profiles`처럼 `role`·`status` 같은 컬럼이 있어 사용자가 자기 행이라도 특정 컬럼을 바꾸면 안 되는 경우에만 GRANT 회수 + admin Server Action을 쓴다.
+
+첫 적용: `bible_reading_records`, `bible_reading_settings`.
+
+## Consequences
+
+### 긍정적
+- 사용자별 격리를 DB(RLS)가 보장한다. 액션 코드 버그가 있어도 남의 행을 못 읽거나 못 쓴다.
+- 아키텍처 규칙(뮤테이션=Server Action)을 지키면서도, 잦은 토글에 admin 왕복 대신 세션 액션 + 낙관적 UI로 반응성을 확보한다.
+- 앞으로 사용자 소유 기능(기도제목·저장한 설교 등)의 정책 기준이 하나로 고정된다.
+
+### 부정적 / 트레이드오프
+- 테이블마다 정책 4개(select/insert/update/delete)를 손으로 써야 한다. 누락(특히 `WITH CHECK`) 시 보안 구멍이 생기므로 마이그레이션 리뷰에서 확인한다.
+- 낙관적 UI라 액션 실패 시 클라이언트가 롤백해야 한다. 실패 처리를 빠뜨리면 화면과 DB가 어긋난다.
+
+### 영향 범위
+- 코드: `supabase/migrations/20260717000000_create_bible_reading.sql`, `src/actions/bible-reading.action.ts`, `src/apis/bible-reading.ts`.
+- 운영: dev·prod 두 프로젝트에 같은 마이그레이션을 적용한다.
+
+## Alternatives Considered
+
+### A안: 클라이언트가 owner-RLS 테이블에 직접 write
+- 사유로 기각: `ARCHITECTURE.md:35`의 "클라이언트 직접 write 금지"와 eslint `app → apis` 차단 규칙을 어긴다. 규칙 자체를 뒤집는 비용이 이득보다 크다.
+
+### B안: `profiles`처럼 GRANT 회수 + admin 클라이언트 Server Action
+- 사유로 기각: 읽기 기록에는 `role`·`status` 같은 권한 상승 컬럼이 없어 admin 우회가 필요 없다. admin 클라이언트는 RLS를 통째로 우회해 오히려 격리가 약해지고, 장 토글마다 admin 경로를 타는 것도 과하다.
+
+## References
+
+- 관련 PR:
+- 관련 exec-plan: `docs/exec-plans/active/2026-07-17-bible-reading-tracker.md`
+- 관련 ADR: `0011`(profiles 관련), `docs/decisions` 내 admin RLS 결정

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -51,5 +51,6 @@
 | [0019](0019-public-anonymous-write-rls.md) | 익명 공개 쓰기를 서버 액션과 anon 전용 RLS로 처리한다 | Accepted | 2026-06-29 |
 | [0020](0020-brown-primary-migration.md) | 공개 primary 색을 navy에서 warm brown으로 이행 | Accepted | 2026-06-30 |
 | [0021](0021-hero-breadcrumb-removal.md) | 공유 Hero·Breadcrumb 제거, 콘텐츠 페이지 헤더를 MobileHeader + sr-only h1로 통일 | Accepted | 2026-07-03 |
+| [0022](0022-user-owned-data-rls.md) | 사용자 소유 데이터는 owner-RLS + 사용자 세션 Server Action | Proposed | 2026-07-17 |
 
 <!-- last-audit: 2026-05-01 -->

--- a/docs/exec-plans/active/2026-07-17-bible-reading-tracker.md
+++ b/docs/exec-plans/active/2026-07-17-bible-reading-tracker.md
@@ -1,0 +1,226 @@
+# bible-reading-tracker
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-07-17
+- **브랜치**: feat/my-page
+- **Open questions**: none (settings RLS·같은 날 통독 리셋은 D1·D5로 해소)
+- **ADR needed**: yes — 이 앱의 첫 사용자 소유 CRUD 테이블. owner-RLS 정책을 도입하되 뮤테이션은 기존 규칙대로 Server Action을 지킨다. `## ADR 판단` 참조.
+
+## 목표
+
+`/mypage`에 성경읽기 트래커를 붙인다. 사용자가 날짜별로 읽은 성경 장을 기록하면 연속 일수, 일·주·월 기록, 성경 통독 진행률, 주간 목표가 그 기록에서 파생돼 보인다. Claude Design 시안(한빛교회 마이페이지.html = 마이 페이지.dc.html 번들 버전)의 성경읽기 영역을 실제 기능으로 만든다.
+
+## 검증된 Assumptions
+
+- 시안 로직은 "모든 것이 날짜별 기록에서 파생된다(일 단위)"로 설계돼 있다 — `mypage-design.dc.html:535`, `logByDate[date][book]=Set<chapter>` 구조.
+- 66권 이름·장수는 고정(총 1189장, 구약 39·신약 27, 최대 150장=시편)이다 — 시안 `books` 배열(`mypage-design.dc.html:496-499`), 노드 스크립트로 합계 검산.
+- 현재 DB에 사용자 활동/읽기 기록 테이블이 없다 — `mcp__claude_ai_Supabase__list_tables` 13개 테이블에 해당 없음.
+- **뮤테이션은 항상 Server Action, 클라이언트 직접 Supabase write 금지** — `docs/ARCHITECTURE.md:35`. eslint가 `app → apis` 직접 import도 error로 막는다(`eslint.config.mjs:84-97`).
+- admin 소유 테이블 RLS는 `EXISTS(profiles WHERE id=auth.uid() AND role='admin')` 패턴 — `sermons` 정책 SQL 조회.
+- `profiles`는 role/status 권한 상승 위험 때문에 클라이언트 쓰기를 GRANT 회수로 잠갔다 — `20260611000000_profiles_rls_lockdown.sql`. 읽기 기록에는 그런 민감 컬럼이 없다.
+- `createServerSideClient()`는 사용자 세션 쿠키를 실어 `auth.uid()`가 로그인 사용자로 잡힌다(RLS owner 정책이 실제로 적용됨, admin bypass 아님) — `.claude/skills/supabase/SKILL.md`.
+
+## Non-goals
+
+- 기록 공유(카카오톡·이미지 저장·링크 복사) — 외부 SDK·이미지 생성 연동이라 별도 task. "내 기록 공유하기" 버튼은 "준비 중" 토스트로 둔다.
+- 설정 시트의 알림 토글·읽기 알림 시간·번역본·고객센터 — my-page task에서 이미 "준비 중"으로 둔 항목. 이번 범위 밖.
+- 성경 본문 표시·읽기 기능 — 기록만 한다.
+- 개역개정 외 번역본의 다른 장수 — 1189장 고정.
+
+## 접근법
+
+- **데이터 모델**: 원자 단위 하나만 저장하고 나머지는 파생한다. `bible_reading_records` 한 행 = "이 사용자가 이 날(`read_date`) 이 책(`book_order`) 이 장(`chapter`)을 이 회차(`cycle`)에 읽었다". 연속·일/주/월·통독·목표는 이 행들에서 계산한다(집계 컬럼 저장 안 함, D4).
+- **66권 참조 데이터**: `src/constants/bible.ts` TS 상수 `BIBLE_BOOKS: {order 1-66, name, chapters, testament}[]` + `getBookByOrder(order)` 헬퍼(내부에서 `order-1` 인덱싱, 1-based↔0-based 경계를 한 곳에 가둔다, D6). `BIBLE_TOTAL_CHAPTERS = 1189`.
+- **쓰기 경로**: 클라이언트 직접 쓰기는 `ARCHITECTURE.md:35` 위반이라 쓰지 않는다. 모든 뮤테이션은 `src/actions/bible-reading.action.ts`의 Server Action이 `createServerSideClient()`(사용자 세션)로 수행한다. RLS owner 정책이 실제로 적용되고, `user_id`는 `getUser()`가 준 값으로 서버가 채워 스푸핑을 원천 차단한다. 잦은 토글은 낙관적 UI(클라이언트 로컬 상태 즉시 반영 후 실패 시 롤백) + 범위/모두읽음은 한 번의 액션으로 여러 장을 보내 왕복을 줄인다.
+- **읽기 경로**: 서버 페이지(`page.tsx`) → `services/bible-reading`(파생 계산) → `apis/bible-reading`(서버 읽기, `createServerSideClient`). 초기 로드에 사용자의 기록 전체(작은 컬럼: book_order·chapter·read_date·cycle) + settings를 한 번 조회해 클라이언트로 내린다. 단일 사용자라 행 수가 작다(1189장×소수 회차 ≈ 수천 행 이하).
+- **배치**: `/mypage`에서 프로필 헤더와 계정 메뉴 사이에 트래커를 넣는다(시안 순서). 기록기는 시안대로 전체 화면 오버레이(`BottomSheet size="full"`).
+
+## 스키마 (마이그레이션 계약)
+
+```sql
+create table public.bible_reading_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  book_order smallint not null check (book_order between 1 and 66),
+  chapter smallint not null check (chapter between 1 and 150),
+  read_date date not null,
+  cycle smallint not null default 1 check (cycle >= 1),
+  created_at timestamptz not null default now(),
+  unique (user_id, book_order, chapter, read_date)   -- 토글 멱등 (cycle 미포함: 같은 날 같은 장 재독은 무시, 극희귀)
+);
+create index on public.bible_reading_records (user_id, read_date);
+create index on public.bible_reading_records (user_id, cycle);
+alter table public.bible_reading_records enable row level security;
+create policy "select_own" on public.bible_reading_records for select to authenticated using (auth.uid() = user_id);
+create policy "insert_own" on public.bible_reading_records for insert to authenticated with check (auth.uid() = user_id);
+create policy "update_own" on public.bible_reading_records for update to authenticated using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "delete_own" on public.bible_reading_records for delete to authenticated using (auth.uid() = user_id);
+
+create table public.bible_reading_settings (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  weekly_goal smallint not null default 50 check (weekly_goal between 5 and 150),
+  current_cycle smallint not null default 1 check (current_cycle >= 1),
+  updated_at timestamptz not null default now()
+);
+alter table public.bible_reading_settings enable row level security;
+create policy "select_own" on public.bible_reading_settings for select to authenticated using (auth.uid() = user_id);
+create policy "insert_own" on public.bible_reading_settings for insert to authenticated with check (auth.uid() = user_id);
+create policy "update_own" on public.bible_reading_settings for update to authenticated using (auth.uid() = user_id) with check (auth.uid() = user_id);
+```
+
+- `WITH CHECK (auth.uid()=user_id)`가 INSERT/UPDATE에 반드시 붙는다 — `USING`만으로는 남의 `user_id` 행 삽입을 못 막는다(Codex 지적).
+- settings 행은 지연 생성: 없으면 서비스가 기본값(weekly_goal=50, current_cycle=1)으로 취급하고, 목표 변경·다음 회독 때 upsert.
+
+## 의사결정 로그
+
+- **D1 — 읽기 기록은 owner-RLS 정책을 두되, 뮤테이션은 기존 규칙대로 사용자 세션 Server Action으로 한다 (Codex CR 반영)**
+  - 문제: 초기 계획은 클라이언트가 Supabase에 직접 write하려 했으나 `ARCHITECTURE.md:35`("뮤테이션은 항상 Server Action")·eslint 레이어와 충돌한다.
+  - 해결: 뮤테이션은 `actions/bible-reading.action.ts`가 `createServerSideClient()`(사용자 세션)로 실행한다. 이 클라이언트는 admin bypass가 아니라 사용자 JWT를 실어 owner-RLS(`auth.uid()=user_id`)가 그대로 적용된다. `profiles`는 role/status 권한 상승 때문에 클라이언트 쓰기를 GRANT 회수로 잠갔지만, 읽기 기록은 민감 컬럼이 없고 행이 전부 `user_id` 소유라 owner-RLS로 CRUD를 연다.
+  - 결과: 아키텍처 규칙을 지키면서 사용자별 격리를 RLS로 보장한다. 첫 사용자 소유 CRUD 테이블이라 정책 경계를 ADR로 남긴다.
+- **D2 — 66권은 DB 테이블이 아니라 `src/constants/bible.ts` TS 상수로 둔다**
+  - 문제: 책 이름·장수는 고정 참조 데이터인데 테이블로 만들면 매 조회에 join이 붙는다.
+  - 해결: 앱의 고정 목록 상수 패턴(예: 갤러리 카테고리)을 따른다. 기록에는 `book_order`(1-66 정경 순번)만 저장. DB CHECK(`book_order 1-66`, `chapter 1-150`)로 하한/상한을, 서버 액션이 `BIBLE_BOOKS[order-1].chapters`로 책별 정확한 상한(예: 창세기 50)을 검증한다.
+  - 결과: 조회에 join이 없고, 잘못된 장 번호는 DB CHECK + 서버 검증 2겹으로 막는다.
+- **D3 — 기록은 (user_id, book_order, chapter, read_date) 유니크로 멱등 처리**
+  - 문제: 같은 장을 같은 날 두 번 눌러도 한 번만 기록돼야 한다(시안은 Set).
+  - 해결: 4컬럼 unique. 장 켜기=insert on conflict do nothing, 끄기=delete. 같은 장을 다른 날 다시 읽는 건 허용(통독은 회차별 distinct로 처리). unique에 cycle을 넣지 않아 "같은 날 같은 장을 두 회차에서 재독"은 무시되지만 극히 희귀해 감수한다.
+  - 결과: 토글이 멱등이고 재독 기록도 날짜별로 남는다.
+- **D4 — 연속·집계는 저장하지 않고 조회 시 계산한다**
+  - 문제: streak·월 집계·통독 진행을 컬럼으로 캐시하면 기록 변경마다 동기화 버그가 생긴다.
+  - 해결: 초기 로드에 사용자 기록 전체(작은 컬럼)를 한 번 조회해 서비스/클라이언트에서 계산. streak은 distinct `read_date`를 전부 받아 오늘부터 연속 일수를 끝까지 세므로 길이 제한이 없다(Codex의 "최근 N일" 오류 방지).
+  - 결과: 단일 진실 원천은 기록 행 하나뿐이고 streak이 임의 길이에 정확하다.
+- **D5 — 통독 회차는 날짜 필터가 아니라 기록의 `cycle` 컬럼으로 구분한다 (Codex CR 반영)**
+  - 문제: 초기 계획의 `read_date >= cycle_start_date` 필터는 "오늘 오전에 1189장을 채우고 다음 회독을 시작"할 때 오전 기록(read_date=오늘)이 새 회차에도 포함돼 0%로 리셋되지 않는다. `read_date`가 date라 오전/오후를 못 가른다.
+  - 해결: 각 기록에 `cycle`(삽입 시점의 `current_cycle`)을 박는다. 통독 진행 = distinct(book_order,chapter) where cycle=current_cycle. "다음 회독 시작하기" = `settings.current_cycle += 1`. 이후 기록은 새 cycle로 저장돼 진행이 0부터 시작한다. 오전 기록은 cycle=1로 남아 새 회차에서 제외된다. 일/주/월·연속은 회차 무관하게 `read_date`로 계산한다(그날 읽은 건 그날 읽은 것).
+  - 결과: 같은 날 회독 리셋이 정확히 0%가 된다. `cycles_done` 표기는 `current_cycle - 1`로 파생.
+- **D6 — book_order는 1-based, 변환은 `getBookByOrder`에 가둔다 (Codex CR 반영)**
+  - 문제: DB는 1-66, 배열 인덱스는 0-65라 `BIBLE_BOOKS[book_order]`로 쓰면 1칸씩 밀리고 66은 undefined가 된다.
+  - 해결: `getBookByOrder(order)`가 유일한 변환 지점(`BIBLE_BOOKS[order-1]`)이고, 쓸 때는 항상 `book.order`를 저장한다. 컴포넌트·서비스는 배열 인덱싱을 직접 하지 않는다.
+  - 결과: off-by-one을 한 함수로 가둔다.
+- **D7 — 시안 대표색 #93702E를 `$accent`(gold)로 매핑해 트래커 데이터 시각화를 골드로 맞춘다 (사용자 UI 대조 요청)**
+  - 문제: 초기 구현은 상태·진행 표시에 `$primary`(brown-800 #5a3f2e)를 써서 시안(#93702E gold)보다 갈색이 짙게 나왔다. 사용자가 목업을 서버로 띄워 나란히 대조하며 "최대한 동일"을 요구했다.
+  - 해결: 시안의 #93702E는 앱 semantic `$accent`(gold-600)와 정확히 같다. 연속 카드 그라디언트·주간 요일 박스·통독 배지/진행바·월 히트맵·기록기 장/책 상태·활성 세그먼트·프로필 아바타를 `$accent` 계열로 바꿨다. 진행바는 `linear-gradient($accent-hover,$accent)`, 히트맵은 `$accent-subtle→$accent-hover→$accent` 3단계. 구조도 시안에 맞춰 일 뷰 항목·빈 상태에 골드 책 아이콘, 목표 모달에 원형 스테퍼를 추가했다.
+  - 결과: 브라우저 실측으로 연속·일/주/월·통독·기록기·목표 모달이 시안과 근접. 다만 공용 컴포넌트 `Button`(primary)·`Tabs`(pill active)는 앱 원칙(ADR 0020: brand=brown)을 따라 brown으로 남긴다 — 시안의 gold 버튼과 다르지만, 공용 컴포넌트를 앱 전역에서 바꾸는 대신 트래커 고유 데이터 시각화만 골드로 맞춘 선택. gold 버튼이 필요하면 `Button` accent variant 신설이 후속 과제.
+
+## ADR 판단
+
+작성 완료 — `docs/decisions/0022-user-owned-data-rls.md`. 결정: "사용자 소유 데이터 테이블은 owner-RLS(`USING`+`WITH CHECK` = `auth.uid()=user_id`)를 두고, 뮤테이션은 사용자 세션 Server Action으로 한다. `profiles`식 admin 잠금은 role/status 같은 권한 상승 컬럼이 있는 테이블에만."
+
+## Success Criteria
+
+- 로그인 사용자가 기록기에서 책→장을 선택하면 `bible_reading_records`에 행이 생기고(오늘 기록·연속·통독 갱신), 같은 장을 다시 누르면 행이 삭제된다 — 브라우저 실측 + `SELECT count(*) ... WHERE user_id=<uid>` 전후 비교.
+- 다른 사용자 스푸핑 차단: user A 세션으로 `user_id=<user B>` INSERT 시도가 RLS로 거부된다(0행/permission denied) — SQL로 확인. 서버 액션은 `user_id`를 `getUser()` 값으로만 채운다.
+- 일/주/월 탭이 각각 오늘 기록, 7일 스트립 + 주간 목표 %, 월 달력 히트맵을 보여준다 — 브라우저 실측.
+- 통독 진행률 = distinct(book_order,chapter) where cycle=current_cycle / 1189. 1189 도달 시 "다음 회독 시작하기"가 뜨고, 누르면 `current_cycle`이 1 늘고 진행률이 0%가 된다. 같은 날 리셋해도 0%다 — SQL로 경계값 주입해 확인.
+- 주간 목표를 바꾸면 `bible_reading_settings.weekly_goal`이 갱신되고 주간 % 분모가 바뀐다.
+- `getBookByOrder`가 order 1→창세기, 66→요한계시록을 반환하고, `sum(BIBLE_BOOKS.chapters) === 1189`·`BIBLE_BOOKS.length === 66`이다 — 단위 확인(런타임 assert 또는 콘솔).
+- 잘못된 장(예: 창세기 51장) 기록 시도가 서버 액션에서 거부된다 — 액션 검증 확인.
+- 비로그인 `/mypage` 접근은 기존대로 `/login` 리다이렉트.
+- `node scripts/verify-task.mjs bible-reading-tracker` (lint·styles·build·knip) 통과.
+
+## 영향받는 파일
+
+- `supabase/migrations/<ts>_create_bible_reading.sql` — 2 테이블 + unique + CHECK + 인덱스 + owner-RLS(USING·WITH CHECK) (신규)
+- `src/types/database.types.ts` — `yarn generate:types` 재생성
+- `src/constants/bible.ts` — `BIBLE_BOOKS`·`getBookByOrder`·`BIBLE_TOTAL_CHAPTERS` (신규)
+- `src/apis/bible-reading.ts` — 서버 읽기(createServerSideClient) (신규)
+- `src/services/bible-reading/index.ts` — 파생 계산(streak·주/월·통독·기간 집계) (신규)
+- `src/actions/bible-reading.action.ts` — 기록/해제/목표/다음회독 Server Action (신규)
+- `src/app/(content)/mypage/_component/tracker/` — StreakCard·RecordTabs(Day/Week/Month)·PlanCard·GoalModal·Recorder + module.scss (신규)
+- `src/app/(content)/mypage/page.tsx` — 트래커 섹션 삽입 + 초기 fetch
+- `docs/decisions/<n>-user-owned-data-rls.md` — ADR (신규)
+
+## 단계별 체크리스트
+
+- [x] 1. 마이그레이션(2 테이블·unique·CHECK·인덱스·owner-RLS USING+WITH CHECK) → dev 적용 → 타입 재생성
+- [x] 2. `bible.ts`(상수+`getBookByOrder`, 합계 assert) + `apis/bible-reading`(서버 읽기) + `services/bible-reading`(파생)
+- [x] 3. `actions/bible-reading.action.ts`(기록/해제/목표/다음회독, user_id=getUser, 장 범위 검증)
+- [x] 4. page.tsx 초기 fetch + StreakCard + 통독 카드
+- [x] 5. 일/주/월 기록 탭(달력 히트맵·주 스트립·목표 %)
+- [x] 6. 기록기 오버레이(책→장, 날짜 이동, 낱장/범위, 모두읽음/해제) + 낙관적 쓰기
+- [x] 7. 주간 목표 모달 + 통독 다음 회독 + 스타일 토큰·반응형 + ADR 작성
+- [x] 8. VERIFY + 브라우저 실측(RLS 교차·기록·파생·목업 대조 UI 개선)·스크린샷
+
+## Verification
+
+- `node scripts/verify-task.mjs bible-reading-tracker`
+
+---
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST (confidence: high) — 2026-07-17 1차. material 6건 반영 완료.
+- **현재 판단**: Codex 지적과 처리:
+  1. "레이어 충돌 — `apis/bible-reading` 브라우저 클라이언트 CRUD가 `ARCHITECTURE.md`의 '뮤테이션은 항상 Server Action'과 충돌" → `ARCHITECTURE.md:35` 직접 확인 후 클라이언트 직접 쓰기를 접고 사용자 세션 Server Action으로 전환(D1 개정, apis=서버 읽기·actions=쓰기).
+  2. "RLS `WITH CHECK` 누락 — `USING`만으로는 user A가 user B 행을 넣는 걸 못 막음" → 스키마 계약에 INSERT/UPDATE `WITH CHECK (auth.uid()=user_id)` 명시.
+  3. "같은 날 통독 리셋 깨짐 — `read_date >= cycle_start_date`는 오전 기록을 새 회차에 포함" → 기록에 `cycle` 컬럼 도입(D5), 진행=cycle=current_cycle distinct, 리셋=current_cycle++.
+  4. "book_order 1-based off-by-one 경계 없음" → `getBookByOrder(order-1)` 단일 변환점(D6).
+  5. "장 유효성 DB CHECK·서버 검증 없음" → `chapter 1-150` CHECK + 액션에서 `BIBLE_BOOKS[order-1].chapters` 상한 검증(D2).
+  6. "streak '최근 N일' pass/fail 기준 없음" → distinct read_date 전부 받아 임의 길이 정확(D4), SC에 명시.
+  - expression-only(Open questions 부정확, unique를 체크리스트에 재명시 등)도 반영.
+- **다음 행동**: WORK 진입. 스키마·RLS는 CODEX_FIRST_PASS에서 diff 재검증.
+
+## Codex 1차 검증
+
+- **결론**: FIX_APPLIED — 2026-07-17. Codex가 직접 수정 3건(모두 correctness), Claude가 diff 교차 확인.
+- **현재 판단**: Codex 적용 수정과 Claude 확인:
+  1. `TrackerSection.tsx` 롤백 회차 보존 — 기록 해제를 롤백할 때 `addRecords`(현재 cycle)가 아니라 `restoreRecords`(제거된 행을 원래 cycle 그대로 복원)를 쓴다. 과거 회차 기록을 오늘 해제·롤백하면 cycle이 바뀌던 버그를 막는다. diff 확인: `toggleChapter`·`clearBook`이 `removed` 스냅샷을 잡아 복원.
+  2. `apis/bible-reading.ts` getBibleReadingRecords 페이지네이션 — Supabase 기본 1000행 한도 때문에 기록이 1000행을 넘는 사용자는 일부만 받아 통독·연속이 틀리던 것을, `range`로 1000행씩 끝까지 받도록 고쳤다.
+  3. `actions/bible-reading.action.ts` startNextCycleAction 페이지네이션 — 통독 완료 판정 `distinct==1189`가 1189>1000이라 1000행 한도에 걸려 영영 완료로 안 잡히던 것을, 같은 range 루프로 고쳤다.
+- **다음 행동**: verify-task + 브라우저 실측 후 2차 갱신.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — 2026-07-17.
+- **현재 판단**: Codex 수정 3건 diff를 다시 읽어 의도·범위 확인(위 1차 기록). 브라우저 실측(dev 서버 3002, 테스트 계정 vihaya8934):
+  - 기록기에서 창세기 2·3장 기록 → `bible_reading_records`에 (cycle=1) 2행 저장, 같은 장 재클릭 시 삭제(토글) — SQL 전후 확인.
+  - 파생 실시간 갱신: 연속 1일째, 이번 달 1일, 오늘 2장, 오늘 기록 "창세기 2–3장", 통독 2/1189장 0%.
+  - 주간 뷰(금요일 ✓·목표 2/50장 4%)·월 달력 히트맵(2026년 7월, 7/1=수요일, 오늘 링) 정상.
+  - RLS: user A 세션으로 본인 insert 성공, user B(admin) id insert는 `new row violates row-level security policy`로 거부 — `pg_policy` role 시뮬레이션 SQL로 확인.
+  - 실측 후 테스트 기록 전량 삭제(원복).
+  - UI 개선(사용자 요청, 목업 대조) — 목업(한빛교회 마이페이지.html)을 8080 정적 서버로 띄워 나란히 비교하며 아래를 반영했다.
+    - 연속 카드에 골드 불꽃 원형 배지를 넣고, 좌측 텍스트·우측 배지 행 배치.
+    - 통독 버튼을 솔리드 브라운 "지난 날짜·권별로 기록하기"로 변경.
+    - 카드 모서리를 $radius-l로 부드럽게.
+- **UI 폴리시 2차(사용자 11개 대조 요청, 최초 2차 검증 이후 추가)**: 목업과 나란히 비교하며 아래를 반영했다.
+  - `Button`에 accent variant(gold) 신설, 트래커 CTA·`Tabs` pill active를 골드로 맞춤(D7의 후속 과제였던 gold 버튼 해소).
+  - 기록 공유 시트(`ShareSheet.tsx`) 신설 — 일/주/월 pill 탭 + 골드 통계 카드(대구동남교회·시편 119:105), 카카오톡·이미지 저장·링크 복사는 "준비 중" 토스트.
+  - 헤더에 설정 아이콘(`resolveHeaderAction /mypage → 'settings'`) → 계정 섹션(`#mypage-account`)으로 스크롤.
+  - 일/주/월 탭을 세그먼트(배경 전환) 방식으로 교체.
+  - 주간 목표를 number input + `-`/`+` 스텝 1로 변경.
+  - 통독 카드 제목 앞 책 아이콘 제거.
+  - 버튼 min-height 부여 — sm 3.6·md 4.2·lg 4.8rem.
+  - 프로필 섹션 배경·패딩 제거.
+  - 기록기 헤더에 뒤로가기 + 닫기 동시 배치.
+  - 날짜 바 화살표를 흰 배경으로, "기록할 날짜" 라벨을 줄바꿈.
+  - 책 목록에서 제목 + 장수를 한 줄에 배치.
+  - 챕터 번호 그리드가 스타일이 안 먹던 것을 고침: `.chapter` 버튼에 `width:100%`(grid 셀이 `<li>`라 버튼이 숫자 폭으로 줄던 문제) + `1px solid $border-card` 테두리 부여.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 최초 2차 | 20260717-141437 | ✅ | ✅ | ✅ | 0 | 브라우저 실측·RLS SQL 완료 |
+| UI 폴리시 재검증 | 20260718-190653 | ✅ | ✅ | ✅ | 0 | 챕터 그리드 실측 완료 |
+
+- **챕터 그리드 실측(dev 3005, 홍길동/vihaya8934)**: 기록기 → 창세기 챕터 그리드를 목업과 대조해 아래를 확인했다.
+  - 8열 셀이 그리드 폭을 꽉 채운다(`width:100%` 반영, 수정 전엔 버튼이 숫자 폭으로 줄었음).
+  - 읽은 장은 골드 배경(`$accent-subtle`)으로 칠해진다.
+  - 안 읽은 장은 연회색 + 1px `$border-card` 테두리로 구분된다(수정 전엔 테두리가 없었음).
+- **다음 행동**: doc-editor 점검 → 사용자 승인 → 커밋.
+
+## 검증 이력
+
+<details>
+<summary>2026-07-17 Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: RLS WITH CHECK 누락·같은 날 통독 리셋 오류·레이어 충돌·book_order 경계 미정의
+- 조치: D1 개정, D5·D6 신설, 스키마 SQL 계약 추가, SC 스푸핑/장검증 보강
+
+</details>
+
+## 후속 작업
+
+- 기록 공유(카카오톡·이미지·링크)
+  - 이유: 외부 SDK·이미지 생성 연동이 필요해 트래커 코어와 분리.
+  - 다음 기준: 트래커 머지 후.
+  - 기록 위치: 없음 (후속 task)

--- a/docs/exec-plans/active/2026-07-17-bible-reading-tracker.md
+++ b/docs/exec-plans/active/2026-07-17-bible-reading-tracker.md
@@ -218,6 +218,20 @@ create policy "update_own" on public.bible_reading_settings for update to authen
 
 </details>
 
+## PR 리뷰 대응 (PR #152)
+
+gemini 봇이 인라인 3건을 남겨 코드로 직접 확인하고, Codex 교차검증(3건 모두 내 판정에 동의)을 거쳐 처리했다.
+
+- **연속 일수가 아침마다 0으로 보임 (봇 HIGH) — 반영**
+  - 문제: `computeStreak`이 `cursor=today`에서 시작해 오늘 기록이 없으면 루프가 0회 돌아 0을 반환했다. 어제까지 이어온 연속이 오늘 아침(아직 안 읽음)엔 0일째로 표시된다.
+  - 해결: 오늘 기록이 없으면 커서를 어제로 옮겨 세기 시작한다. 오늘 읽으면 오늘부터 세어 하루 늘어난다. JSDoc도 갱신. 호출부는 `TrackerSection.tsx:46` 한 곳이고 표시 전용이라 무회귀.
+- **number input 스피너가 Firefox에 남음 (봇 MEDIUM) — 반영**
+  - 문제: `.stepper_input`에 `-webkit-` 스피너 제거만 있어 Firefox는 화살표를 계속 노출한다.
+  - 해결: `.stepper_input`에 표준 `appearance: textfield`를 넣었다. Codex 지적대로 수기 `-moz-` 프리픽스는 넣지 않는다 — 저장소 관례가 unprefixed이고 autoprefixer가 빌드 때 붙인다.
+- **Tabs `.pill` border-radius가 타원으로 찌그러진다 (봇 MEDIUM) — 반영 안 함(오탐)**
+  - 봇 주장: `border-radius: $radius-circle`이 사각형을 타원으로 만든다, `99rem` 하드코딩 권장.
+  - 확인: `$radius-circle` = `var(--radius-999)` = `9999px`(globals.scss:47). 큰 고정 px는 border-radius 클램핑으로 stadium(알약)이 된다 — 타원은 백분율(`50%`)일 때만 생긴다. 봇 전제가 오류. 게다가 하드코딩 제안은 토큰 규칙 위반이라 반영하지 않고 봇에 근거를 회신했다.
+
 ## 후속 작업
 
 - 기록 공유(카카오톡·이미지·링크)

--- a/docs/exec-plans/active/2026-07-17-my-page.md
+++ b/docs/exec-plans/active/2026-07-17-my-page.md
@@ -1,0 +1,162 @@
+# my-page
+
+- **상태**: 🟡 진행 중
+- **시작일**: 2026-07-17
+- **브랜치**: feat/my-page
+- **Open questions**: none
+- **ADR needed**: no — 기존 레이어 패턴(ActionResult·apis 횡단 쿼리·admin 클라이언트)을 따르는 기능 추가로 새 구조 결정 없음. admin 클라이언트 사용 이유는 의사결정 로그 D1에 기록.
+
+## 목표
+
+placeholder인 `/mypage`를 Claude Design 시안(마이 페이지.dc.html)의 프로필 영역 기준으로 실제 페이지로 바꾼다. 이번 단계 범위는 프로필 표시, 프로필 편집(표시 이름·아바타), 비밀번호 변경, 로그아웃까지다. 백엔드 없는 메뉴는 "준비 중" 라벨을 달아 클릭해도 이동하지 않게 보여준다. 시안의 성경읽기 트래커는 후속 task로 뺀다.
+
+## 검증된 Assumptions
+
+- `/mypage`는 `(content)` 그룹 안의 placeholder(`<div>Mypage</div>`) — `src/app/(content)/mypage/page.tsx:1-3` Read.
+- `profiles` 컬럼에 `display_name`·`avatar_url`(둘 다 nullable) 존재 — `src/types/database.types.ts:210-214`.
+- `profiles`는 RLS SELECT own(`auth.uid() = id`) 정책만 있고, `authenticated`의 INSERT/UPDATE/DELETE는 GRANT 레벨에서 회수돼 있다 — dev 프로젝트 `pg_policy` 직접 조회 + `supabase/migrations/20260611000000_profiles_rls_lockdown.sql:19`. role 탈취 차단이 잠금 목적이므로 클라이언트 쓰기 경로를 다시 열지 않는다.
+- Cloudinary 업로드 함수 `uploadImage({ file, folder, filename })` 존재 — `src/apis/cloudinary.ts:22-46`. 주보 전용 helper(`src/actions/_bulletin-helpers.ts`)와 별개다.
+- `departments` 테이블이 스키마 타입에 없다 — `database.types.ts` grep 0건. 부서 표시·수정은 범위에서 뺀다.
+- 미들웨어가 `/mypage`를 보호 라우트로 등록해 비로그인 시 `/login?redirect=`로 보낸다 — `src/lib/supabase/middleware.ts:15,29-31`.
+- 서버 인증 조회 패턴 `getUserSession()` 존재 — `src/apis/auth-server.ts:3-8`.
+- 결과객체 반환형 Server Action 패턴(`ActionResult<T>`) 존재 — `src/actions/auth.action.ts`, `src/actions/_types.ts`.
+- 공용 UI에 Button·TextField·Modal·BottomSheet·ListItem·Label·Skeleton 존재 — `.claude/skills/ui-components/SKILL.md` 카탈로그.
+- `createAdminServerClient()`(service_role) 팩토리 존재 — `.claude/skills/supabase/SKILL.md` 클라이언트 표.
+
+## Non-goals
+
+- 성경읽기 트래커 전체(연속 기록 카드·일/주/월 기록 탭·통독 진행률·기록기·기록 공유) — DB 스키마 신설이 필요한 별도 task.
+- 저장한 설교·나의 기도제목·출석 현황·알림 토글·읽기 알림 시간·번역본 — 백엔드 없음. "준비 중" 비활성 표시로만 노출.
+- 헤더(Desktop/Mobile) 로그인·프로필 진입점 추가.
+- 계정 탈퇴, 이름(`name`)·부서 수정.
+
+## 접근법
+
+- 시안은 412px 폰 프레임 + 자체 탭바 구조지만, 실제 앱은 `(content)` 레이아웃(Header·BottomNav)이 이미 있으므로 화면 콘텐츠만 가져온다. 하드코딩 색은 semantic 토큰으로 치환하고 모바일 퍼스트(`respond-up`)로 쓴다. "한빛교회" 표기는 쓰지 않는다.
+- `page.tsx`는 Server Component로 프로필을 서버에서 조회해 내려주고, 편집 Modal·비밀번호 변경·설정 등 인터랙션은 `_component/` Client Component로 나눈다. module.scss는 상위 1개로 통합한다.
+- 프로필 편집 필드는 시안의 이름/부서/속회 대신 실제 스키마에 있는 표시 이름(`display_name`)과 아바타(`avatar_url`)만 다룬다.
+
+## 의사결정 로그
+
+- **D1 — 프로필 갱신은 RLS 정책 신설 대신 Server Action + admin 클라이언트로 한다**
+  - 문제: `profiles`는 잠금 마이그레이션으로 `authenticated`의 UPDATE GRANT 자체가 회수돼 있어 클라이언트·일반 서버 클라이언트로는 수정이 불가능하다.
+  - 해결: 컬럼 단위 GRANT(`GRANT UPDATE (display_name, avatar_url)`) + UPDATE own 정책을 여는 대안도 있으나, 잠금 마이그레이션을 되돌리는 새 마이그레이션이 필요하고 dev·prod 두 프로젝트에 적용을 맞춰야 한다. Server Action에서 `getUser()`로 본인 확인 후 `createAdminServerClient()`로 갱신하는 쪽이 마이그레이션 없이 같은 효과를 내서 이를 택했다.
+  - 결과: DB 마이그레이션 없이 허용 컬럼만 갱신하는 쓰기 경로가 생긴다.
+  - **payload 가드 (Codex 계획 검증 CHANGE_REQUEST(이하 CR) 반영)**: `profiles.Update` 타입은 `role`·`status`도 optional로 열려 있다(`database.types.ts:237-249`). admin 클라이언트는 RLS를 우회하므로, update payload는 `{ display_name, avatar_url }` 2컬럼 상수 객체로 고정하고 FormData·입력 객체 spread를 금지한다.
+- **D2 — 비밀번호 변경은 현재 비밀번호 재확인을 요구한다 (Codex CR 반영)**
+  - 문제: 세션만으로 `auth.updateUser({ password })`를 부르면 탈취된 세션·공용 PC 로그인 상태에서 계정을 영구 장악할 수 있다. 같은 위험이 `docs/tech-debt/active.md`의 `/reset-password` 항목에 이미 등록돼 있고, 그 항목의 마이그레이션 경로 (4)가 "계정 설정의 비밀번호 변경은 현재 비밀번호 재확인 요구"를 명시한다.
+  - 해결: changePasswordAction 진입부에서 (1) 새 비밀번호 `PASSWORD_REGEX` 서버 재검증, (2) `signInWithPassword(email, 현재 비밀번호)`로 재확인 후 성공 시에만 `updateUser({ password })` 호출. rate-limit은 Supabase 인증 기본 rate limit(로그인 시도 제한)에 위임하고 자체 구현은 하지 않는다 — 재확인이 로그인 엔드포인트를 타므로 같은 제한이 걸린다.
+  - 결과: 마이 페이지 비밀번호 변경은 현재 비밀번호 없이는 불가능하다. `/reset-password` 흐름 자체의 가드 보강은 이번 범위 밖(기존 tech-debt 유지).
+- **D3 — 아바타 업로드는 `src/apis/cloudinary.ts`의 `uploadImage()`를 쓴다 (Codex CR 반영)**
+  - 문제: "기존 업로드 유틸 재사용"만으로는 주보 전용 helper(`src/actions/_bulletin-helpers.ts`의 folder/date/order 규칙)를 오용할 수 있다.
+  - 해결: 범용 `uploadImage({ file, folder, filename })`를 직접 호출하고 folder는 프로필 전용 경로(예: `profiles/avatars`), filename은 user id 기반으로 고정한다. 주보 helper는 사용하지 않는다.
+  - 결과: 아바타 업로드가 주보 규칙과 얽히지 않는다.
+- **D4 — 세션·프로필 조회는 `services/user` 경유, 로그아웃은 Server Action으로 한다**
+  - 문제: ESLint 레이어 규칙이 `app/ → apis/` 직접 import를 error로 차단한다(`eslint.config.mjs:84-97`, 기존 위반 10건만 부채 등록). page.tsx의 `getUserSession`·`getProfileByIdServer` import와 AccountMenu의 `signOut` import가 걸렸다.
+  - 해결: 서버 조회는 `src/services/user/index.ts`(server-only)의 `getMySessionProfile()`로 감쌌다 — `services/about`과 같은 패턴. 클라이언트 로그아웃은 browser용 `apis/auth.signOut` 대신 `signOutAction`(Server Action)을 새로 만들어 호출했다 — `app/ → actions/`는 허용 방향이고, 성공 시 `window.location.replace('/')` 전체 리로드로 SessionContextProvider의 클라이언트 상태까지 초기화된다.
+  - 결과: 신규 코드 레이어 위반 0건으로 lint 통과.
+
+## Success Criteria
+
+- 로그인 상태에서 `http://localhost:3000/mypage` 접속 시 아바타(이미지 또는 이니셜)·이름·이메일이 렌더된다 — 브라우저 실측 + 스크린샷.
+- 프로필 편집 Modal에서 표시 이름 저장 후, dev 프로젝트에 `SELECT display_name, avatar_url FROM profiles WHERE id = '<테스트 계정 uid>'` 실행 결과가 입력값과 일치하고 화면도 새 이름을 보여준다.
+- 아바타 이미지 업로드 후 같은 SQL에서 `avatar_url`이 Cloudinary URL(`res.cloudinary.com` 포함)이고, 페이지에서 `<Image>`로 렌더된다.
+- 비밀번호 변경 폼: (1) 현재 비밀번호가 틀리면 실패 메시지가 뜨고 변경되지 않는다, (2) 현재 비밀번호가 맞으면 성공하고 로그아웃 → 새 비밀번호로 재로그인된다 — 브라우저 실측 2케이스.
+- 로그아웃 버튼 클릭 시 세션이 제거되고 홈(`/`)으로 이동한다 — 이동 후 `/mypage` 재접근 시 `/login?redirect=`로 튕기는 것까지 확인.
+- 준비 중 메뉴(저장한 설교·기도제목·출석)는 클릭해도 라우트 이동이 없고 "준비 중" Label이 보인다.
+- `node scripts/verify-task.mjs my-page` (lint·styles·build·knip) 통과 — `logs/my-page/<run-id>/` 증적.
+
+## 영향받는 파일
+
+- `src/app/(content)/mypage/page.tsx` — placeholder 교체
+- `src/app/(content)/mypage/_component/` — ProfileSection·ProfileEditModal·PasswordChangeModal·AccountMenu 신규 + 통합 mypage.module.scss 1개
+- `src/apis/user-server.ts` — 서버용 프로필 조회 (신규)
+- `src/services/user/index.ts` — 세션+프로필 조회 `getMySessionProfile` (신규, D4)
+- `src/actions/profile.action.ts` — updateProfileAction (신규)
+- `src/actions/auth.action.ts` — changePasswordAction·signOutAction 추가
+
+## 단계별 체크리스트
+
+- [x] 1. 서버 프로필 조회(apis + services/user) + page.tsx 골격(프로필 헤더·메뉴 리스트·준비 중 표시)
+- [x] 2. 프로필 편집 Modal + updateProfileAction(표시 이름)
+- [x] 3. 아바타 Cloudinary 업로드 연결(`uploadImage()`, D3)
+- [x] 4. 비밀번호 변경 폼(현재·새 비밀번호) + changePasswordAction(현재 비밀번호 재확인 → `auth.updateUser`, D2)
+- [x] 5. 로그아웃 연결(signOutAction, D4)
+- [x] 6. 시안의 하드코딩 색을 semantic 토큰으로 치환하고 `respond-up` 기준 반응형으로 작성
+- [x] 7. VERIFY + 브라우저 실측·스크린샷
+
+## Verification
+
+- `node scripts/verify-task.mjs my-page`
+
+---
+
+<!-- 검증 섹션 — Codex/Claude 호출 후 verdict 1줄 갱신. harness-gate가 verdict token + placeholder denylist + 최소 30자 본문 강제. -->
+
+## Codex 계획 검증
+
+- **결론**: CHANGE_REQUEST (confidence: high) — 2026-07-17 1차
+- **현재 판단**: material(구현 판단을 바꾸는 지적) 4건 모두 plan에 반영 완료. Codex 지적 verbatim 요지:
+  1. "service_role UPDATE에 '2컬럼 상수 payload, spread 금지' 조건 없음 — `profiles.Update`에 `role`/`status` 포함(`database.types.ts:237-249`), admin client가 RLS 우회" → D1에 payload 가드 추가.
+  2. "비밀번호 변경에 현재 비밀번호 재확인/재인증/rate-limit 결정 0개 — 기존 tech-debt 항목(`docs/tech-debt/active.md:375-382`)과 같은 위험" → D2 신설(현재 비밀번호 재확인 + `PASSWORD_REGEX` 서버 재검증 + rate-limit은 Supabase 기본에 위임).
+  3. "Success Criteria가 구체 명령·SQL·브라우저 절차 미고정" → SC를 SQL 문·URL·실측 케이스 2개로 다시 썼다.
+  4. "아바타 업로드 유틸 재사용 대상 불명확(`uploadImage()` vs `uploadBulletinImages()`)" → D3 신설(`src/apis/cloudinary.ts`의 `uploadImage()` 고정).
+  - expression-only(표현만 고치면 되는 지적) 1건: "D1 설명이 RLS 문제로만 서술, column-level GRANT 대안 미언급" → D1 해결 단락에 대안·기각 사유를 적었다.
+- **다음 행동**: 반영 완료 — WORK 진입. 재검증은 사용자 명시 요청 시만.
+
+## Codex 1차 검증
+
+- **결론**: FIX_APPLIED — 2026-07-17. Codex 원문 verdict는 `NEEDS_FOLLOWUP`(직접 수정 3건 + Claude 판단 요청 2건)이며, 판단 요청 2건은 아래처럼 처리해 남은 항목이 없다.
+- **현재 판단**: Codex verbatim 요지와 처리:
+  - 수정 적용 3건 (Codex가 직접 고침):
+    1. "`ProfileSection.tsx:14` — OAuth 가입 trigger가 외부 `picture/profile_image`를 `profiles.avatar_url`에 저장할 수 있는데 (...) `res.cloudinary.com` 제한과 충돌" → `cloudinaryFetchUrl()` 래핑으로 수정.
+    2. "`ProfileEditModal.tsx:100` — hidden file input DOM value가 남아 같은 파일 재선택에서 `change`가 안 날 수 있었다" → 선택 전 value 초기화로 수정.
+    3. "`user-server.ts:1` — 서버 전용 API 파일인데 자체 `server-only` marker가 없다" → `import 'server-only'` 추가.
+  - 판단 요청 2건 (Claude 처리):
+    1. "D1이 요구한 '정확히 2키 상수 literal'이 아니다 — 조건부 키 추가 방식" → 상수 literal 2개 분기(`avatarId ? {2키} : {1키}`)로 다시 썼다. 동작 동일.
+    2. "성공한 reverify가 SSR client의 cookie adapter를 타고 응답 쿠키를 갱신할 수 있다" → 허용으로 결정. 재발급되는 세션의 소유자가 같은 사용자이고 이후 `updateUser`도 그 세션으로 이어지므로 무해하다. 쿠키를 안 건드리는 별도 일회용 클라이언트는 팩토리 추가 비용 대비 이득이 없어 기각.
+  - 그 외 확인 결과 4건(파일 guard·kakao 분기·레이어 경유·D2 실패 시 조기 반환)은 issue 없음 판정.
+- **다음 행동**: verify-task + 브라우저 실측 후 Claude 2차 검증 섹션 갱신.
+
+## Claude 2차 검증
+
+- **최종 판단**: PASS — 2026-07-17
+- **현재 판단**: Codex 직접 수정 3건의 diff를 다시 읽어 의도·범위를 확인했다 — (1) `ProfileEditModal` file input value 초기화는 클릭 직전 값 비우기 한 줄이라 부작용 없음, (2) `ProfileSection`의 `cloudinaryFetchUrl()` 래핑은 외부 URL만 fetch 경로로 감싸고 public_id·cloudinary URL은 그대로 통과(`src/utils/cloudinary.ts:66-72`), (3) `user-server.ts`의 `server-only`는 기존 `services/about` 패턴과 같다. D1 payload는 상수 literal 2분기로 재작성해 재확인했다.
+- 브라우저 실측 (localhost:3001, dev DB 테스트 계정 vihaya8934@luckfeed.com):
+  - 프로필 렌더(이니셜 아바타·이름·이메일) 확인. 편집 저장 후 화면·DB(`display_name='길동테스트'`) 동시 반영.
+  - 아바타 업로드 → `avatar_url`에 public_id 저장·`<Image>` 렌더 확인. 단, 저장 경로에 폴더가 중복된다(`uploads/profiles/<ROOT>/uploads/profiles/...`) — 기존 `uploadImage()`가 folder와 public_id를 함께 넘겨 생기는 동작으로, 주보 `bulletin_images.cloudinary_id`도 같은 패턴이라 이번 변경의 회귀가 아니다. 후속 작업에 기술 부채로 올린다.
+  - 비밀번호 변경 2케이스: 틀린 현재 비밀번호 → "현재 비밀번호가 일치하지 않습니다." 토스트 + 변경 차단 / 맞는 현재 비밀번호 → 성공 토스트 + 새 비밀번호(test5678) 재로그인 성공.
+  - 준비 중 메뉴 클릭 → 이동 없음 + info 토스트. 로그아웃 → 홈 이동, `/mypage` 재접근 시 `/login?redirect=%2Fmypage` 리다이렉트 유지.
+  - 실측 후 테스트 계정 `display_name`·`avatar_url`을 NULL로 원복.
+
+| 시점 | run-id | lint | styles | build | knip신규 | 수동 확인 필요 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1차 | 20260717-074745 | ✅ | ✅ | ✅ | 0 | — (브라우저 실측 완료) |
+
+- **다음 행동**: doc-editor 점검 → 사용자 승인 → 커밋.
+
+## 검증 이력
+
+<details>
+<summary>2026-07-17 Codex 계획 검증 1차</summary>
+
+- 판정: CHANGE_REQUEST
+- 이유: admin 클라이언트 payload 가드·비밀번호 재확인 정책·SC 구체화·업로드 유틸 지정 4건 누락
+- 조치: D1 보강, D2·D3 신설, SC 재작성
+
+</details>
+
+## 후속 작업
+
+- `uploadImage()` 폴더 중복 저장 (`<folder>/<ROOT>/<folder>/<file>`)
+  - 이유: Cloudinary upload 옵션에 `folder`와 folder가 포함된 `public_id`를 함께 넘겨 최종 public_id에 폴더가 두 번 들어간다. 주보(`bulletin_images.cloudinary_id`)도 같은 패턴으로 저장돼 있어 이번 작업의 회귀가 아니다. 저장된 id가 실제 경로와 일치해 렌더는 정상이다.
+  - 다음 기준: Cloudinary 자산 정리나 업로드 유틸을 다시 만질 때 함께 수정.
+  - 기록 위치: `docs/tech-debt/active.md` 등록 완료 (2026-07-17)
+- 성경읽기 트래커(기록·통독·주간 목표·공유)
+  - 이유: 읽기 기록·통독 진행 테이블이 없어 DB 스키마 신설부터 필요한 별도 규모의 작업.
+  - 다음 기준: 이번 task 머지 후 새 task로 시작.
+  - 기록 위치: 없음 (후속 task로 진행)
+- 헤더 로그인·프로필 진입점
+  - 이유: Desktop/MobileHeader에 인증 진입점이 없는 문제는 마이 페이지와 별개 화면 작업.
+  - 다음 기준: 마이 페이지 공개 후 UX 점검 시.
+  - 기록 위치: `docs/research/FEATURE_SPEC.md` 감사에 이미 기록됨

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -444,3 +444,13 @@
 - **영향 범위**: `src/apis/cloudinary.ts`, (선택) 기존 Cloudinary 자산 정리
 - **확인**: dev DB `SELECT cloudinary_id FROM bulletin_images ORDER BY created_at DESC LIMIT 1` → `uploads/bulletins/2026/07/05/dnchurch-dev/uploads/bulletins/2026/07/05/...` 중복 경로 확인.
 - **발견일**: 2026-07-17 (my-page 아바타 업로드 브라우저 실측 — `docs/exec-plans/active/2026-07-17-my-page.md` 후속 작업)
+
+### 🟡 성경읽기 기록기 낱장 토글이 탭마다 Server Action을 호출 (2026-07-17 bible-reading-tracker)
+
+- **상태**: 등록만 (다음 PR에서 개선 — medium)
+- **무엇**: `TrackerSection.toggleChapter`가 낱장 모드에서 장 하나를 누를 때마다 `recordChaptersAction`/`unrecordChaptersAction`을 한 번씩 호출한다. 낱장으로 10장을 하나씩 누르면 서버 왕복이 10번 일어난다(각 호출이 서버에서 `getUser` + settings 조회 + upsert/delete). 범위·모두읽음·해제는 이미 한 번에 묶어 보낸다.
+- **왜**: 낙관적 UI로 화면은 즉시 반영되지만 네트워크·DB 요청이 잦다. 또한 같은 장을 아주 빠르게 켰다 껐다 하면 record/unrecord 요청이 순서 보장 없이 각각 날아가 드물게 최종 상태가 어긋날 여지가 있다(rapid-toggle race).
+- **마이그레이션 경로**: 탭은 로컬 state에만 반영하고, 300~500ms 디바운스 후(또는 기록기 닫힘·날짜/책 전환 시) 그 책·날짜의 변경분을 모아 `record`/`unrecord`로 한 번에 flush한다. 호출 수가 줄고 rapid-toggle race도 사라진다.
+- **영향 범위**: `src/app/(content)/mypage/_component/tracker/TrackerSection.tsx`
+- **확인**: 낱장 모드로 여러 장을 연속 탭하며 네트워크 탭에서 Server Action POST가 탭 수만큼 발생하는지 확인.
+- **발견일**: 2026-07-17 (bible-reading-tracker 구현 중 사용자 지적)

--- a/docs/tech-debt/active.md
+++ b/docs/tech-debt/active.md
@@ -434,3 +434,13 @@
 - **확인**: `rg "server-only" src/lib/supabase/admin.ts src/apis/auth-server.ts` → 0 hits.
 - **발견일**: 2026-07-16 (인증 A-to-Z 감사 10절 — `docs/research/2026-07-16-auth-a-to-z.md`)
 
+
+### 🟢 `uploadImage()`가 public_id에 폴더를 두 번 넣음 (2026-07-17 my-page 실측)
+
+- **상태**: 등록만 (낮은 우선순위 — 렌더·삭제는 정상 동작)
+- **무엇**: `uploadImage()`가 Cloudinary upload 옵션에 `folder`와, 같은 folder를 앞에 붙인 `public_id`를 동시에 넘긴다. Cloudinary는 folder를 public_id 앞에 다시 붙여 최종 public_id가 `<folder>/<ROOT>/<folder>/<file>`처럼 폴더가 중복된 경로로 저장된다. 주보(`bulletin_images.cloudinary_id`)와 마이페이지 아바타(`profiles.avatar_url`) 모두 이 패턴이다.
+- **왜**: DB에는 업로드 응답의 실제 public_id가 저장되므로 URL 합성·렌더·삭제는 전부 맞는 경로를 쓴다. 결함이 아니라 Cloudinary 콘솔에서 자산 경로가 길고 중복돼 보이는 관리 문제다.
+- **마이그레이션 경로**: `uploadImage()`에서 `folder` 옵션을 빼고 `public_id`만 넘기거나, `public_id`를 filename만 남긴다. 기존 자산은 경로 그대로 두고 신규 업로드부터 적용한다.
+- **영향 범위**: `src/apis/cloudinary.ts`, (선택) 기존 Cloudinary 자산 정리
+- **확인**: dev DB `SELECT cloudinary_id FROM bulletin_images ORDER BY created_at DESC LIMIT 1` → `uploads/bulletins/2026/07/05/dnchurch-dev/uploads/bulletins/2026/07/05/...` 중복 경로 확인.
+- **발견일**: 2026-07-17 (my-page 아바타 업로드 브라우저 실측 — `docs/exec-plans/active/2026-07-17-my-page.md` 후속 작업)

--- a/src/actions/auth.action.ts
+++ b/src/actions/auth.action.ts
@@ -71,6 +71,54 @@ export async function verifyPasswordResetOtpAction(
   return { success: true, message: '인증되었습니다.' };
 }
 
+export async function signOutAction(): Promise<ActionResult> {
+  const supabase = await createServerSideClient();
+  const { error } = await supabase.auth.signOut();
+
+  if (error) {
+    return { success: false, message: '로그아웃에 실패했습니다. 잠시 후 다시 시도해주세요.' };
+  }
+
+  return { success: true, message: '로그아웃되었습니다.' };
+}
+
+export async function changePasswordAction(
+  currentPassword: string,
+  newPassword: string
+): Promise<ActionResult> {
+  if (!currentPassword) {
+    return { success: false, message: '현재 비밀번호를 입력해주세요.' };
+  }
+  // 클라이언트 폼 검증은 UX 보조 — 서버에서 항상 다시 검증한다 (ADR 0016)
+  if (!PASSWORD_REGEX.test(newPassword)) {
+    return { success: false, message: '비밀번호는 영문, 숫자 포함 8자 이상이여야 합니다.' };
+  }
+
+  const supabase = await createServerSideClient();
+  const { data } = await supabase.auth.getUser();
+  const email = data.user?.email;
+  if (!email) {
+    return { success: false, message: '로그인이 필요합니다.' };
+  }
+
+  // 현재 비밀번호 재확인 — 세션만 쥔 사람이 비밀번호를 바꾸지 못하게 막는다 (exec-plan D2).
+  // 로그인 엔드포인트를 타므로 Supabase 기본 rate limit이 함께 걸린다.
+  const { error: verifyError } = await supabase.auth.signInWithPassword({
+    email,
+    password: currentPassword
+  });
+  if (verifyError) {
+    return { success: false, message: '현재 비밀번호가 일치하지 않습니다.' };
+  }
+
+  const { error } = await supabase.auth.updateUser({ password: newPassword });
+  if (error) {
+    return { success: false, message: generateErrorMessage(error) };
+  }
+
+  return { success: true, message: '비밀번호가 변경되었습니다.' };
+}
+
 export async function signUpAction({
   email,
   password,

--- a/src/actions/bible-reading.action.ts
+++ b/src/actions/bible-reading.action.ts
@@ -1,0 +1,157 @@
+'use server';
+
+import { createServerSideClient } from '@/lib/supabase/server';
+import { isValidChapter, BIBLE_TOTAL_CHAPTERS } from '@/constants/bible';
+import { kstToday } from '@/utils/bible-tracker';
+import type { ActionResult } from './_types';
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const WEEKLY_GOAL_MIN = 5;
+const WEEKLY_GOAL_MAX = 150;
+const PAGE_SIZE = 1000;
+
+// 기록/해제 공통 입력 검증 — 날짜 형식·미래 금지·유효 장만 남긴다.
+function validateRecordInput(
+  bookOrder: number,
+  chapters: number[],
+  readDate: string
+): { ok: true; chapters: number[] } | { ok: false; message: string } {
+  if (!DATE_RE.test(readDate) || readDate > kstToday()) {
+    return { ok: false, message: '올바른 날짜가 아닙니다.' };
+  }
+  const valid = [...new Set(chapters)].filter((chapter) => isValidChapter(bookOrder, chapter));
+  if (valid.length === 0) {
+    return { ok: false, message: '기록할 장이 없습니다.' };
+  }
+  return { ok: true, chapters: valid };
+}
+
+export async function recordChaptersAction(
+  bookOrder: number,
+  chapters: number[],
+  readDate: string
+): Promise<ActionResult> {
+  const validated = validateRecordInput(bookOrder, chapters, readDate);
+  if (!validated.ok) return { success: false, message: validated.message };
+
+  const supabase = await createServerSideClient();
+  const { data } = await supabase.auth.getUser();
+  const user = data.user;
+  if (!user) return { success: false, message: '로그인이 필요합니다.' };
+
+  // 현재 회차를 기록에 박는다 (없으면 1). 통독 진행은 이 cycle로 구분한다 (D5).
+  const { data: settings } = await supabase
+    .from('bible_reading_settings')
+    .select('current_cycle')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  const cycle = settings?.current_cycle ?? 1;
+
+  // user_id는 세션에서만 채운다 — 클라이언트가 남의 id를 넣을 수 없다.
+  const rows = validated.chapters.map((chapter) => ({
+    user_id: user.id,
+    book_order: bookOrder,
+    chapter,
+    read_date: readDate,
+    cycle
+  }));
+
+  const { error } = await supabase
+    .from('bible_reading_records')
+    .upsert(rows, { onConflict: 'user_id,book_order,chapter,read_date', ignoreDuplicates: true });
+
+  if (error) return { success: false, message: '기록에 실패했습니다.' };
+  return { success: true, message: '기록했습니다.' };
+}
+
+export async function unrecordChaptersAction(
+  bookOrder: number,
+  chapters: number[],
+  readDate: string
+): Promise<ActionResult> {
+  const validated = validateRecordInput(bookOrder, chapters, readDate);
+  if (!validated.ok) return { success: false, message: validated.message };
+
+  const supabase = await createServerSideClient();
+  const { data } = await supabase.auth.getUser();
+  const user = data.user;
+  if (!user) return { success: false, message: '로그인이 필요합니다.' };
+
+  const { error } = await supabase
+    .from('bible_reading_records')
+    .delete()
+    .eq('user_id', user.id)
+    .eq('book_order', bookOrder)
+    .eq('read_date', readDate)
+    .in('chapter', validated.chapters);
+
+  if (error) return { success: false, message: '기록 해제에 실패했습니다.' };
+  return { success: true, message: '기록을 해제했습니다.' };
+}
+
+export async function setWeeklyGoalAction(goal: number): Promise<ActionResult> {
+  if (!Number.isInteger(goal) || goal < WEEKLY_GOAL_MIN || goal > WEEKLY_GOAL_MAX) {
+    return { success: false, message: `주간 목표는 ${WEEKLY_GOAL_MIN}~${WEEKLY_GOAL_MAX}장 사이여야 합니다.` };
+  }
+
+  const supabase = await createServerSideClient();
+  const { data } = await supabase.auth.getUser();
+  const user = data.user;
+  if (!user) return { success: false, message: '로그인이 필요합니다.' };
+
+  const { error } = await supabase
+    .from('bible_reading_settings')
+    .upsert(
+      { user_id: user.id, weekly_goal: goal, updated_at: new Date().toISOString() },
+      { onConflict: 'user_id' }
+    );
+
+  if (error) return { success: false, message: '목표 저장에 실패했습니다.' };
+  return { success: true, message: '주간 목표를 저장했습니다.' };
+}
+
+export async function startNextCycleAction(): Promise<ActionResult> {
+  const supabase = await createServerSideClient();
+  const { data } = await supabase.auth.getUser();
+  const user = data.user;
+  if (!user) return { success: false, message: '로그인이 필요합니다.' };
+
+  const { data: settings } = await supabase
+    .from('bible_reading_settings')
+    .select('current_cycle')
+    .eq('user_id', user.id)
+    .maybeSingle();
+  const currentCycle = settings?.current_cycle ?? 1;
+
+  // 현재 회차를 다 읽었을 때만 다음 회독을 연다 — 실수로 진행이 리셋되지 않게.
+  const rows: Array<{ book_order: number; chapter: number }> = [];
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error: readError } = await supabase
+      .from('bible_reading_records')
+      .select('book_order, chapter')
+      .eq('user_id', user.id)
+      .eq('cycle', currentCycle)
+      .order('book_order', { ascending: true })
+      .order('chapter', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+    if (readError) return { success: false, message: '통독 진행을 확인하지 못했습니다.' };
+
+    rows.push(...(data ?? []));
+    if ((data?.length ?? 0) < PAGE_SIZE) break;
+  }
+
+  const distinct = new Set(rows.map((row) => `${row.book_order}:${row.chapter}`));
+  if (distinct.size < BIBLE_TOTAL_CHAPTERS) {
+    return { success: false, message: '아직 통독을 마치지 않았습니다.' };
+  }
+
+  const { error } = await supabase
+    .from('bible_reading_settings')
+    .upsert(
+      { user_id: user.id, current_cycle: currentCycle + 1, updated_at: new Date().toISOString() },
+      { onConflict: 'user_id' }
+    );
+
+  if (error) return { success: false, message: '다음 회독 시작에 실패했습니다.' };
+  return { success: true, message: '다음 회독을 시작했습니다.' };
+}

--- a/src/actions/profile.action.ts
+++ b/src/actions/profile.action.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import { randomUUID } from 'crypto';
+import { createServerSideClient } from '@/lib/supabase/server';
+import { createAdminServerClient } from '@/lib/supabase/admin';
+import { uploadImage, deleteImage } from '@/apis/cloudinary';
+import { stripRootPrefix, uploadFolder } from '@/utils/cloudinary';
+import type { ActionResult } from './_types';
+
+const DISPLAY_NAME_MAX_LENGTH = 10;
+const AVATAR_MAX_SIZE = 5 * 1024 * 1024;
+
+export async function updateProfileAction(formData: FormData): Promise<ActionResult> {
+  // 클라이언트 폼 검증은 UX 보조 — 서버에서 항상 다시 검증한다 (ADR 0016)
+  const displayName = String(formData.get('displayName') ?? '').trim();
+  if (!displayName || displayName.length > DISPLAY_NAME_MAX_LENGTH) {
+    return {
+      success: false,
+      message: `표시 이름은 1~${DISPLAY_NAME_MAX_LENGTH}자로 입력해주세요.`
+    };
+  }
+
+  const supabase = await createServerSideClient();
+  const { data } = await supabase.auth.getUser();
+  const user = data.user;
+  if (!user) {
+    return { success: false, message: '로그인이 필요합니다.' };
+  }
+
+  let avatarId: string | undefined;
+  let previousAvatarId: string | null = null;
+  const avatarEntry = formData.get('avatar');
+  if (avatarEntry instanceof File && avatarEntry.size > 0) {
+    if (!avatarEntry.type.startsWith('image/')) {
+      return { success: false, message: '이미지 파일만 올릴 수 있습니다.' };
+    }
+    if (avatarEntry.size > AVATAR_MAX_SIZE) {
+      return { success: false, message: '이미지는 5MB 이하만 올릴 수 있습니다.' };
+    }
+
+    const { data: currentProfile } = await supabase
+      .from('profiles')
+      .select('avatar_url')
+      .eq('id', user.id)
+      .single();
+    previousAvatarId = currentProfile?.avatar_url ?? null;
+
+    try {
+      const uploaded = await uploadImage({
+        file: avatarEntry,
+        folder: uploadFolder('profiles'),
+        // UUID로 재업로드마다 public_id를 바꿔 변환 URL 캐시가 이전 이미지를 물지 않게 한다
+        filename: `${user.id}-${randomUUID().slice(0, 8)}`
+      });
+      avatarId = stripRootPrefix(uploaded.public_id);
+    } catch {
+      return { success: false, message: '이미지 업로드에 실패했습니다. 잠시 후 다시 시도해주세요.' };
+    }
+  }
+
+  // profiles는 클라이언트 쓰기가 잠겨 있어(UPDATE GRANT 회수, 20260611000000 마이그레이션)
+  // 본인 확인 후 admin 클라이언트로 갱신한다. admin은 RLS를 우회하므로
+  // payload는 허용 2컬럼 상수 literal만 쓴다 — 입력 객체 spread 금지 (exec-plan D1)
+  const payload = avatarId
+    ? { display_name: displayName, avatar_url: avatarId }
+    : { display_name: displayName };
+
+  const admin = createAdminServerClient();
+  const { error } = await admin.from('profiles').update(payload).eq('id', user.id);
+  if (error) {
+    if (avatarId) {
+      await deleteImage(avatarId).catch(() => {});
+    }
+    return { success: false, message: '프로필 저장에 실패했습니다. 잠시 후 다시 시도해주세요.' };
+  }
+
+  // 교체된 이전 아바타는 orphan으로 남기지 않는다. 외부 URL(카카오 프로필 등)은 삭제 대상이 아니다.
+  if (avatarId && previousAvatarId && !/^https?:\/\//i.test(previousAvatarId)) {
+    await deleteImage(previousAvatarId).catch(() => {});
+  }
+
+  return { success: true, message: '프로필을 저장했습니다.' };
+}

--- a/src/apis/bible-reading.ts
+++ b/src/apis/bible-reading.ts
@@ -1,0 +1,41 @@
+import { createServerSideClient } from '@/lib/supabase/server';
+import type { ReadingRecord, BibleReadingSettings } from '@/utils/bible-tracker';
+
+const DEFAULT_SETTINGS: BibleReadingSettings = { weekly_goal: 50, current_cycle: 1 };
+const PAGE_SIZE = 1000;
+
+// RLS owner 정책이 본인 행만 돌려주지만, 인덱스를 타도록 user_id도 명시한다.
+export async function getBibleReadingRecords(userId: string): Promise<ReadingRecord[]> {
+  const supabase = await createServerSideClient();
+  const records: ReadingRecord[] = [];
+
+  for (let from = 0; ; from += PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from('bible_reading_records')
+      .select('book_order, chapter, read_date, cycle')
+      .eq('user_id', userId)
+      .order('read_date', { ascending: true })
+      .order('book_order', { ascending: true })
+      .order('chapter', { ascending: true })
+      .range(from, from + PAGE_SIZE - 1);
+
+    if (error) throw error;
+    records.push(...(data ?? []));
+    if ((data?.length ?? 0) < PAGE_SIZE) break;
+  }
+
+  return records;
+}
+
+// settings 행은 지연 생성이라 없으면 기본값으로 취급한다.
+export async function getBibleReadingSettings(userId: string): Promise<BibleReadingSettings> {
+  const supabase = await createServerSideClient();
+  const { data, error } = await supabase
+    .from('bible_reading_settings')
+    .select('weekly_goal, current_cycle')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data ?? DEFAULT_SETTINGS;
+}

--- a/src/apis/user-server.ts
+++ b/src/apis/user-server.ts
@@ -1,0 +1,16 @@
+import 'server-only';
+
+import { createServerSideClient } from '@/lib/supabase/server';
+
+export const getProfileByIdServer = async (userId: string) => {
+  const supabase = await createServerSideClient();
+  const { data: profile, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('id', userId)
+    .single();
+
+  if (error) throw error;
+
+  return profile;
+};

--- a/src/app/(content)/mypage/_component/AccountMenu.tsx
+++ b/src/app/(content)/mypage/_component/AccountMenu.tsx
@@ -44,7 +44,7 @@ export default function AccountMenu({ hasPasswordAuth }: { hasPasswordAuth: bool
         </div>
       </section>
 
-      <section className={styles.menu_section} aria-label="계정">
+      <section id="mypage-account" className={styles.menu_section} aria-label="계정">
         <h3 className={styles.menu_title}>계정</h3>
         <div className={styles.menu_group}>
           {hasPasswordAuth && (

--- a/src/app/(content)/mypage/_component/AccountMenu.tsx
+++ b/src/app/(content)/mypage/_component/AccountMenu.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { LuChevronRight } from 'react-icons/lu';
+import { Label, ListItem } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import { signOutAction } from '@/actions/auth.action';
+import PasswordChangeModal from './PasswordChangeModal';
+import styles from './mypage.module.scss';
+
+const PLANNED_MENUS = ['저장한 설교', '나의 기도제목', '출석 현황'];
+
+export default function AccountMenu({ hasPasswordAuth }: { hasPasswordAuth: boolean }) {
+  const { info, error } = useToastStore();
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [isSigningOut, startSignOut] = useTransition();
+
+  const handleSignOut = () => {
+    startSignOut(async () => {
+      const result = await signOutAction();
+      if (result.success) {
+        // 전체 리로드로 SessionContextProvider 등 클라이언트 인증 상태까지 초기화한다
+        window.location.replace('/');
+      } else {
+        error(result.message);
+      }
+    });
+  };
+
+  return (
+    <>
+      <section className={styles.menu_section} aria-label="내 활동">
+        <h3 className={styles.menu_title}>내 활동</h3>
+        <div className={styles.menu_group}>
+          {PLANNED_MENUS.map((menu) => (
+            <ListItem
+              key={menu}
+              trailing={<Label variant="neutral">준비 중</Label>}
+              onClick={() => info('준비 중인 기능이에요.')}
+            >
+              {menu}
+            </ListItem>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.menu_section} aria-label="계정">
+        <h3 className={styles.menu_title}>계정</h3>
+        <div className={styles.menu_group}>
+          {hasPasswordAuth && (
+            <ListItem
+              trailing={<LuChevronRight aria-hidden="true" />}
+              onClick={() => setPasswordOpen(true)}
+            >
+              비밀번호 변경
+            </ListItem>
+          )}
+          <ListItem className={styles.logout} onClick={handleSignOut} disabled={isSigningOut}>
+            로그아웃
+          </ListItem>
+        </div>
+      </section>
+
+      <PasswordChangeModal open={passwordOpen} onClose={() => setPasswordOpen(false)} />
+    </>
+  );
+}

--- a/src/app/(content)/mypage/_component/PasswordChangeModal.tsx
+++ b/src/app/(content)/mypage/_component/PasswordChangeModal.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { Button, Modal, TextField } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import { changePasswordAction } from '@/actions/auth.action';
+import { PASSWORD_REGEX } from '@/constants/regex';
+import styles from './mypage.module.scss';
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function PasswordChangeModal({ open, onClose }: Props) {
+  const { success, error } = useToastStore();
+  const [isPending, startTransition] = useTransition();
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [newPasswordError, setNewPasswordError] = useState('');
+  const [confirmError, setConfirmError] = useState('');
+
+  // 열림 전환 시 초기화 — effect 대신 렌더 중 prev 비교 (GalleryComposeSheet와 동일 패턴)
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setCurrentPassword('');
+      setNewPassword('');
+      setConfirmPassword('');
+      setNewPasswordError('');
+      setConfirmError('');
+    }
+  }
+
+  const handleSubmit = () => {
+    if (!PASSWORD_REGEX.test(newPassword)) {
+      setNewPasswordError('비밀번호는 영문, 숫자 포함 8자 이상이여야 합니다.');
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setConfirmError('새 비밀번호가 서로 일치하지 않습니다.');
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await changePasswordAction(currentPassword, newPassword);
+      if (result.success) {
+        success(result.message);
+        onClose();
+      } else {
+        error(result.message);
+      }
+    });
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="비밀번호 변경"
+      size="sm"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+            취소
+          </Button>
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isPending ? '변경 중…' : '변경'}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.password_fields}>
+        <TextField
+          label="현재 비밀번호"
+          type="password"
+          autoComplete="current-password"
+          value={currentPassword}
+          onChange={(event) => setCurrentPassword(event.target.value)}
+        />
+        <TextField
+          label="새 비밀번호"
+          type="password"
+          autoComplete="new-password"
+          value={newPassword}
+          onChange={(event) => {
+            setNewPassword(event.target.value);
+            setNewPasswordError('');
+          }}
+          error={newPasswordError || undefined}
+          helper="영문, 숫자 포함 8자 이상"
+        />
+        <TextField
+          label="새 비밀번호 확인"
+          type="password"
+          autoComplete="new-password"
+          value={confirmPassword}
+          onChange={(event) => {
+            setConfirmPassword(event.target.value);
+            setConfirmError('');
+          }}
+          error={confirmError || undefined}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(content)/mypage/_component/ProfileEditModal.tsx
+++ b/src/app/(content)/mypage/_component/ProfileEditModal.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button, Modal, TextField } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import { updateProfileAction } from '@/actions/profile.action';
+import type { ProfileType } from '@/types/common';
+import styles from './mypage.module.scss';
+
+const DISPLAY_NAME_MAX_LENGTH = 10;
+const AVATAR_MAX_SIZE = 5 * 1024 * 1024;
+
+type Props = {
+  profile: ProfileType;
+  open: boolean;
+  onClose: () => void;
+};
+
+export default function ProfileEditModal({ profile, open, onClose }: Props) {
+  const router = useRouter();
+  const { success, error } = useToastStore();
+  const [isPending, startTransition] = useTransition();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [displayName, setDisplayName] = useState(profile.display_name ?? profile.name);
+  const [avatarFile, setAvatarFile] = useState<File | null>(null);
+  const [fieldError, setFieldError] = useState('');
+
+  // 열림 전환 시 초기화 — effect 대신 렌더 중 prev 비교 (GalleryComposeSheet와 동일 패턴)
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) {
+      setDisplayName(profile.display_name ?? profile.name);
+      setAvatarFile(null);
+      setFieldError('');
+    }
+  }
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      error('이미지 파일만 올릴 수 있습니다.');
+      return;
+    }
+    if (file.size > AVATAR_MAX_SIZE) {
+      error('이미지는 5MB 이하만 올릴 수 있습니다.');
+      return;
+    }
+    setAvatarFile(file);
+  };
+
+  const handleSave = () => {
+    const trimmed = displayName.trim();
+    if (!trimmed || trimmed.length > DISPLAY_NAME_MAX_LENGTH) {
+      setFieldError(`표시 이름은 1~${DISPLAY_NAME_MAX_LENGTH}자로 입력해주세요.`);
+      return;
+    }
+
+    const formData = new FormData();
+    formData.set('displayName', trimmed);
+    if (avatarFile) {
+      formData.set('avatar', avatarFile);
+    }
+
+    startTransition(async () => {
+      const result = await updateProfileAction(formData);
+      if (result.success) {
+        success(result.message);
+        onClose();
+        router.refresh();
+      } else {
+        error(result.message);
+      }
+    });
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="프로필 편집"
+      size="sm"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose} disabled={isPending}>
+            취소
+          </Button>
+          <Button onClick={handleSave} disabled={isPending}>
+            {isPending ? '저장 중…' : '저장'}
+          </Button>
+        </>
+      }
+    >
+      <div className={styles.edit_avatar}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => {
+            if (fileInputRef.current) {
+              fileInputRef.current.value = '';
+              fileInputRef.current.click();
+            }
+          }}
+        >
+          사진 변경
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          hidden
+          onChange={handleFileChange}
+        />
+        {avatarFile && <span className={styles.file_name}>{avatarFile.name}</span>}
+      </div>
+      <TextField
+        label="표시 이름"
+        value={displayName}
+        onChange={(event) => {
+          setDisplayName(event.target.value);
+          setFieldError('');
+        }}
+        maxLength={DISPLAY_NAME_MAX_LENGTH}
+        error={fieldError || undefined}
+        helper={`커뮤니티에서 보이는 이름이에요 (${DISPLAY_NAME_MAX_LENGTH}자 이내)`}
+      />
+    </Modal>
+  );
+}

--- a/src/app/(content)/mypage/_component/ProfileSection.tsx
+++ b/src/app/(content)/mypage/_component/ProfileSection.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui';
+import CloudinaryImage from '@/components/common/CloudinaryImage';
+import { cloudinaryFetchUrl } from '@/utils/cloudinary';
+import type { ProfileType } from '@/types/common';
+import ProfileEditModal from './ProfileEditModal';
+import styles from './mypage.module.scss';
+
+export default function ProfileSection({ profile }: { profile: ProfileType }) {
+  const [editOpen, setEditOpen] = useState(false);
+  const displayName = profile.display_name || profile.name;
+  const avatarSrc = profile.avatar_url ? cloudinaryFetchUrl(profile.avatar_url) : null;
+
+  return (
+    <section className={styles.profile} aria-label="내 프로필">
+      <span className={styles.avatar} aria-hidden="true">
+        {avatarSrc ? (
+          <CloudinaryImage
+            src={avatarSrc}
+            alt=""
+            fill
+            sizes="64px"
+            cropMode="fill"
+            gravity="face"
+            aspectRatio="1:1"
+          />
+        ) : (
+          displayName.charAt(0)
+        )}
+      </span>
+      <div className={styles.identity}>
+        <strong className={styles.name}>{displayName}</strong>
+        <span className={styles.email}>{profile.email}</span>
+      </div>
+      <Button variant="secondary" size="sm" onClick={() => setEditOpen(true)}>
+        프로필 편집
+      </Button>
+      <ProfileEditModal profile={profile} open={editOpen} onClose={() => setEditOpen(false)} />
+    </section>
+  );
+}

--- a/src/app/(content)/mypage/_component/mypage.module.scss
+++ b/src/app/(content)/mypage/_component/mypage.module.scss
@@ -1,0 +1,107 @@
+// ══════════════════════════════════════════
+// 마이 페이지 — Claude Design 시안(마이 페이지.dc.html)의 프로필 영역 기준.
+// 성경읽기 트래커 카드는 후속 task에서 추가 예정.
+// ══════════════════════════════════════════
+
+$avatar-size: 6.4rem;
+$page-max-width: 60rem; // 계정 메뉴가 PC 폭 전체로 퍼지지 않게 좁은 단일 컬럼로 고정
+
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-l;
+  max-width: $page-max-width;
+  margin: 0 auto;
+}
+
+// ── 프로필 헤더 ──
+.profile {
+  display: flex;
+  align-items: center;
+  gap: $content-gap-m;
+  padding: $padding-card;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+}
+
+.avatar {
+  position: relative;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: $avatar-size;
+  height: $avatar-size;
+  border-radius: $radius-l;
+  background-color: $primary;
+  color: $txt-inverse;
+  font-size: $font-size-24;
+  font-weight: $font-weight-bold;
+}
+
+.identity {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-4;
+  flex: 1;
+  min-width: 0;
+}
+
+.name {
+  @include text-card-title;
+  @include ellipsis-multi(1);
+}
+
+.email {
+  @include text-caption;
+  @include ellipsis-multi(1);
+}
+
+// ── 메뉴 그룹 ──
+.menu_section {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-xs;
+}
+
+.menu_title {
+  @include text-label-emphasis;
+  padding: 0 $spacing-4;
+}
+
+.menu_group {
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  overflow: hidden;
+
+  > * + * {
+    border-top: 1px solid $border-subtle;
+  }
+}
+
+.logout {
+  color: $status-negative;
+}
+
+// ── 프로필 편집 모달 ──
+.edit_avatar {
+  display: flex;
+  align-items: center;
+  gap: $content-gap-s;
+  margin-bottom: $content-gap-m;
+}
+
+.file_name {
+  @include text-caption-small;
+  @include ellipsis-multi(1);
+  min-width: 0;
+}
+
+// ── 비밀번호 변경 모달 ──
+.password_fields {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+}

--- a/src/app/(content)/mypage/_component/mypage.module.scss
+++ b/src/app/(content)/mypage/_component/mypage.module.scss
@@ -14,15 +14,12 @@ $page-max-width: 60rem; // 계정 메뉴가 PC 폭 전체로 퍼지지 않게 �
   margin: 0 auto;
 }
 
-// ── 프로필 헤더 ──
+// ── 프로필 헤더 — 카드 없이 페이지 배경 위에 (시안) ──
 .profile {
   display: flex;
   align-items: center;
   gap: $content-gap-m;
-  padding: $padding-card;
-  background-color: $bg-card;
-  border: 1px solid $border-card;
-  border-radius: $radius-s;
+  padding: $spacing-4 0;
 }
 
 .avatar {
@@ -34,7 +31,8 @@ $page-max-width: 60rem; // 계정 메뉴가 PC 폭 전체로 퍼지지 않게 �
   width: $avatar-size;
   height: $avatar-size;
   border-radius: $radius-l;
-  background-color: $primary;
+  // 시안의 gold 그라디언트 아바타 (styles SKILL 그라디언트 예외)
+  background: linear-gradient(140deg, $accent-hover, $accent);
   color: $txt-inverse;
   font-size: $font-size-24;
   font-weight: $font-weight-bold;

--- a/src/app/(content)/mypage/_component/tracker/GoalModal.tsx
+++ b/src/app/(content)/mypage/_component/tracker/GoalModal.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import { LuMinus, LuPlus } from 'react-icons/lu';
+import { Modal, Button } from '@/components/ui';
+import styles from './tracker.module.scss';
+
+const GOAL_MIN = 5;
+const GOAL_MAX = 150;
+const GOAL_STEP = 1;
+
+const clampGoal = (value: number) => Math.min(GOAL_MAX, Math.max(GOAL_MIN, value));
+
+type Props = {
+  open: boolean;
+  initialGoal: number;
+  onClose: () => void;
+  onSave: (goal: number) => void;
+};
+
+export default function GoalModal({ open, initialGoal, onClose, onSave }: Props) {
+  const [goal, setGoal] = useState(initialGoal);
+
+  // 열릴 때 현재 목표로 초기화 — 렌더 중 prev 비교 (앱 공통 패턴).
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (open) setGoal(initialGoal);
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="주간 목표"
+      size="sm"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            취소
+          </Button>
+          <Button variant="accent" onClick={() => onSave(clampGoal(goal))}>
+            완료
+          </Button>
+        </>
+      }
+    >
+      <p className={styles.goal_desc}>일주일에 읽을 목표 장 수를 정하세요</p>
+      <div className={styles.stepper}>
+        <button
+          type="button"
+          className={styles.stepper_btn}
+          onClick={() => setGoal((value) => clampGoal(value - GOAL_STEP))}
+          aria-label="목표 줄이기"
+        >
+          <LuMinus aria-hidden="true" />
+        </button>
+        <span className={styles.stepper_value}>
+          <input
+            type="number"
+            className={styles.stepper_input}
+            value={goal}
+            min={GOAL_MIN}
+            max={GOAL_MAX}
+            inputMode="numeric"
+            aria-label="주간 목표 장 수"
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              setGoal(Number.isFinite(next) ? next : GOAL_MIN);
+            }}
+            onBlur={() => setGoal((value) => clampGoal(value))}
+          />
+          장
+        </span>
+        <button
+          type="button"
+          className={styles.stepper_btn}
+          onClick={() => setGoal((value) => clampGoal(value + GOAL_STEP))}
+          aria-label="목표 늘리기"
+        >
+          <LuPlus aria-hidden="true" />
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/app/(content)/mypage/_component/tracker/RecordTabs.tsx
+++ b/src/app/(content)/mypage/_component/tracker/RecordTabs.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useState } from 'react';
+import clsx from 'clsx';
+import { LuChevronRight, LuPencil, LuPlus, LuBookOpen } from 'react-icons/lu';
+import { Tabs, Button } from '@/components/ui';
+import { formatDateLabel, type TodayEntry, type WeekView, type MonthView } from '@/utils/bible-tracker';
+import styles from './tracker.module.scss';
+
+type TabId = 'day' | 'week' | 'month';
+
+const TAB_ITEMS = [
+  { id: 'day', label: '일' },
+  { id: 'week', label: '주' },
+  { id: 'month', label: '월' }
+];
+
+const MONTH_WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+function shortDate(date: string): string {
+  const [, m, d] = date.split('-').map(Number);
+  return `${m}월 ${d}일`;
+}
+
+type Props = {
+  today: string;
+  todayEntries: TodayEntry[];
+  todayChapters: number;
+  week: WeekView;
+  month: MonthView;
+  onOpenRecorder: (bookOrder: number | null) => void;
+  onOpenGoal: () => void;
+};
+
+export default function RecordTabs({
+  today,
+  todayEntries,
+  todayChapters,
+  week,
+  month,
+  onOpenRecorder,
+  onOpenGoal
+}: Props) {
+  const [tab, setTab] = useState<TabId>('day');
+
+  return (
+    <div className={styles.records}>
+      <div className={styles.records_head}>
+        <h3 className={styles.records_title}>성경읽기 기록</h3>
+        <Tabs
+          variant="pill"
+          size="sm"
+          items={TAB_ITEMS}
+          activeId={tab}
+          onChange={(id) => setTab(id as TabId)}
+        />
+      </div>
+
+      {tab === 'day' && (
+        <div className={styles.card}>
+          <div className={styles.day_head}>
+            <div>
+              <p className={styles.caption}>오늘 · {formatDateLabel(today)}</p>
+              <p className={styles.day_title}>오늘 읽은 곳</p>
+            </div>
+            <p className={styles.day_count}>
+              <strong>{todayChapters}</strong>장
+            </p>
+          </div>
+
+          {todayEntries.length > 0 ? (
+            <ul className={styles.entry_list}>
+              {todayEntries.map((entry) => (
+                <li key={entry.bookOrder}>
+                  <button
+                    type="button"
+                    className={styles.entry}
+                    onClick={() => onOpenRecorder(entry.bookOrder)}
+                  >
+                    <span className={styles.entry_icon} aria-hidden="true">
+                      <LuBookOpen />
+                    </span>
+                    <span className={styles.entry_range}>{entry.ranges}</span>
+                    <span className={styles.entry_count}>{entry.count}장</span>
+                    <LuChevronRight aria-hidden="true" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className={styles.empty}>
+              <span className={styles.empty_icon} aria-hidden="true">
+                <LuBookOpen />
+              </span>
+              <p className={styles.empty_title}>아직 오늘 읽은 곳이 없어요</p>
+              <p className={styles.empty_sub}>읽은 성경을 기록해 보세요</p>
+            </div>
+          )}
+
+          <Button
+            variant="accent"
+            fullWidth
+            leadingIcon={<LuPlus aria-hidden="true" />}
+            onClick={() => onOpenRecorder(null)}
+          >
+            오늘 읽은 곳 기록하기
+          </Button>
+        </div>
+      )}
+
+      {tab === 'week' && (
+        <div className={styles.card}>
+          <div className={styles.week_head}>
+            <span>
+              {shortDate(week.days[0].date)} – {shortDate(week.days[6].date)}
+            </span>
+            <span className={styles.week_done}>
+              <strong>{week.doneCount}</strong> / 7일
+            </span>
+          </div>
+          <ul className={styles.week_strip}>
+            {week.days.map((day) => (
+              <li key={day.date} className={styles.week_day}>
+                <span className={clsx(styles.week_label, day.isToday && styles.week_label_today)}>
+                  {day.label}
+                </span>
+                <span
+                  className={clsx(
+                    styles.week_box,
+                    day.done && styles.week_box_done,
+                    !day.done && day.isToday && styles.week_box_today
+                  )}
+                >
+                  {day.done ? '✓' : day.isToday ? '오늘' : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+
+          <div className={styles.goal}>
+            <div className={styles.goal_head}>
+              <span className={styles.caption}>주간 목표</span>
+              <button type="button" className={styles.goal_edit} onClick={onOpenGoal}>
+                <LuPencil aria-hidden="true" /> 목표 수정
+              </button>
+            </div>
+            <div className={styles.goal_meta}>
+              <span>
+                <strong>{week.chapters}</strong> / {week.goal}장
+              </span>
+              <span className={styles.goal_pct}>{week.goalPct}%</span>
+            </div>
+            <div className={styles.bar}>
+              <span className={styles.bar_fill} style={{ width: `${week.goalPct}%` }} />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {tab === 'month' && (
+        <div className={styles.card}>
+          <div className={styles.month_head}>
+            <span className={styles.month_label}>{month.label}</span>
+            <span className={styles.week_done}>
+              <strong>{month.readDays}</strong>일 읽음
+            </span>
+          </div>
+          <div className={styles.month_grid}>
+            {MONTH_WEEKDAYS.map((label) => (
+              <span key={label} className={styles.month_weekday}>
+                {label}
+              </span>
+            ))}
+            {month.cells.map((cell, index) => (
+              <span
+                key={index}
+                className={clsx(
+                  styles.month_cell,
+                  cell.day !== null && styles[`level_${cell.level}`],
+                  cell.isToday && styles.month_cell_today
+                )}
+              >
+                {cell.day ?? ''}
+              </span>
+            ))}
+          </div>
+          <div className={styles.legend}>
+            <span>적음</span>
+            <span className={styles.level_0} />
+            <span className={styles.level_1} />
+            <span className={styles.level_2} />
+            <span className={styles.level_3} />
+            <span>많음</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(content)/mypage/_component/tracker/Recorder.tsx
+++ b/src/app/(content)/mypage/_component/tracker/Recorder.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useState } from 'react';
+import clsx from 'clsx';
+import { LuChevronLeft, LuChevronRight, LuX } from 'react-icons/lu';
+import { BottomSheet } from '@/components/ui';
+import { BIBLE_BOOKS, getBookByOrder, type Testament } from '@/constants/bible';
+import {
+  chaptersOnDate,
+  cycleUnionByBook,
+  formatDateLabel,
+  shiftDate,
+  type ReadingRecord
+} from '@/utils/bible-tracker';
+import styles from './tracker.module.scss';
+
+type Mode = 'single' | 'range';
+
+type Props = {
+  records: ReadingRecord[];
+  today: string;
+  currentCycle: number;
+  initialDate: string;
+  initialBook: number | null;
+  onToggleChapter: (bookOrder: number, chapter: number, date: string) => void;
+  onRecordChapters: (bookOrder: number, chapters: number[], date: string) => void;
+  onClearBook: (bookOrder: number, date: string) => void;
+  onClose: () => void;
+  getBookName: (order: number) => string;
+};
+
+export default function Recorder({
+  records,
+  today,
+  currentCycle,
+  initialDate,
+  initialBook,
+  onToggleChapter,
+  onRecordChapters,
+  onClearBook,
+  onClose
+}: Props) {
+  const [date, setDate] = useState(initialDate);
+  const [book, setBook] = useState<number | null>(initialBook);
+  const [testament, setTestament] = useState<Testament>(
+    initialBook !== null && getBookByOrder(initialBook)?.testament === '신약' ? '신약' : '구약'
+  );
+  const [mode, setMode] = useState<Mode>('single');
+  const [rangeStart, setRangeStart] = useState<number | null>(null);
+
+  const cycleUnion = cycleUnionByBook(records, currentCycle);
+  const isChapters = book !== null;
+  const canGoNext = date < today;
+
+  function goToBook(order: number) {
+    setBook(order);
+    setRangeStart(null);
+  }
+
+  function backToBooks() {
+    setBook(null);
+    setRangeStart(null);
+  }
+
+  function shiftRecorderDate(delta: number) {
+    if (delta > 0 && !canGoNext) return;
+    setDate((value) => shiftDate(value, delta));
+    setRangeStart(null);
+  }
+
+  function tapChapter(order: number, chapter: number) {
+    if (mode === 'single') {
+      onToggleChapter(order, chapter, date);
+      return;
+    }
+    if (rangeStart === null) {
+      setRangeStart(chapter);
+      return;
+    }
+    const from = Math.min(rangeStart, chapter);
+    const to = Math.max(rangeStart, chapter);
+    const range = Array.from({ length: to - from + 1 }, (_, i) => from + i);
+    onRecordChapters(order, range, date);
+    setRangeStart(null);
+  }
+
+  const header = (
+    <div className={styles.rec_head}>
+      <button
+        type="button"
+        className={styles.rec_icon}
+        onClick={isChapters ? backToBooks : onClose}
+        aria-label={isChapters ? '책 목록으로' : '닫기'}
+      >
+        <LuChevronLeft aria-hidden="true" />
+      </button>
+      <span className={styles.rec_title}>
+        {isChapters ? getBookByOrder(book)?.name : '성경 읽기 기록'}
+      </span>
+      <button type="button" className={styles.rec_icon} onClick={onClose} aria-label="닫기">
+        <LuX aria-hidden="true" />
+      </button>
+    </div>
+  );
+
+  const selectedBook = book !== null ? getBookByOrder(book) : undefined;
+  const dateChapters = book !== null ? chaptersOnDate(records, date, book) : new Set<number>();
+  const bookUnion = book !== null ? cycleUnion.get(book) ?? new Set<number>() : new Set<number>();
+
+  const rangeHint =
+    mode === 'range'
+      ? rangeStart === null
+        ? '시작 장을 선택하세요'
+        : `${rangeStart}장부터 · 끝 장을 선택하세요`
+      : '읽은 장을 눌러 이 날짜에 기록하세요';
+
+  return (
+    <BottomSheet open onClose={onClose} size="full" ariaLabel="성경 읽기 기록" enableHistory header={header}>
+      <div className={styles.rec_datebar}>
+        <button
+          type="button"
+          className={styles.rec_date_nav}
+          onClick={() => shiftRecorderDate(-1)}
+          aria-label="이전 날짜"
+        >
+          <LuChevronLeft aria-hidden="true" />
+        </button>
+        <div className={styles.rec_date}>
+          <span className={styles.rec_date_caption}>기록할 날짜</span>
+          <span className={styles.rec_date_label}>
+            {formatDateLabel(date)}
+            {date === today && <span className={styles.rec_today}>오늘</span>}
+          </span>
+        </div>
+        <button
+          type="button"
+          className={clsx(styles.rec_date_nav, !canGoNext && styles.rec_date_nav_off)}
+          onClick={() => shiftRecorderDate(1)}
+          aria-label="다음 날짜"
+          disabled={!canGoNext}
+        >
+          <LuChevronRight aria-hidden="true" />
+        </button>
+      </div>
+
+      {!isChapters && (
+        <div className={styles.rec_body}>
+          <div className={styles.rec_testament}>
+            <button
+              type="button"
+              className={clsx(styles.rec_seg, testament === '구약' && styles.rec_seg_on)}
+              onClick={() => setTestament('구약')}
+            >
+              구약 39권
+            </button>
+            <button
+              type="button"
+              className={clsx(styles.rec_seg, testament === '신약' && styles.rec_seg_on)}
+              onClick={() => setTestament('신약')}
+            >
+              신약 27권
+            </button>
+          </div>
+          <ul className={styles.book_grid}>
+            {BIBLE_BOOKS.filter((item) => item.testament === testament).map((item) => {
+              const read = cycleUnion.get(item.order)?.size ?? 0;
+              const pct = Math.round((read / item.chapters) * 100);
+              const full = read === item.chapters;
+              return (
+                <li key={item.order}>
+                  <button
+                    type="button"
+                    className={clsx(styles.book, full && styles.book_full)}
+                    onClick={() => goToBook(item.order)}
+                  >
+                    <span className={styles.book_row}>
+                      <span className={styles.book_name}>{item.name}</span>
+                      <span className={styles.book_sub}>
+                        {read}/{item.chapters}
+                      </span>
+                    </span>
+                    <span className={styles.bar}>
+                      <span className={styles.bar_fill} style={{ width: `${pct}%` }} />
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+
+      {isChapters && selectedBook && (
+        <div className={styles.rec_body}>
+          <div className={styles.rec_controls}>
+            <div className={styles.rec_modes}>
+              <button
+                type="button"
+                className={clsx(styles.rec_seg, mode === 'single' && styles.rec_seg_on)}
+                onClick={() => {
+                  setMode('single');
+                  setRangeStart(null);
+                }}
+              >
+                낱장
+              </button>
+              <button
+                type="button"
+                className={clsx(styles.rec_seg, mode === 'range' && styles.rec_seg_on)}
+                onClick={() => setMode('range')}
+              >
+                범위
+              </button>
+            </div>
+            <div className={styles.rec_actions}>
+              <button
+                type="button"
+                className={styles.rec_text_btn}
+                onClick={() =>
+                  onRecordChapters(
+                    selectedBook.order,
+                    Array.from({ length: selectedBook.chapters }, (_, i) => i + 1),
+                    date
+                  )
+                }
+              >
+                모두 읽음
+              </button>
+              <button
+                type="button"
+                className={styles.rec_text_btn}
+                onClick={() => onClearBook(selectedBook.order, date)}
+              >
+                해제
+              </button>
+            </div>
+          </div>
+          <p className={styles.rec_hint}>{rangeHint}</p>
+          <ul className={styles.chapter_grid}>
+            {Array.from({ length: selectedBook.chapters }, (_, i) => i + 1).map((chapter) => {
+              const readToday = dateChapters.has(chapter);
+              const readBefore = bookUnion.has(chapter) && !readToday;
+              const isStart = rangeStart === chapter;
+              return (
+                <li key={chapter}>
+                  <button
+                    type="button"
+                    className={clsx(
+                      styles.chapter,
+                      readToday && styles.chapter_today,
+                      readBefore && styles.chapter_before,
+                      isStart && styles.chapter_start
+                    )}
+                    onClick={() => tapChapter(selectedBook.order, chapter)}
+                    aria-pressed={readToday}
+                  >
+                    {chapter}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/src/app/(content)/mypage/_component/tracker/ShareSheet.tsx
+++ b/src/app/(content)/mypage/_component/tracker/ShareSheet.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { LuMessageCircle, LuDownload, LuLink } from 'react-icons/lu';
+import { BottomSheet, Button, Tabs } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import styles from './tracker.module.scss';
+
+type Period = 'day' | 'week' | 'month';
+
+const PERIOD_ITEMS = [
+  { id: 'day', label: '일간' },
+  { id: 'week', label: '주간' },
+  { id: 'month', label: '월간' }
+];
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  todayChapters: number;
+  weekChapters: number;
+  weekDoneCount: number;
+  monthChapters: number;
+  monthReadDays: number;
+};
+
+export default function ShareSheet({
+  open,
+  onClose,
+  todayChapters,
+  weekChapters,
+  weekDoneCount,
+  monthChapters,
+  monthReadDays
+}: Props) {
+  const { info } = useToastStore();
+  const [period, setPeriod] = useState<Period>('week');
+
+  const stat =
+    period === 'day'
+      ? { title: '오늘', value: todayChapters, sub: '오늘 읽은 장' }
+      : period === 'week'
+        ? { title: '이번 주', value: weekChapters, sub: `${weekDoneCount}일 함께한 한 주` }
+        : { title: '이번 달', value: monthChapters, sub: `${monthReadDays}일 읽은 이번 달` };
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="기록 공유하기">
+      <div className={styles.share}>
+        <Tabs
+          variant="pill"
+          size="sm"
+          fitted
+          items={PERIOD_ITEMS}
+          activeId={period}
+          onChange={(id) => setPeriod(id as Period)}
+        />
+
+        <div className={styles.share_card}>
+          <span className={styles.share_brand}>대구동남교회</span>
+          <span className={styles.share_eyebrow}>{stat.title} 성경읽기</span>
+          <p className={styles.share_stat}>
+            <strong>{stat.value}</strong>장 읽음
+          </p>
+          <p className={styles.share_sub}>{stat.sub}</p>
+          <p className={styles.share_verse}>
+            “주의 말씀은 내 발에 등이요 내 길에 빛이니이다”
+            <span className={styles.share_verse_ref}>시편 119:105</span>
+          </p>
+        </div>
+
+        <div className={styles.share_actions}>
+          <button
+            type="button"
+            className={styles.share_action}
+            onClick={() => info('카카오톡 공유는 준비 중이에요.')}
+          >
+            <span className={styles.share_action_icon}>
+              <LuMessageCircle aria-hidden="true" />
+            </span>
+            카카오톡
+          </button>
+          <button
+            type="button"
+            className={styles.share_action}
+            onClick={() => info('이미지 저장은 준비 중이에요.')}
+          >
+            <span className={styles.share_action_icon}>
+              <LuDownload aria-hidden="true" />
+            </span>
+            이미지 저장
+          </button>
+          <button
+            type="button"
+            className={styles.share_action}
+            onClick={() => info('링크 복사는 준비 중이에요.')}
+          >
+            <span className={styles.share_action_icon}>
+              <LuLink aria-hidden="true" />
+            </span>
+            링크 복사
+          </button>
+        </div>
+
+        <Button variant="secondary" fullWidth onClick={onClose}>
+          닫기
+        </Button>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/app/(content)/mypage/_component/tracker/TrackerSection.tsx
+++ b/src/app/(content)/mypage/_component/tracker/TrackerSection.tsx
@@ -1,0 +1,279 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { LuFlame, LuShare2, LuBookOpen } from 'react-icons/lu';
+import { Button } from '@/components/ui';
+import { useToastStore } from '@/store/toast.store';
+import {
+  recordChaptersAction,
+  unrecordChaptersAction,
+  setWeeklyGoalAction,
+  startNextCycleAction
+} from '@/actions/bible-reading.action';
+import {
+  computeStreak,
+  computeTodayEntries,
+  countChaptersOnDate,
+  computeWeek,
+  computeMonth,
+  computePlan,
+  chaptersOnDate,
+  type ReadingRecord,
+  type BibleReadingSettings
+} from '@/utils/bible-tracker';
+import { getBookByOrder } from '@/constants/bible';
+import RecordTabs from './RecordTabs';
+import GoalModal from './GoalModal';
+import Recorder from './Recorder';
+import ShareSheet from './ShareSheet';
+import styles from './tracker.module.scss';
+
+type Props = {
+  initialRecords: ReadingRecord[];
+  initialSettings: BibleReadingSettings;
+  today: string;
+};
+
+export default function TrackerSection({ initialRecords, initialSettings, today }: Props) {
+  const { success, error } = useToastStore();
+  const [records, setRecords] = useState<ReadingRecord[]>(initialRecords);
+  const [settings, setSettings] = useState<BibleReadingSettings>(initialSettings);
+  const [recorderDate, setRecorderDate] = useState<string | null>(null);
+  const [recorderBook, setRecorderBook] = useState<number | null>(null);
+  const [goalOpen, setGoalOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
+
+  const streak = useMemo(() => computeStreak(records, today), [records, today]);
+  const todayEntries = useMemo(() => computeTodayEntries(records, today), [records, today]);
+  const todayChapters = useMemo(() => countChaptersOnDate(records, today), [records, today]);
+  const week = useMemo(
+    () => computeWeek(records, today, settings.weekly_goal),
+    [records, today, settings.weekly_goal]
+  );
+  const month = useMemo(() => computeMonth(records, today), [records, today]);
+  const plan = useMemo(() => computePlan(records, settings.current_cycle), [records, settings.current_cycle]);
+
+  // 낙관적 쓰기 — 로컬 기록을 먼저 바꾸고 액션 실패 시 되돌린다.
+  async function persist(
+    action: () => Promise<{ success: boolean; message: string }>,
+    rollback: () => void
+  ) {
+    const result = await action();
+    if (!result.success) {
+      rollback();
+      error(result.message);
+    }
+  }
+
+  function addRecords(bookOrder: number, chapters: number[], date: string) {
+    const cycle = settings.current_cycle;
+    setRecords((prev) => {
+      const existing = new Set(
+        prev
+          .filter((r) => r.read_date === date && r.book_order === bookOrder)
+          .map((r) => r.chapter)
+      );
+      const additions = chapters
+        .filter((chapter) => !existing.has(chapter))
+        .map((chapter) => ({ book_order: bookOrder, chapter, read_date: date, cycle }));
+      return additions.length ? [...prev, ...additions] : prev;
+    });
+  }
+
+  function removeRecords(bookOrder: number, chapters: number[], date: string) {
+    const remove = new Set(chapters);
+    setRecords((prev) =>
+      prev.filter(
+        (r) => !(r.read_date === date && r.book_order === bookOrder && remove.has(r.chapter))
+      )
+    );
+  }
+
+  function restoreRecords(removed: ReadingRecord[]) {
+    if (removed.length === 0) return;
+    setRecords((prev) => {
+      const existing = new Set(
+        prev.map((r) => `${r.read_date}:${r.book_order}:${r.chapter}:${r.cycle}`)
+      );
+      const restored = removed.filter(
+        (r) => !existing.has(`${r.read_date}:${r.book_order}:${r.chapter}:${r.cycle}`)
+      );
+      return restored.length ? [...prev, ...restored] : prev;
+    });
+  }
+
+  function toggleChapter(bookOrder: number, chapter: number, date: string) {
+    const isRecorded = chaptersOnDate(records, date, bookOrder).has(chapter);
+    if (isRecorded) {
+      const removed = records.filter(
+        (r) => r.read_date === date && r.book_order === bookOrder && r.chapter === chapter
+      );
+      removeRecords(bookOrder, [chapter], date);
+      void persist(
+        () => unrecordChaptersAction(bookOrder, [chapter], date),
+        () => restoreRecords(removed)
+      );
+    } else {
+      addRecords(bookOrder, [chapter], date);
+      void persist(
+        () => recordChaptersAction(bookOrder, [chapter], date),
+        () => removeRecords(bookOrder, [chapter], date)
+      );
+    }
+  }
+
+  function recordChapters(bookOrder: number, chapters: number[], date: string) {
+    const before = chaptersOnDate(records, date, bookOrder);
+    const fresh = chapters.filter((chapter) => !before.has(chapter));
+    if (fresh.length === 0) return;
+    addRecords(bookOrder, fresh, date);
+    void persist(
+      () => recordChaptersAction(bookOrder, fresh, date),
+      () => removeRecords(bookOrder, fresh, date)
+    );
+  }
+
+  function clearBook(bookOrder: number, date: string) {
+    const removed = records.filter((r) => r.read_date === date && r.book_order === bookOrder);
+    const chapters = removed.map((r) => r.chapter);
+    if (chapters.length === 0) return;
+    removeRecords(bookOrder, chapters, date);
+    void persist(
+      () => unrecordChaptersAction(bookOrder, chapters, date),
+      () => restoreRecords(removed)
+    );
+  }
+
+  async function changeGoal(goal: number) {
+    const previous = settings.weekly_goal;
+    setSettings((prev) => ({ ...prev, weekly_goal: goal }));
+    setGoalOpen(false);
+    await persist(
+      () => setWeeklyGoalAction(goal),
+      () => setSettings((prev) => ({ ...prev, weekly_goal: previous }))
+    );
+  }
+
+  async function startNextCycle() {
+    const result = await startNextCycleAction();
+    if (result.success) {
+      setSettings((prev) => ({ ...prev, current_cycle: prev.current_cycle + 1 }));
+      success(result.message);
+    } else {
+      error(result.message);
+    }
+  }
+
+  function openRecorder(date: string, bookOrder: number | null) {
+    setRecorderDate(date);
+    setRecorderBook(bookOrder);
+  }
+
+  const cyclePastLabel = plan.cyclesDone > 0 ? `지난 ${plan.cyclesDone}회독 완료` : '첫 통독';
+
+  return (
+    <section className={styles.tracker} aria-label="성경읽기 기록">
+      <div className={styles.streak}>
+        <div className={styles.streak_top}>
+          <div className={styles.streak_head}>
+            <span className={styles.streak_eyebrow}>성경읽기 연속</span>
+            <p className={styles.streak_count}>
+              <strong>{streak}</strong>일째
+            </p>
+            <p className={styles.streak_sub}>
+              이번 달 <b>{month.readDays}일</b> 말씀과 함께했어요
+            </p>
+          </div>
+          <span className={styles.streak_flame} aria-hidden="true">
+            <LuFlame />
+          </span>
+        </div>
+        <Button
+          variant="secondary"
+          leadingIcon={<LuShare2 aria-hidden="true" />}
+          onClick={() => setShareOpen(true)}
+        >
+          내 기록 공유하기
+        </Button>
+      </div>
+
+      <RecordTabs
+        today={today}
+        todayEntries={todayEntries}
+        todayChapters={todayChapters}
+        week={week}
+        month={month}
+        onOpenRecorder={(bookOrder) => openRecorder(today, bookOrder)}
+        onOpenGoal={() => setGoalOpen(true)}
+      />
+
+      <div className={styles.plan}>
+        <div className={styles.plan_head}>
+          <span className={styles.plan_title}>
+            성경 통독
+            <span className={styles.plan_cycle}>{plan.cycleNum}회독</span>
+          </span>
+          <span className={styles.plan_pct}>{plan.pct}%</span>
+        </div>
+        <div className={styles.bar}>
+          <span className={styles.bar_fill} style={{ width: `${plan.pct}%` }} />
+        </div>
+        <div className={styles.plan_meta}>
+          <span>
+            {plan.read} / {plan.total}장 · {plan.left}장 남음
+          </span>
+          <span>{cyclePastLabel}</span>
+        </div>
+        {plan.done && (
+          <div className={styles.plan_done}>
+            <p className={styles.plan_done_title}>🎉 {plan.cycleNum}회독 완료!</p>
+            <p className={styles.plan_done_sub}>1,189장을 모두 읽었어요. 다음 회독을 새로 시작할 수 있어요.</p>
+            <Button variant="accent" fullWidth onClick={startNextCycle}>
+              다음 회독 시작하기
+            </Button>
+          </div>
+        )}
+        <Button
+          variant="accent"
+          fullWidth
+          leadingIcon={<LuBookOpen aria-hidden="true" />}
+          onClick={() => openRecorder(today, null)}
+        >
+          지난 날짜·권별로 기록하기
+        </Button>
+      </div>
+
+      {recorderDate !== null && (
+        <Recorder
+          records={records}
+          today={today}
+          currentCycle={settings.current_cycle}
+          initialDate={recorderDate}
+          initialBook={recorderBook}
+          onToggleChapter={toggleChapter}
+          onRecordChapters={recordChapters}
+          onClearBook={clearBook}
+          onClose={() => setRecorderDate(null)}
+          getBookName={(order) => getBookByOrder(order)?.name ?? ''}
+        />
+      )}
+
+      <GoalModal
+        open={goalOpen}
+        initialGoal={settings.weekly_goal}
+        onClose={() => setGoalOpen(false)}
+        onSave={changeGoal}
+      />
+
+      <ShareSheet
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        todayChapters={todayChapters}
+        weekChapters={week.chapters}
+        weekDoneCount={week.doneCount}
+        monthChapters={month.chapters}
+        monthReadDays={month.readDays}
+      />
+    </section>
+  );
+}

--- a/src/app/(content)/mypage/_component/tracker/tracker.module.scss
+++ b/src/app/(content)/mypage/_component/tracker/tracker.module.scss
@@ -557,6 +557,7 @@
   font-weight: $font-weight-bold;
   color: $txt-primary;
   outline: none;
+  appearance: textfield; // Firefox 스피너 제거 (webkit은 아래 의사요소로)
 
   &::-webkit-outer-spin-button,
   &::-webkit-inner-spin-button {

--- a/src/app/(content)/mypage/_component/tracker/tracker.module.scss
+++ b/src/app/(content)/mypage/_component/tracker/tracker.module.scss
@@ -1,0 +1,942 @@
+// 성경읽기 트래커 — Claude Design 시안(한빛교회 마이페이지.html) 기준.
+// 시안의 대표색 #93702E는 앱 semantic $accent(gold-600)와 같다. 데이터 시각화·상태 표시는
+// $accent 계열(gold)로, 텍스트 위계·면은 warm neutral 토큰으로 맞춘다. primitive 직접 사용 금지.
+
+.tracker {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-l;
+}
+
+// ── 공통 진행 바 ──
+.bar {
+  display: block;
+  overflow: hidden;
+  width: 100%;
+  height: 1rem;
+  border-radius: $radius-circle;
+  background-color: $bg-secondary-deep;
+}
+
+.bar_fill {
+  display: block;
+  height: 100%;
+  border-radius: $radius-circle;
+  // 시안의 밝은 gold → gold 진행 그라디언트 (styles SKILL 그라디언트 예외)
+  background: linear-gradient(90deg, $accent-hover, $accent);
+}
+
+.caption {
+  @include text-caption;
+}
+
+// ── 연속 기록 카드 (히어로) ──
+.streak {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+  padding: $padding-card-lg;
+  border-radius: $radius-l;
+  // 시안 #93702E → 어두운 warm. gold($accent) → brown($primary) (styles SKILL 예외)
+  background: linear-gradient(135deg, $accent, $primary);
+  color: $txt-inverse;
+}
+
+.streak_top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $content-gap-m;
+}
+
+.streak_flame {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 7rem;
+  height: 7rem;
+  border-radius: $radius-circle;
+  // 다크 카드 위 장식 배지 — 반투명 면 + gold 불꽃 (styles SKILL rgba 예외)
+  background-color: rgba($txt-inverse, 0.16);
+  border: 1.5px solid rgba($txt-inverse, 0.35);
+  color: $accent-subtle;
+
+  svg {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
+}
+
+.streak_eyebrow {
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.02em;
+  color: $accent-subtle;
+}
+
+.streak_count {
+  margin-top: $spacing-8;
+  font-size: $font-size-16;
+  color: $txt-inverse;
+
+  strong {
+    font-size: $font-size-42;
+    font-weight: $font-weight-bold;
+    line-height: 1;
+  }
+}
+
+.streak_sub {
+  margin-top: $spacing-8;
+  font-size: $font-size-13;
+  color: $txt-dark-muted;
+
+  b {
+    font-weight: $font-weight-bold;
+    color: $txt-inverse;
+  }
+}
+
+// ── 기록 탭 영역 ──
+.records {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-s;
+}
+
+.records_head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $content-gap-s;
+  flex-wrap: wrap;
+}
+
+.records_title {
+  @include text-card-title;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+  padding: $padding-card;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-l;
+}
+
+// ── 일 뷰 ──
+.day_head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.day_title {
+  margin-top: $spacing-4;
+  font-size: $font-size-16;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+}
+
+.day_count {
+  font-size: $font-size-14;
+  color: $accent;
+
+  strong {
+    font-size: $font-size-24;
+    font-weight: $font-weight-bold;
+  }
+}
+
+.entry_list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-8;
+}
+
+.entry {
+  display: flex;
+  align-items: center;
+  gap: $spacing-10;
+  width: 100%;
+  padding: $padding-card-compact;
+  text-align: left;
+  background-color: $bg-accent-subtle;
+  border: 1px solid $border-warm;
+  border-radius: $radius-s;
+  cursor: pointer;
+
+  @include hover-bg-shift($primary-subtle);
+}
+
+.entry_icon {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 3rem;
+  height: 3rem;
+  border-radius: $radius-xs;
+  background-color: $accent-subtle;
+  color: $accent;
+
+  svg {
+    width: 1.7rem;
+    height: 1.7rem;
+  }
+}
+
+.entry_range {
+  flex: 1;
+  min-width: 0;
+  font-size: $font-size-14;
+  font-weight: $font-weight-semibold;
+  color: $accent;
+}
+
+.entry_count {
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $accent-hover;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-4;
+  padding: $spacing-24 $spacing-16;
+  text-align: center;
+  background-color: $bg-beige-subtle;
+  border: 1px dashed $border-warm;
+  border-radius: $radius-s;
+}
+
+.empty_icon {
+  display: grid;
+  place-items: center;
+  width: 4.4rem;
+  height: 4.4rem;
+  margin-bottom: $spacing-8;
+  border-radius: $radius-s;
+  background-color: $accent-subtle;
+  color: $accent;
+
+  svg {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+}
+
+.empty_title {
+  font-size: $font-size-14;
+  font-weight: $font-weight-semibold;
+  color: $txt-secondary;
+}
+
+.empty_sub {
+  @include text-caption;
+}
+
+// ── 주 뷰 ──
+.week_head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: $font-size-13;
+  color: $txt-secondary;
+}
+
+.week_done {
+  font-weight: $font-weight-bold;
+  color: $accent;
+
+  strong {
+    font-size: $font-size-14;
+  }
+}
+
+.week_strip {
+  display: flex;
+  justify-content: space-between;
+  gap: $spacing-4;
+}
+
+.week_day {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-8;
+}
+
+.week_label {
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  color: $txt-tertiary;
+}
+
+.week_label_today {
+  color: $accent;
+}
+
+.week_box {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  max-width: 3.8rem;
+  aspect-ratio: 1;
+  border-radius: $radius-xs;
+  background-color: $bg-secondary;
+  font-size: $font-size-13;
+  font-weight: $font-weight-bold;
+  color: $txt-tertiary;
+}
+
+.week_box_done {
+  background-color: $accent;
+  color: $txt-inverse;
+}
+
+.week_box_today {
+  background-color: $accent-subtle;
+  color: $accent;
+  box-shadow: inset 0 0 0 2px $accent;
+}
+
+// ── 주간 목표 ──
+.goal {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-10;
+  padding: $padding-card-compact;
+  background-color: $bg-beige-subtle;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+}
+
+.goal_head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.goal_edit {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-4;
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $accent;
+  cursor: pointer;
+
+  @include hover-color-shift($accent-hover);
+}
+
+.goal_meta {
+  display: flex;
+  align-items: baseline;
+  gap: $spacing-6;
+  font-size: $font-size-13;
+  color: $txt-secondary;
+
+  strong {
+    font-size: $font-size-20;
+    font-weight: $font-weight-bold;
+    color: $txt-primary;
+  }
+}
+
+.goal_pct {
+  margin-left: auto;
+  font-weight: $font-weight-bold;
+  color: $accent;
+}
+
+// ── 월 뷰 ──
+.month_head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.month_label {
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+}
+
+.month_grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: $spacing-4;
+}
+
+.month_weekday {
+  padding-bottom: $spacing-4;
+  text-align: center;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  color: $txt-tertiary;
+}
+
+.month_cell {
+  display: grid;
+  place-items: center;
+  aspect-ratio: 1;
+  border-radius: $radius-xxs;
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $txt-tertiary;
+}
+
+.month_cell_today {
+  box-shadow: inset 0 0 0 2px $txt-primary;
+}
+
+// 히트맵 4단계 — beige → 옅은 gold → 중간 gold → gold
+.level_0 {
+  background-color: $bg-secondary;
+}
+
+.level_1 {
+  background-color: $accent-subtle;
+  color: $accent;
+}
+
+.level_2 {
+  background-color: $accent-hover;
+  color: $txt-inverse;
+}
+
+.level_3 {
+  background-color: $accent;
+  color: $txt-inverse;
+}
+
+.legend {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: $spacing-8;
+  font-size: $font-size-11;
+  color: $txt-tertiary;
+
+  span[class*='level_'] {
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: $radius-xxs;
+  }
+}
+
+// ── 통독 카드 ──
+.plan {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-s;
+  padding: $padding-card;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-l;
+}
+
+.plan_head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.plan_title {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-8;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $accent;
+}
+
+.plan_cycle {
+  padding: $spacing-2 $spacing-8;
+  border-radius: $radius-circle;
+  background-color: $accent;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  color: $txt-inverse;
+}
+
+.plan_pct {
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $accent;
+}
+
+.plan_meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $spacing-8;
+  font-size: $font-size-12;
+  color: $txt-secondary;
+}
+
+.plan_done {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-8;
+  padding: $padding-card-compact;
+  text-align: center;
+  background-color: $bg-accent-subtle;
+  border: 1px solid $border-warm;
+  border-radius: $radius-s;
+}
+
+.plan_done_title {
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $accent;
+}
+
+.plan_done_sub {
+  font-size: $font-size-13;
+  line-height: $line-height-normal;
+  color: $txt-secondary;
+}
+
+// ── 주간 목표 모달 ──
+.goal_desc {
+  text-align: center;
+  @include text-sub;
+}
+
+.stepper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: $spacing-24;
+  margin: $spacing-24 0;
+}
+
+.stepper_btn {
+  display: grid;
+  place-items: center;
+  width: 5.2rem;
+  height: 5.2rem;
+  border: 1.5px solid $border-primary;
+  border-radius: $radius-circle;
+  background-color: $bg-card;
+  color: $accent;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+
+  svg {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+}
+
+.stepper_value {
+  display: inline-flex;
+  align-items: baseline;
+  gap: $spacing-4;
+  min-width: 10rem;
+  justify-content: center;
+  font-size: $font-size-16;
+  color: $txt-secondary;
+}
+
+// 목표 장 수 직접 입력 — spinner 제거, 큰 숫자 표시
+.stepper_input {
+  width: 6rem;
+  border: none;
+  background: transparent;
+  text-align: right;
+  font-family: inherit;
+  font-size: $font-size-42;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+  outline: none;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    margin: 0;
+    appearance: none;
+  }
+}
+
+// ── 기록기 오버레이 ──
+.rec_head {
+  display: flex;
+  align-items: center;
+  gap: $spacing-8;
+  width: 100%;
+}
+
+.rec_title {
+  flex: 1;
+  min-width: 0;
+  text-align: center;
+  font-size: $font-size-16;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+}
+
+.rec_icon {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: $icon-button-size;
+  height: $icon-button-size;
+  border-radius: $radius-xs;
+  color: $txt-primary;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+
+  svg {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+}
+
+.rec_datebar {
+  display: flex;
+  align-items: center;
+  gap: $spacing-10;
+  padding: $spacing-12 $spacing-20;
+  background-color: $bg-accent-subtle;
+  border-bottom: 1px solid $border-warm;
+}
+
+// 날짜 이동 화살표 — 흰 배경 라운드 버튼 (시안)
+.rec_date_nav {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 3.8rem;
+  height: 3.8rem;
+  border: 1px solid $border-warm;
+  border-radius: $radius-xs;
+  background-color: $bg-card;
+  color: $accent;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+
+  svg {
+    width: 2rem;
+    height: 2rem;
+  }
+}
+
+.rec_date_nav_off {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.rec_date {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-2;
+}
+
+.rec_date_caption {
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.04em;
+  color: $accent;
+}
+
+.rec_date_label {
+  display: inline-flex;
+  align-items: center;
+  gap: $spacing-6;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+  color: $txt-primary;
+}
+
+.rec_today {
+  padding: $spacing-2 $spacing-8;
+  border-radius: $radius-circle;
+  background-color: $bg-card;
+  font-size: $font-size-11;
+  font-weight: $font-weight-bold;
+  color: $accent;
+}
+
+.rec_body {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-s;
+  padding: $spacing-16 $spacing-20;
+}
+
+.rec_testament,
+.rec_modes {
+  display: inline-flex;
+  gap: $spacing-4;
+  padding: $spacing-4;
+  border-radius: $radius-circle;
+  background-color: $bg-secondary-deep;
+}
+
+.rec_testament {
+  display: flex;
+}
+
+.rec_seg {
+  flex: 1;
+  padding: $spacing-8 $spacing-16;
+  border-radius: $radius-circle;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $txt-secondary;
+  cursor: pointer;
+
+  @include hover-color-shift($txt-primary);
+}
+
+.rec_seg_on {
+  background-color: $accent;
+  color: $txt-inverse;
+
+  &:hover {
+    color: $txt-inverse;
+  }
+}
+
+.rec_controls {
+  display: flex;
+  align-items: center;
+  gap: $spacing-10;
+  flex-wrap: wrap;
+}
+
+.rec_actions {
+  display: inline-flex;
+  gap: $spacing-8;
+  margin-left: auto;
+}
+
+.rec_text_btn {
+  padding: $spacing-6 $spacing-12;
+  border: 1px solid $border-primary;
+  border-radius: $radius-circle;
+  background-color: $bg-card;
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $accent;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+}
+
+.rec_hint {
+  font-size: $font-size-13;
+  color: $accent;
+}
+
+// 책 그리드
+.book_grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: $spacing-10;
+}
+
+.book {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-8;
+  width: 100%;
+  padding: $padding-card-compact;
+  text-align: left;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-s;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+}
+
+.book_full {
+  background-color: $bg-accent-subtle;
+  border-color: $border-warm;
+}
+
+// 제목 + 읽은 수를 한 줄에 (예: 창세기        0/50)
+.book_row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: $spacing-8;
+}
+
+.book_name {
+  min-width: 0;
+  font-size: $font-size-14;
+  font-weight: $font-weight-semibold;
+  color: $txt-primary;
+}
+
+.book_sub {
+  flex-shrink: 0;
+  font-size: $font-size-11;
+  font-weight: $font-weight-semibold;
+  color: $txt-tertiary;
+}
+
+// 장 그리드
+.chapter_grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: $spacing-8;
+
+  @include respond-up($breakpoint-tablet-sm) {
+    grid-template-columns: repeat(8, 1fr);
+  }
+}
+
+.chapter {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  aspect-ratio: 1;
+  border: 1px solid $border-card;
+  border-radius: $radius-xs;
+  background-color: $bg-secondary;
+  font-size: $font-size-13;
+  font-weight: $font-weight-semibold;
+  color: $txt-tertiary;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+}
+
+.chapter_before {
+  background-color: $accent-subtle;
+  border-color: $border-warm;
+  color: $accent;
+}
+
+.chapter_today {
+  background-color: $accent;
+  border-color: transparent;
+  color: $txt-inverse;
+
+  &:hover {
+    color: $txt-inverse;
+  }
+}
+
+.chapter_start {
+  border-color: $accent;
+  box-shadow: inset 0 0 0 1px $accent;
+}
+
+// ── 기록 공유 시트 ──
+.share {
+  display: flex;
+  flex-direction: column;
+  gap: $content-gap-m;
+}
+
+.share_card {
+  display: flex;
+  flex-direction: column;
+  padding: $padding-card-lg;
+  border-radius: $radius-l;
+  // 시안의 dark warm 공유 카드 (styles SKILL 그라디언트 예외)
+  background: linear-gradient(150deg, $primary, $accent);
+  color: $txt-inverse;
+}
+
+.share_brand {
+  font-family: $font-family-secondary;
+  font-size: $font-size-15;
+  font-weight: $font-weight-bold;
+}
+
+.share_eyebrow {
+  margin-top: $spacing-16;
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  letter-spacing: 0.08em;
+  color: $accent-subtle;
+}
+
+.share_stat {
+  margin-top: $spacing-8;
+  font-size: $font-size-15;
+
+  strong {
+    font-size: $font-size-42;
+    font-weight: $font-weight-bold;
+    line-height: 1;
+  }
+}
+
+.share_sub {
+  margin-top: $spacing-8;
+  font-size: $font-size-13;
+  color: $txt-dark-muted;
+}
+
+.share_verse {
+  margin-top: $spacing-16;
+  padding-top: $spacing-16;
+  border-top: 1px solid rgba($txt-inverse, 0.2);
+  font-family: $font-family-secondary;
+  font-size: $font-size-14;
+  line-height: $line-height-loose;
+  color: $accent-subtle;
+}
+
+.share_verse_ref {
+  display: block;
+  margin-top: $spacing-4;
+  font-family: $font-family-base;
+  font-size: $font-size-11;
+  color: $txt-dark-muted;
+}
+
+.share_actions {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: $spacing-10;
+}
+
+.share_action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: $spacing-8;
+  padding: $spacing-16 $spacing-8;
+  background-color: $bg-card;
+  border: 1px solid $border-card;
+  border-radius: $radius-m;
+  font-size: $font-size-12;
+  font-weight: $font-weight-semibold;
+  color: $txt-secondary;
+  cursor: pointer;
+
+  @include hover-bg-shift($bg-hover);
+}
+
+.share_action_icon {
+  display: grid;
+  place-items: center;
+  width: 4.2rem;
+  height: 4.2rem;
+  border-radius: $radius-circle;
+  background-color: $accent-subtle;
+  color: $accent;
+
+  svg {
+    width: 2.1rem;
+    height: 2.1rem;
+  }
+}

--- a/src/app/(content)/mypage/page.tsx
+++ b/src/app/(content)/mypage/page.tsx
@@ -1,3 +1,33 @@
-export default function Mypage() {
-  return <div>Mypage</div>;
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { getMySessionProfile } from '@/services/user';
+import MainContainer from '@/components/layout/container/MainContainer';
+import ProfileSection from './_component/ProfileSection';
+import AccountMenu from './_component/AccountMenu';
+import styles from './_component/mypage.module.scss';
+
+export const metadata: Metadata = {
+  title: '마이 페이지'
+};
+
+export default async function Mypage() {
+  // 미들웨어가 1차로 막지만, 직접 렌더 경로 방어로 한 번 더 확인한다
+  const sessionProfile = await getMySessionProfile();
+  if (!sessionProfile) {
+    redirect('/login?redirect=/mypage');
+  }
+
+  const { user, profile } = sessionProfile;
+  // 카카오 전용 계정은 확인할 현재 비밀번호가 없으므로 비밀번호 변경 메뉴를 숨긴다
+  const providers = (user.app_metadata?.providers as string[] | undefined) ?? [];
+  const hasPasswordAuth = providers.includes('email') || user.app_metadata?.provider === 'email';
+
+  return (
+    <MainContainer title="마이 페이지">
+      <div className={styles.page}>
+        <ProfileSection profile={profile} />
+        <AccountMenu hasPasswordAuth={hasPasswordAuth} />
+      </div>
+    </MainContainer>
+  );
 }

--- a/src/app/(content)/mypage/page.tsx
+++ b/src/app/(content)/mypage/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { getMySessionProfile } from '@/services/user';
+import { getBibleTrackerData } from '@/services/bible-reading';
 import MainContainer from '@/components/layout/container/MainContainer';
 import ProfileSection from './_component/ProfileSection';
 import AccountMenu from './_component/AccountMenu';
+import TrackerSection from './_component/tracker/TrackerSection';
 import styles from './_component/mypage.module.scss';
 
 export const metadata: Metadata = {
@@ -22,10 +24,17 @@ export default async function Mypage() {
   const providers = (user.app_metadata?.providers as string[] | undefined) ?? [];
   const hasPasswordAuth = providers.includes('email') || user.app_metadata?.provider === 'email';
 
+  const tracker = await getBibleTrackerData(user.id);
+
   return (
     <MainContainer title="마이 페이지">
       <div className={styles.page}>
         <ProfileSection profile={profile} />
+        <TrackerSection
+          initialRecords={tracker.records}
+          initialSettings={tracker.settings}
+          today={tracker.today}
+        />
         <AccountMenu hasPasswordAuth={hasPasswordAuth} />
       </div>
     </MainContainer>

--- a/src/components/layout/Header/MobileHeader.tsx
+++ b/src/components/layout/Header/MobileHeader.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { IoChevronBack, IoShareSocialOutline } from 'react-icons/io5';
+import { IoChevronBack, IoShareSocialOutline, IoSettingsOutline } from 'react-icons/io5';
 import { LuMenu } from 'react-icons/lu';
 import clsx from 'clsx';
 import { resolveHeaderAction, resolveMobileHeader, resolveSiblingTabs } from '@/config/navigation';
@@ -74,6 +74,19 @@ export default function MobileHeader() {
                 aria-expanded={shareOpen}
               >
                 <IoShareSocialOutline />
+              </button>
+            ) : headerAction === 'settings' ? (
+              <button
+                type="button"
+                className={styles.mobile_menu}
+                onClick={() =>
+                  document
+                    .getElementById('mypage-account')
+                    ?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+                }
+                aria-label="설정"
+              >
+                <IoSettingsOutline />
               </button>
             ) : (
               <button

--- a/src/components/ui/Button/Button.module.scss
+++ b/src/components/ui/Button/Button.module.scss
@@ -19,7 +19,9 @@
 }
 
 // ── Sizes ──
+// min-height로 높이를 고정해 아이콘 유무·줄바꿈에 상관없이 일정한 버튼 높이를 보장한다.
 .sm {
+  min-height: 3.6rem;
   padding: $spacing-8 $spacing-12;
   border-radius: $radius-xs;
   font-size: $font-size-12;
@@ -27,6 +29,7 @@
 }
 
 .md {
+  min-height: 4.2rem;
   padding: $spacing-12 $spacing-16;
   border-radius: $radius-xs;
   font-size: $font-size-13;
@@ -34,6 +37,7 @@
 }
 
 .lg {
+  min-height: 4.8rem;
   padding: $spacing-16 $spacing-24;
   border-radius: $radius-s;
   font-size: $font-size-14;

--- a/src/components/ui/Tabs/Tabs.module.scss
+++ b/src/components/ui/Tabs/Tabs.module.scss
@@ -86,8 +86,12 @@
 
 // ── Pill variant ──
 
+// 배경 면 위에서 활성 탭이 채워지는 세그먼트 컨트롤. 활성색은 warm gold($accent).
 .pill {
   gap: $spacing-4;
+  padding: $spacing-4;
+  background-color: $bg-secondary-deep;
+  border-radius: $radius-circle;
 
   .tab {
     font-weight: $font-weight-semibold;
@@ -103,7 +107,7 @@
 
     &.active {
       color: $txt-inverse;
-      background-color: $primary;
+      background-color: $accent;
     }
   }
 }

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -214,6 +214,9 @@ export function resolveMobileHeader(pathname: string): { title: string; showBack
   // 주보 상세·create·update(/news/bulletins/...)는 '주보' 타이틀 + 뒤로가기(목록은 위 '교회 소식'이 처리).
   if (isBulletinPath(pathname)) return { title: '주보', showBack: true };
 
+  // 마이 페이지 — 시안 헤더(뒤로가기 + '마이 페이지' + 설정). GNB 라벨('마이페이지')과 달리 공백 포함 표기.
+  if (pathname === '/mypage') return { title: '마이 페이지', showBack: true };
+
   const special = SPECIAL_PAGES[pathname];
   if (special) return { title: special, showBack: false };
 
@@ -269,14 +272,16 @@ export function resolveSiblingTabs(pathname: string): NavItem[] | null {
 // ── MobileHeader action (우측 아이콘 슬롯) ──
 
 /** 헤더 우측 액션 종류. 기본은 전체 메뉴(drawer), 특정 화면은 다른 액션으로 교체 가능. */
-export type HeaderAction = 'menu' | 'share';
+export type HeaderAction = 'menu' | 'share' | 'settings';
 
-/** pathname → 헤더 우측 액션. 설교 상세·공지 상세·주보 상세는 공유, 그 외는 전체 메뉴. */
+/** pathname → 헤더 우측 액션. 설교 상세·공지 상세·주보 상세는 공유, 마이 페이지는 설정, 그 외는 전체 메뉴. */
 export function resolveHeaderAction(pathname: string): HeaderAction {
   if (isSermonDetailPath(pathname)) return 'share';
   // 공지 상세(/news/notices/[id])만 공유 — 목록(/news/notices)은 전체 메뉴 유지.
   if (/^\/news\/notices\/[^/]+$/.test(pathname)) return 'share';
   // 주보 상세(/news/bulletins/[숫자id])만 공유 — 목록·create·update는 전체 메뉴 유지.
   if (isBulletinDetailPath(pathname)) return 'share';
+  // 마이 페이지는 설정 아이콘 — 페이지의 계정 설정으로 이동.
+  if (pathname === '/mypage') return 'settings';
   return 'menu';
 }

--- a/src/constants/bible.ts
+++ b/src/constants/bible.ts
@@ -1,0 +1,53 @@
+// 성경 66권 참조 데이터 (개역개정 기준, 총 1189장).
+// 고정값이라 DB 테이블 대신 상수로 둔다 (exec-plan bible-reading-tracker D2).
+// 기록에는 order(1-66 정경 순번)만 저장하고, 이름·장수는 여기서 가져온다.
+
+export type Testament = '구약' | '신약';
+
+type BibleBook = {
+  /** 정경 순번 1-66. DB `book_order`와 1:1. */
+  order: number;
+  name: string;
+  chapters: number;
+  testament: Testament;
+};
+
+const RAW_BOOKS: ReadonlyArray<[name: string, chapters: number, testament: Testament]> = [
+  ['창세기', 50, '구약'], ['출애굽기', 40, '구약'], ['레위기', 27, '구약'], ['민수기', 36, '구약'],
+  ['신명기', 34, '구약'], ['여호수아', 24, '구약'], ['사사기', 21, '구약'], ['룻기', 4, '구약'],
+  ['사무엘상', 31, '구약'], ['사무엘하', 24, '구약'], ['열왕기상', 22, '구약'], ['열왕기하', 25, '구약'],
+  ['역대상', 29, '구약'], ['역대하', 36, '구약'], ['에스라', 10, '구약'], ['느헤미야', 13, '구약'],
+  ['에스더', 10, '구약'], ['욥기', 42, '구약'], ['시편', 150, '구약'], ['잠언', 31, '구약'],
+  ['전도서', 12, '구약'], ['아가', 8, '구약'], ['이사야', 66, '구약'], ['예레미야', 52, '구약'],
+  ['예레미야애가', 5, '구약'], ['에스겔', 48, '구약'], ['다니엘', 12, '구약'], ['호세아', 14, '구약'],
+  ['요엘', 3, '구약'], ['아모스', 9, '구약'], ['오바댜', 1, '구약'], ['요나', 4, '구약'],
+  ['미가', 7, '구약'], ['나훔', 3, '구약'], ['하박국', 3, '구약'], ['스바냐', 3, '구약'],
+  ['학개', 2, '구약'], ['스가랴', 14, '구약'], ['말라기', 4, '구약'],
+  ['마태복음', 28, '신약'], ['마가복음', 16, '신약'], ['누가복음', 24, '신약'], ['요한복음', 21, '신약'],
+  ['사도행전', 28, '신약'], ['로마서', 16, '신약'], ['고린도전서', 16, '신약'], ['고린도후서', 13, '신약'],
+  ['갈라디아서', 6, '신약'], ['에베소서', 6, '신약'], ['빌립보서', 4, '신약'], ['골로새서', 4, '신약'],
+  ['데살로니가전서', 5, '신약'], ['데살로니가후서', 3, '신약'], ['디모데전서', 6, '신약'], ['디모데후서', 4, '신약'],
+  ['디도서', 3, '신약'], ['빌레몬서', 1, '신약'], ['히브리서', 13, '신약'], ['야고보서', 5, '신약'],
+  ['베드로전서', 5, '신약'], ['베드로후서', 3, '신약'], ['요한일서', 5, '신약'], ['요한이서', 1, '신약'],
+  ['요한삼서', 1, '신약'], ['유다서', 1, '신약'], ['요한계시록', 22, '신약']
+];
+
+export const BIBLE_BOOKS: ReadonlyArray<BibleBook> = RAW_BOOKS.map(([name, chapters, testament], index) => ({
+  order: index + 1,
+  name,
+  chapters,
+  testament
+}));
+
+export const BIBLE_TOTAL_CHAPTERS = BIBLE_BOOKS.reduce((sum, book) => sum + book.chapters, 0);
+
+/** order(1-66) → 책. 1-based↔0-based 변환은 이 함수 한 곳에만 둔다 (D6). 범위 밖이면 undefined. */
+export function getBookByOrder(order: number): BibleBook | undefined {
+  return BIBLE_BOOKS[order - 1];
+}
+
+/** 해당 order 책의 chapter가 유효한 장 번호인지. 서버 액션의 장 범위 검증에 쓴다. */
+export function isValidChapter(order: number, chapter: number): boolean {
+  const book = getBookByOrder(order);
+  return book !== undefined && Number.isInteger(chapter) && chapter >= 1 && chapter <= book.chapters;
+}

--- a/src/services/bible-reading/index.ts
+++ b/src/services/bible-reading/index.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+
+import { getBibleReadingRecords, getBibleReadingSettings } from '@/apis/bible-reading';
+import { kstToday, type ReadingRecord, type BibleReadingSettings } from '@/utils/bible-tracker';
+
+type BibleTrackerData = {
+  records: ReadingRecord[];
+  settings: BibleReadingSettings;
+  today: string;
+};
+
+// 초기 로드: 사용자 기록 전체(작은 컬럼)와 설정을 한 번에 받아 클라이언트에서 파생한다 (D4).
+export async function getBibleTrackerData(userId: string): Promise<BibleTrackerData> {
+  const [records, settings] = await Promise.all([
+    getBibleReadingRecords(userId),
+    getBibleReadingSettings(userId)
+  ]);
+  return { records, settings, today: kstToday() };
+}

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -1,0 +1,14 @@
+import 'server-only';
+
+import { getUserSession } from '@/apis/auth-server';
+import { getProfileByIdServer } from '@/apis/user-server';
+
+// 마이 페이지 등 로그인 사용자 화면용 — 세션과 프로필을 한 번에 조회한다
+export const getMySessionProfile = async () => {
+  const user = await getUserSession();
+  if (!user) return null;
+
+  const profile = await getProfileByIdServer(user.id);
+
+  return { user, profile };
+};

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -14,6 +14,57 @@ export type Database = {
   }
   public: {
     Tables: {
+      bible_reading_records: {
+        Row: {
+          book_order: number
+          chapter: number
+          created_at: string
+          cycle: number
+          id: string
+          read_date: string
+          user_id: string
+        }
+        Insert: {
+          book_order: number
+          chapter: number
+          created_at?: string
+          cycle?: number
+          id?: string
+          read_date: string
+          user_id: string
+        }
+        Update: {
+          book_order?: number
+          chapter?: number
+          created_at?: string
+          cycle?: number
+          id?: string
+          read_date?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      bible_reading_settings: {
+        Row: {
+          current_cycle: number
+          updated_at: string
+          user_id: string
+          weekly_goal: number
+        }
+        Insert: {
+          current_cycle?: number
+          updated_at?: string
+          user_id: string
+          weekly_goal?: number
+        }
+        Update: {
+          current_cycle?: number
+          updated_at?: string
+          user_id?: string
+          weekly_goal?: number
+        }
+        Relationships: []
+      }
       bulletin_images: {
         Row: {
           bulletin_id: number

--- a/src/utils/bible-tracker.ts
+++ b/src/utils/bible-tracker.ts
@@ -94,11 +94,16 @@ export function cycleUnionByBook(records: ReadingRecord[], cycle: number): Map<n
   return map;
 }
 
-/** 오늘부터 거꾸로 연속으로 읽은 일수. 길이 제한 없음. */
+/**
+ * 연속으로 읽은 일수. 길이 제한 없음.
+ * 오늘 아직 안 읽었으면 어제부터 세어, 그날이 다 가기 전까지 연속을 유지한다
+ * (아침마다 0으로 깜빡이지 않게). 오늘 읽으면 오늘부터 세어 하루 늘어난다.
+ */
 export function computeStreak(records: ReadingRecord[], today: string): number {
   const counts = countByDate(records);
-  let streak = 0;
   let cursor = today;
+  if ((counts.get(cursor) ?? 0) === 0) cursor = shiftDate(cursor, -1);
+  let streak = 0;
   while ((counts.get(cursor) ?? 0) > 0) {
     streak += 1;
     cursor = shiftDate(cursor, -1);

--- a/src/utils/bible-tracker.ts
+++ b/src/utils/bible-tracker.ts
@@ -1,0 +1,227 @@
+// 성경읽기 트래커 파생 계산 (순수 함수, 클라이언트·서버 공용).
+// 단일 진실 원천은 기록 행뿐이고 연속·일/주/월·통독은 모두 여기서 계산한다 (D4).
+// 낙관적 UI를 위해 클라이언트가 로컬 기록 배열로 뷰를 다시 그린다.
+
+import { BIBLE_TOTAL_CHAPTERS, getBookByOrder } from '@/constants/bible';
+
+export type ReadingRecord = {
+  book_order: number;
+  chapter: number;
+  read_date: string;
+  cycle: number;
+};
+
+export type BibleReadingSettings = {
+  weekly_goal: number;
+  current_cycle: number;
+};
+
+const pad = (n: number) => String(n).padStart(2, '0');
+const WEEKDAY_KR = ['일', '월', '화', '수', '목', '금', '토'];
+
+/** Asia/Seoul 기준 오늘 'YYYY-MM-DD'. 서버(UTC)·클라이언트 어디서 불러도 KST 달력 날짜를 준다. */
+export function kstToday(): string {
+  // en-CA 로케일은 'YYYY-MM-DD' 형태를 준다.
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul' }).format(new Date());
+}
+
+export function shiftDate(date: string, delta: number): string {
+  const [y, m, d] = date.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  return `${dt.getUTCFullYear()}-${pad(dt.getUTCMonth() + 1)}-${pad(dt.getUTCDate())}`;
+}
+
+function weekdayOf(date: string): number {
+  const [y, m, d] = date.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+}
+
+/** "7월 17일 (목)" */
+export function formatDateLabel(date: string): string {
+  const [, m, d] = date.split('-').map(Number);
+  return `${m}월 ${d}일 (${WEEKDAY_KR[weekdayOf(date)]})`;
+}
+
+/** 연속 장 번호를 "1–3, 5" 로 압축. */
+function compressChapters(chapters: number[]): string {
+  const sorted = [...chapters].sort((a, b) => a - b);
+  const parts: string[] = [];
+  let start: number | null = null;
+  let prev: number | null = null;
+  for (const n of sorted) {
+    if (start === null) {
+      start = prev = n;
+    } else if (prev !== null && n === prev + 1) {
+      prev = n;
+    } else {
+      parts.push(start === prev ? `${start}` : `${start}–${prev}`);
+      start = prev = n;
+    }
+  }
+  if (start !== null) parts.push(start === prev ? `${start}` : `${start}–${prev}`);
+  return parts.join(', ');
+}
+
+/** 날짜별 읽은 장 수 합계. */
+function countByDate(records: ReadingRecord[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const rec of records) map.set(rec.read_date, (map.get(rec.read_date) ?? 0) + 1);
+  return map;
+}
+
+/** 특정 날짜·책의 장 집합. */
+export function chaptersOnDate(records: ReadingRecord[], date: string, bookOrder: number): Set<number> {
+  const set = new Set<number>();
+  for (const rec of records) {
+    if (rec.read_date === date && rec.book_order === bookOrder) set.add(rec.chapter);
+  }
+  return set;
+}
+
+/** 회차 내 책별 distinct 장 집합 (통독·기록기 누적 표시용). */
+export function cycleUnionByBook(records: ReadingRecord[], cycle: number): Map<number, Set<number>> {
+  const map = new Map<number, Set<number>>();
+  for (const rec of records) {
+    if (rec.cycle !== cycle) continue;
+    let set = map.get(rec.book_order);
+    if (!set) {
+      set = new Set<number>();
+      map.set(rec.book_order, set);
+    }
+    set.add(rec.chapter);
+  }
+  return map;
+}
+
+/** 오늘부터 거꾸로 연속으로 읽은 일수. 길이 제한 없음. */
+export function computeStreak(records: ReadingRecord[], today: string): number {
+  const counts = countByDate(records);
+  let streak = 0;
+  let cursor = today;
+  while ((counts.get(cursor) ?? 0) > 0) {
+    streak += 1;
+    cursor = shiftDate(cursor, -1);
+  }
+  return streak;
+}
+
+export type TodayEntry = { bookOrder: number; name: string; ranges: string; count: number };
+
+/** 오늘 읽은 곳: 책별로 압축된 장 범위 + 장 수. */
+export function computeTodayEntries(records: ReadingRecord[], today: string): TodayEntry[] {
+  const byBook = new Map<number, number[]>();
+  for (const rec of records) {
+    if (rec.read_date !== today) continue;
+    const list = byBook.get(rec.book_order) ?? [];
+    list.push(rec.chapter);
+    byBook.set(rec.book_order, list);
+  }
+  return [...byBook.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([bookOrder, chapters]) => {
+      const book = getBookByOrder(bookOrder);
+      return {
+        bookOrder,
+        name: book?.name ?? '',
+        ranges: `${book?.name ?? ''} ${compressChapters(chapters)}장`,
+        count: chapters.length
+      };
+    });
+}
+
+export function countChaptersOnDate(records: ReadingRecord[], date: string): number {
+  return records.reduce((sum, rec) => (rec.read_date === date ? sum + 1 : sum), 0);
+}
+
+export type WeekDay = { label: string; date: string; done: boolean; isToday: boolean };
+export type WeekView = {
+  days: WeekDay[];
+  doneCount: number;
+  chapters: number;
+  goal: number;
+  goalPct: number;
+};
+
+/** 오늘이 속한 월~일 주간. */
+export function computeWeek(records: ReadingRecord[], today: string, weeklyGoal: number): WeekView {
+  const counts = countByDate(records);
+  const mondayOffset = (weekdayOf(today) + 6) % 7; // 월요일까지 뒤로
+  const monday = shiftDate(today, -mondayOffset);
+  const days: WeekDay[] = Array.from({ length: 7 }, (_, i) => {
+    const date = shiftDate(monday, i);
+    return {
+      label: WEEKDAY_KR[weekdayOf(date)],
+      date,
+      done: (counts.get(date) ?? 0) > 0,
+      isToday: date === today
+    };
+  });
+  const chapters = days.reduce((sum, day) => sum + (counts.get(day.date) ?? 0), 0);
+  const goalPct = weeklyGoal > 0 ? Math.min(100, Math.round((chapters / weeklyGoal) * 100)) : 0;
+  return {
+    days,
+    doneCount: days.filter((day) => day.done).length,
+    chapters,
+    goal: weeklyGoal,
+    goalPct
+  };
+}
+
+export type MonthCell = { day: number | null; level: 0 | 1 | 2 | 3; isToday: boolean };
+export type MonthView = { cells: MonthCell[]; readDays: number; chapters: number; label: string };
+
+function levelOf(count: number): 0 | 1 | 2 | 3 {
+  if (count > 6) return 3;
+  if (count > 2) return 2;
+  if (count > 0) return 1;
+  return 0;
+}
+
+/** 오늘이 속한 달의 달력 히트맵 (일요일 시작). */
+export function computeMonth(records: ReadingRecord[], today: string): MonthView {
+  const counts = countByDate(records);
+  const [year, month] = today.split('-').map(Number);
+  const firstWeekday = new Date(Date.UTC(year, month - 1, 1)).getUTCDay(); // 0=일
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const cells: MonthCell[] = [];
+  for (let i = 0; i < firstWeekday; i += 1) cells.push({ day: null, level: 0, isToday: false });
+  let readDays = 0;
+  let chapters = 0;
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const date = `${year}-${pad(month)}-${pad(day)}`;
+    const count = counts.get(date) ?? 0;
+    const level = levelOf(count);
+    if (level > 0) readDays += 1;
+    chapters += count;
+    cells.push({ day, level, isToday: date === today });
+  }
+  return { cells, readDays, chapters, label: `${year}년 ${month}월` };
+}
+
+type PlanView = {
+  read: number;
+  total: number;
+  pct: number;
+  left: number;
+  done: boolean;
+  cycleNum: number;
+  cyclesDone: number;
+};
+
+/** 현재 회차의 통독 진행률 = distinct(book,chapter) where cycle=current_cycle / 1189. */
+export function computePlan(records: ReadingRecord[], currentCycle: number): PlanView {
+  const union = cycleUnionByBook(records, currentCycle);
+  let read = 0;
+  for (const set of union.values()) read += set.size;
+  const total = BIBLE_TOTAL_CHAPTERS;
+  return {
+    read,
+    total,
+    pct: total > 0 ? Math.round((read / total) * 100) : 0,
+    left: total - read,
+    done: read >= total,
+    cycleNum: currentCycle,
+    cyclesDone: currentCycle - 1
+  };
+}

--- a/supabase/migrations/20260717000000_create_bible_reading.sql
+++ b/supabase/migrations/20260717000000_create_bible_reading.sql
@@ -1,0 +1,71 @@
+-- 성경읽기 트래커 (사용자 소유 데이터)
+--
+-- 이 앱의 첫 사용자 소유 CRUD 테이블. profiles는 role/status 권한 상승 위험 때문에
+-- 클라이언트 쓰기를 GRANT 회수로 잠갔지만, 읽기 기록은 민감 컬럼이 없고 행이 전부
+-- user_id 소유라 owner-RLS(auth.uid() = user_id)로 CRUD를 연다. 뮤테이션은 여전히
+-- 사용자 세션 Server Action이 수행하고(ARCHITECTURE.md: 클라이언트 직접 write 금지),
+-- 세션 클라이언트라 RLS가 실제로 적용된다(admin bypass 아님). 관련 ADR: user-owned-data-rls.
+
+-- 원자 단위 = 이 사용자가 이 날(read_date) 이 책(book_order) 이 장(chapter)을
+-- 이 회차(cycle)에 읽었다. 연속·일/주/월·통독·목표는 모두 이 행에서 파생한다.
+create table public.bible_reading_records (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  book_order smallint not null check (book_order between 1 and 66),
+  chapter smallint not null check (chapter between 1 and 150),
+  read_date date not null,
+  cycle smallint not null default 1 check (cycle >= 1),
+  created_at timestamptz not null default now(),
+  -- 토글 멱등. cycle 미포함이라 같은 날 같은 장을 두 회차에서 재독하는 극희귀 케이스는 무시.
+  unique (user_id, book_order, chapter, read_date)
+);
+
+comment on table public.bible_reading_records is '사용자별 성경 장 읽기 기록. 원자 단위(날짜·책·장·회차)에서 연속·통독 등을 파생.';
+
+create index bible_reading_records_user_date_idx on public.bible_reading_records (user_id, read_date);
+create index bible_reading_records_user_cycle_idx on public.bible_reading_records (user_id, cycle);
+
+alter table public.bible_reading_records enable row level security;
+
+create policy "bible_records_select_own"
+  on public.bible_reading_records for select to authenticated
+  using (auth.uid() = user_id);
+
+create policy "bible_records_insert_own"
+  on public.bible_reading_records for insert to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "bible_records_update_own"
+  on public.bible_reading_records for update to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "bible_records_delete_own"
+  on public.bible_reading_records for delete to authenticated
+  using (auth.uid() = user_id);
+
+-- 사용자당 1행. 없으면 서비스가 기본값(weekly_goal=50, current_cycle=1)으로 취급하고
+-- 목표 변경·다음 회독 시 upsert로 생성한다.
+create table public.bible_reading_settings (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  weekly_goal smallint not null default 50 check (weekly_goal between 5 and 150),
+  current_cycle smallint not null default 1 check (current_cycle >= 1),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.bible_reading_settings is '사용자별 성경읽기 설정 (주간 목표·현재 통독 회차).';
+
+alter table public.bible_reading_settings enable row level security;
+
+create policy "bible_settings_select_own"
+  on public.bible_reading_settings for select to authenticated
+  using (auth.uid() = user_id);
+
+create policy "bible_settings_insert_own"
+  on public.bible_reading_settings for insert to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "bible_settings_update_own"
+  on public.bible_reading_settings for update to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 📋 개요 (Summary)

**목적**: placeholder였던 `/mypage`를 성도가 계정을 관리하고 성경읽기를 기록하는 화면으로 바꾼다.

**범위**:

- 프로필 표시·수정(display_name·avatar), 비밀번호 변경, 로그아웃
- 성경읽기 트래커 — 읽은 장을 기록하면 연속 일수·통독 진행률·주간 목표가 그 기록에서 파생
- 마이 페이지 헤더 설정 아이콘으로 계정 메뉴에 바로 이동

---

## 🔗 개발 컨텍스트

- **Task ID**: `my-page`, `bible-reading-tracker`
- **Exec Plan**: `docs/exec-plans/active/2026-07-17-my-page.md`, `docs/exec-plans/active/2026-07-17-bible-reading-tracker.md`
- **관련 ADR**: `docs/decisions/0022-user-owned-data-rls.md` (사용자 소유 데이터는 owner-RLS + 사용자 세션 Server Action, Status: Proposed)
- **관련 tech debt**: `docs/tech-debt/active.md` — 성경읽기 기록기 낱장 토글이 탭마다 Server Action을 호출 (다음 PR에서 디바운스 배치)
- **작업 범위**: 프로필 표시·수정, 비밀번호 변경, 로그아웃, 성경읽기 트래커, 설정 아이콘
- **제외한 범위**: 기록 공유(카카오톡·이미지·링크)는 "준비 중" 표시만, 낱장 토글 디바운스 배치

---

## 💡 변경 배경 (Motivation)

**해결하려는 문제:**

- `/mypage`가 placeholder여서 로그인한 성도가 프로필·비밀번호·로그아웃을 화면에서 다루지 못했다.
- 통독을 이어가는 성도가 읽은 장을 기록하고 연속 일수·진행률을 눈으로 확인할 화면이 없었다.

**관련 이슈:**

- Issue: #

---

## 🔒 보안·아키텍처 — 본인 데이터만, 요청마다 서버에서

로그인한 본인의 데이터만, 요청마다 서버에서 렌더한다. 세 계층이 겹쳐 한 겹이 뚫려도 나머지가 막는다.

**1. RLS (DB 계층)**

- 두 테이블 모두 RLS를 켜고, SELECT/INSERT/UPDATE/DELETE 4개 정책이 `auth.uid() = user_id`로 소유자만 통과시킨다.
- INSERT·UPDATE는 `WITH CHECK`까지 걸어, 남의 `user_id`를 실은 쓰기를 DB가 거부한다.
- 읽기는 `createServerSideClient`(사용자 세션 쿠키)를 써서 `auth.uid()`가 로그인 당사자로 잡힌다 — admin bypass가 아니라 RLS가 실제로 걸린다.
- 코드가 `user_id` 필터를 빠뜨려도 DB가 본인 행만 반환한다.

**2. 세션 기반 user_id (Server Action 계층)**

- 뮤테이션 Server Action 4개(`recordChaptersAction`·`unrecordChaptersAction`·`setWeeklyGoalAction`·`startNextCycleAction`)가 모두 내부에서 `supabase.auth.getUser()`로 사용자를 잡고 `user_id: user.id`로만 채운다.
- 클라이언트가 남의 id를 실을 자리가 없다.
- 읽기의 `userId`도 `page.tsx`가 `getMySessionProfile()` → `auth.getUser()`로 얻은 세션 사용자다 (클라이언트 파라미터 아님).

**3. 라우팅 가드 (2겹)**

- 미들웨어(`src/lib/supabase/middleware.ts`)가 `/mypage`를 `exactMatches`로 잡아, 미로그인 요청을 `/login?redirect=`로 돌려보낸다.
- `page.tsx`가 `getMySessionProfile()`로 한 번 더 확인해, 세션이 없으면 `redirect('/login?redirect=/mypage')`한다.

**SSR (요청마다 서버 렌더)**

- `page.tsx`는 `async` 서버 컴포넌트, 서비스는 `import 'server-only'`, `createServerSideClient`(캐시 없음)로 요청마다 렌더한다.
- 개인 데이터라 정적 캐싱을 쓰지 않는다.
- 초기 기록·설정만 서버에서 받아 `TrackerSection`(클라이언트)에 props로 내리고, 이후 상호작용은 Server Action으로 서버에 되돌린다.

---

## 🔍 문제 해결 과정

### Codex 계획 검증 — 6건 지적, 전부 반영

**1. 클라이언트 직접 write가 레이어 규칙과 충돌**

- 문제: 초안은 브라우저에서 Supabase에 직접 썼다. `ARCHITECTURE.md`의 "뮤테이션은 항상 Server Action"과 어긋난다.
- 해결: 사용자 세션 Server Action으로 옮겼다.

**2. RLS `WITH CHECK` 누락**

- 문제: `USING`만으로는 남의 `user_id`를 실은 INSERT를 막지 못한다.
- 해결: INSERT·UPDATE 정책에 `WITH CHECK (auth.uid() = user_id)`를 추가했다.

**3. 같은 날 통독 리셋이 안 되던 문제**

- 문제: `read_date`가 `date` 타입이라 오전·오후를 구분하지 못해, 같은 날 새 회차를 시작해도 이전 기록과 섞였다.
- 해결: 기록에 `cycle` 컬럼을 넣어 회차로 구분하고, 리셋은 `current_cycle + 1`로 올린다.

**4. `book_order` 1-based off-by-one 위험**

- 문제: 1부터 세는 책 순서를 0부터 세는 배열에 그대로 넣으면 한 칸씩 밀린다.
- 해결: `getBookByOrder`가 `BIBLE_BOOKS[order - 1]` 변환을 한 곳에서만 하도록 가뒀다.

**5. 장 유효성 검증 없음**

- 문제: 존재하지 않는 장(예: 창세기 51장) 기록을 막을 방어가 없었다.
- 해결: DB에 `CHECK (chapter between 1 and 150)`를 걸고, 서버 액션에서 책별 상한(`BIBLE_BOOKS[order-1].chapters`)으로 한 번 더 검증한다.

**6. streak "최근 N일" 기준 오류**

- 문제: 최근 N일만 보면 그보다 긴 연속을 놓친다.
- 해결: distinct `read_date`를 전부 받아 임의 길이의 연속을 정확히 센다.

### Codex 1차 검증 — 3건 수정

**1. 기록 해제 롤백 시 원래 cycle 보존**

- 문제: 낙관적 UI에서 해제가 서버에서 실패하면, 되돌린 기록의 `cycle`이 바뀔 수 있었다.
- 해결: 지웠던 기록을 원래 `cycle` 그대로 로컬 상태에 되돌린다(`TrackerSection.restoreRecords`).

**2. 기록 조회 페이지네이션**

- 문제: Supabase 기본 1000행 한도에 걸려, 1000행이 넘는 사용자는 기록이 잘렸다.
- 해결: `PAGE_SIZE = 1000`으로 `.range()` 페이지를 끝까지 이어 받는다.

**3. 통독 완료 판정 페이지네이션**

- 문제: distinct 장 수가 1189(`BIBLE_TOTAL_CHAPTERS`)인지 세는 조회도 1000행 한도에 걸려 완료가 영영 안 잡혔다.
- 해결: 같은 방식으로 페이지를 이어 받아 1189장을 정확히 센다.

### UI 실측

- 목업과 나란히 대조하며 브라우저에서 확인했다.
- 챕터 번호 그리드가 스타일을 안 먹던 것을 `.chapter`에 `width: 100%` + 테두리를 넣어 고쳤다.

---

## 🏗️ 의사 결정 기록 (Design Decisions)

| 결정 항목 | 선택 | 선택 이유 | 제외한 대안 / 버린 이유 |
| --- | --- | --- | --- |
| 사용자 소유 데이터 접근 제어 | owner-RLS (`USING` + `WITH CHECK` = `auth.uid() = user_id`) | 저장소의 첫 사용자 소유 CRUD 테이블 — 행 소유권을 DB가 강제해 다른 사용자 행 읽기·쓰기를 막는다 | 애플리케이션 레이어 필터만 — Server Action을 우회하면 방어선이 없어 버림 |
| 뮤테이션 진입점 | 사용자 세션 Server Action (`createServerSideClient` + `auth.getUser()`) | `user_id`를 클라이언트 입력이 아닌 `getUser()` 값으로만 채워 소유자 위조를 막는다 | 클라이언트가 `user_id`를 실어 보내는 방식 — 남의 id를 실을 수 있어 버림 |
| 렌더 방식 | SSR (`async` 서버 컴포넌트 + `server-only` + 캐시 없는 클라이언트) | 개인 데이터라 요청마다 세션 사용자 기준으로 받는다 | 정적 캐싱 — 사용자 간 데이터가 섞일 위험으로 버림 |
| 같은 날 회차 구분 | 기록에 `cycle` 컬럼을 넣고 리셋은 `current_cycle + 1` | `read_date`(date)는 하루 안의 재독 회차를 구분하지 못한다 | `read_date`만으로 판정 — 같은 날 새 통독이 이전 기록과 섞여 버림 |
| 파생 지표 저장 | 원자 행(`user_id`·`book_order`·`chapter`·`read_date`·`cycle`)만 저장 | 연속·진행률·주간 목표를 저장하면 읽은 장 기록과 어긋난다 — 기록 하나가 단일 진실 | 집계 컬럼 동시 저장 — 두 값을 맞추는 부담으로 버림 |

> ⚠️ **트레이드오프:** 낱장 토글이 탭마다 Server Action을 호출한다 — 낱장으로 10장을 하나씩 누르면 서버 왕복이 10번 일어난다(범위·모두읽음·해제는 한 번에 묶어 보낸다). 낱장 디바운스 배치는 `docs/tech-debt/active.md`에 등록했고 다음 PR에서 처리한다.

---

## 📸 스크린샷 (Screenshots)

| **(a) 마이 페이지 전체 — 프로필 + 연속 카드 + 기록 탭** |  **(b) 프로필 편집 (display_name·avatar)**  |
| --- | --- |
| <img width="599" height="868" alt="a-overview" src="https://github.com/user-attachments/assets/735c748b-a95e-48a5-8d82-2e3380c7915a" /> | <img width="599" height="798" alt="b-profile-edit" src="https://github.com/user-attachments/assets/aa9029ed-a4fd-4bf2-8a06-7596b0329c4d" />|

| **(c) 비밀번호 변경 모달** | **(d) 성경읽기 기록기 — 책 목록 + 챕터 그리드** | **(d) 성경읽기 기록기 — 책 목록 + 챕터 그리드** |
| --- | --- | --- |
|  <img width="599" height="798" alt="c-password-modal" src="https://github.com/user-attachments/assets/c9998e61-0b3e-4b67-8c83-de5f980be934" />|  <img width="599" height="798" alt="d-recorder-books" src="https://github.com/user-attachments/assets/f8a7cf63-4e53-4401-bc53-3847c56bba8f" /> | <img width="599" height="798" alt="d-recorder-chapters" src="https://github.com/user-attachments/assets/9c4693ee-cd8a-4017-8c9e-9dd209a31b96" />|

| **(e) 일/주/월 기록 탭** | **(f) 기록 공유 시트 ("준비 중")** |  **(g) 헤더 설정 아이콘 → 계정 메뉴** |
| --- | --- | --- |
| <img width="599" height="868" alt="e-week-tab" src="https://github.com/user-attachments/assets/9e510116-6da5-4ef2-ad10-2f624c4f875b" /> | <img width="599" height="868" alt="f-share-sheet" src="https://github.com/user-attachments/assets/314195db-453d-44cd-9872-7551c8a86cc4" />|<img width="599" height="798" alt="g-account-menu" src="https://github.com/user-attachments/assets/90e78ecf-062f-4d50-a504-204684956367" /> |

---

## ✅ 하네스 검증 (Harness Verification)

| 항목 | 결과 |
| --- | --- |
| N/A 사용 여부 | 없음 |
| `verify-task` (my-page) | `node scripts/verify-task.mjs my-page` — PASS, RUN_ID=`20260717-074745`, lint·styles·build 통과, warned=Knip |
| `verify-task` (bible-reading-tracker) | `node scripts/verify-task.mjs bible-reading-tracker` — PASS, RUN_ID=`20260718-190653`, lint·styles·build 통과, warned=Knip |
| `harness-gate` | 머지 전 `node scripts/harness-gate.mjs`로 재확인 |
| Codex 계획 검증 | CHANGE_REQUEST → 6건 전부 반영 |
| Codex 1차 검증 | FIX_APPLIED (3건) |
| Claude 2차 검증 | 완료 (PASS) |
| ADR 판단 | `docs/decisions/0022-user-owned-data-rls.md` |
| 남은 warning | 기존 부채 (Knip) |

---

## 👀 PM / 리뷰어 확인 포인트

- **사용자에게 달라지는 점**: `/mypage`에서 프로필 수정·비밀번호 변경·로그아웃을 직접 하고, 읽은 성경 장을 기록해 연속 일수·통독 진행률·주간 목표를 본다.
- **운영 리스크**: 마이그레이션 `supabase/migrations/20260717000000_create_bible_reading.sql`을 dev에 먼저 적용한 뒤 prod에 적용 — 배포 순서를 확인한다.
- **QA 후속**: 낱장 모드로 여러 장을 연속 탭하며 네트워크 탭에서 Server Action POST가 탭 수만큼 발생하는지 확인한다(디바운스 배치 전 현재 동작).
- **롤백 시 영향**: 성경읽기 테이블·RLS를 롤백하면 기록 조회·저장이 멈춘다. 마이 페이지 계정 기능은 기존 auth 흐름을 재사용해 롤백 영향이 없다.
- **먼저 볼 화면 / 흐름**: `/mypage` → 프로필 수정 → 성경읽기 기록기에서 낱장·범위 기록 → 일/주/월 탭.

---

## 📝 리뷰어를 위한 메모 (Notes for Future Me)

- owner-RLS + 사용자 세션 Server Action은 이 저장소의 첫 사용자 소유 CRUD 패턴이다. 이후 사용자 소유 테이블은 ADR 0022를 따른다.
- 파생 지표(연속·통독 진행률·주간 목표)는 `src/utils/bible-tracker.ts`에서 읽은 장 기록으로 센다. 집계 컬럼을 추가하고 싶어지면 기록과 어긋날 위험을 먼저 따진다.
- `book_order` 1-based ↔ 0-based 변환은 `getBookByOrder`(`src/constants/bible.ts`) 한 곳에만 있다. 배열 인덱스를 직접 쓰지 않는다.
- 기록 조회·통독 판정은 Supabase 1000행 한도 때문에 `.range()` 페이지네이션을 쓴다. 새 조회를 추가할 때 같은 한도를 잊지 않는다.
